### PR TITLE
Add all TrainingPeaks workout types to create workout tool

### DIFF
--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -187,7 +187,10 @@ TOOLS = [
                 },
                 "sport": {
                     "type": "string",
-                    "enum": ["Bike", "Run", "Swim", "Strength", "DayOff", "Other"],
+                    "enum": [
+                        "Swim", "Bike", "Run", "Brick", "Crosstrain", "Walk",
+                        "Strength", "Rowing", "XCSki", "Other", "Custom", "DayOff", "MtnBike",
+                    ],
                     "description": "Sport type.",
                 },
                 "title": {

--- a/src/tp_mcp/tools/_validation.py
+++ b/src/tp_mcp/tools/_validation.py
@@ -54,7 +54,10 @@ class CreateWorkoutInput(BaseModel):
     """Validates input for workout creation."""
 
     date: date
-    sport: Literal["Bike", "Run", "Swim", "Strength", "DayOff", "Other"]
+    sport: Literal[
+        "Swim", "Bike", "Run", "Brick", "Crosstrain", "Walk",
+        "Strength", "Rowing", "XCSki", "Other", "Custom", "DayOff", "MtnBike",
+    ]
     title: str = Field(min_length=1, max_length=200)
     duration_minutes: int = Field(ge=1, le=1440)
     description: str | None = Field(default=None, max_length=2000)

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -17,12 +17,19 @@ logger = logging.getLogger("tp-mcp")
 
 # Maps sport name to (workoutTypeFamilyId, workoutTypeValueId)
 SPORT_TYPE_MAP: dict[str, tuple[int, int]] = {
+    "Swim": (1, 1),
     "Bike": (2, 2),
     "Run": (3, 3),
-    "Swim": (1, 1),
+    "Brick": (4, 4),
+    "Crosstrain": (5, 5),
+    "Walk": (6, 6),
     "Strength": (7, 7),
-    "DayOff": (12, 12),
+    "Rowing": (8, 8),
+    "XCSki": (9, 9),
     "Other": (10, 10),
+    "Custom": (11, 11),
+    "DayOff": (12, 12),
+    "MtnBike": (13, 13),
 }
 
 
@@ -218,7 +225,7 @@ async def tp_create_workout(
 
     Args:
         date_str: Workout date in ISO format (YYYY-MM-DD).
-        sport: Sport type (Bike, Run, Swim, Strength, DayOff, Other).
+        sport: Sport type (Swim, Bike, Run, Brick, Crosstrain, Walk, Strength, Rowing, XCSki, Other, Custom, DayOff, MtnBike).
         title: Workout title.
         duration_minutes: Planned duration in minutes.
         description: Optional workout description.

--- a/tests/test_tools/test_workouts.py
+++ b/tests/test_tools/test_workouts.py
@@ -172,6 +172,54 @@ class TestTpCreateWorkout:
         assert payload["totalTimePlanned"] == 1.0  # 60 min -> 1.0 hours
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "sport,expected_family,expected_value",
+        [
+            ("Swim", 1, 1),
+            ("Bike", 2, 2),
+            ("Run", 3, 3),
+            ("Brick", 4, 4),
+            ("Crosstrain", 5, 5),
+            ("Walk", 6, 6),
+            ("Strength", 7, 7),
+            ("Rowing", 8, 8),
+            ("XCSki", 9, 9),
+            ("Other", 10, 10),
+            ("Custom", 11, 11),
+            ("DayOff", 12, 12),
+            ("MtnBike", 13, 13),
+        ],
+    )
+    async def test_create_workout_all_sport_types(self, sport, expected_family, expected_value):
+        """Test that all sport types map to correct API IDs."""
+        create_response = APIResponse(
+            success=True,
+            data={
+                "workoutId": 6001,
+                "title": f"Test {sport}",
+                "workoutDay": "2026-03-01T00:00:00",
+            },
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=create_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_create_workout(
+                date_str="2026-03-01",
+                sport=sport,
+                title=f"Test {sport}",
+                duration_minutes=30,
+            )
+
+        assert result["success"] is True
+        payload = mock_instance.post.call_args[1]["json"]
+        assert payload["workoutTypeFamilyId"] == expected_family
+        assert payload["workoutTypeValueId"] == expected_value
+
+    @pytest.mark.asyncio
     async def test_create_workout_optional_fields(self):
         """Test that distance_km and tss_planned are passed to API when provided."""
         create_response = APIResponse(


### PR DESCRIPTION
## Summary
- Adds the 7 missing workout types to `tp_create_workout`: **Brick**, **Crosstrain**, **Walk**, **Rowing**, **XCSki**, **Custom**, and **MtnBike**
- Previously only 6 of the 13 TrainingPeaks sport types were supported (Bike, Run, Swim, Strength, DayOff, Other)
- Updates `SPORT_TYPE_MAP`, Pydantic `CreateWorkoutInput` validation, and the MCP tool schema enum

## ID Mapping

| Sport | familyId | valueId | Source |
|-------|----------|---------|--------|
| Swim | 1 | 1 | existing |
| Bike | 2 | 2 | existing |
| Run | 3 | 3 | existing |
| Brick | 4 | 4 | [external ref](https://gist.github.com/vakata/af0df34b4df599409d5545e1293d3409) |
| Crosstrain | 5 | 5 | inferred from sequence |
| Walk | 6 | 6 | inferred from sequence |
| Strength | 7 | 7 | existing |
| Rowing | 8 | 8 | inferred from sequence |
| XCSki | 9 | 9 | inferred from sequence |
| Other | 10 | 10 | existing |
| Custom | 11 | 11 | inferred from sequence |
| DayOff | 12 | 12 | existing |
| MtnBike | 13 | 13 | inferred from sequence |

> **Note:** Some IDs are inferred from the sequential pattern observed in confirmed IDs. The TrainingPeaks API documentation for these internal IDs is not publicly available. Please verify the inferred IDs (Crosstrain, Walk, Rowing, XCSki, Custom, MtnBike) against the actual API if possible.

## Test plan
- [x] Added parametrized test covering all 13 sport types and their ID mappings
- [x] All 165 existing tests continue to pass
- [ ] Manually test creating a workout with each new type via the MCP tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)