### PR TITLE
Extract distance conversion helpers, fix 0.0 distance bug

### DIFF
--- a/src/tp_mcp/tools/_validation.py
+++ b/src/tp_mcp/tools/_validation.py
@@ -63,7 +63,7 @@ class CreateWorkoutInput(BaseModel):
 
     @field_validator("date", mode="before")
     @classmethod
-    def coerce_date_string(cls, v: object) -> object:
+    def coerce_string(cls, v: object) -> object:
         if isinstance(v, str):
             return date.fromisoformat(v)
         return v

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -15,6 +15,17 @@ from tp_mcp.tools._validation import (
 
 logger = logging.getLogger("tp-mcp")
 
+
+def _m_to_km(metres: float | None) -> float | None:
+    """Convert metres to kilometres, preserving None."""
+    return metres / 1000 if metres is not None else None
+
+
+def _km_to_m(km: float) -> float:
+    """Convert kilometres to metres."""
+    return km * 1000
+
+
 # Maps sport name to (workoutTypeFamilyId, workoutTypeValueId)
 SPORT_TYPE_MAP: dict[str, tuple[int, int]] = {
     "Swim": (1, 1),
@@ -106,8 +117,8 @@ async def tp_get_workouts(
                     "sport": w.sport,
                     "duration_planned": w.duration_planned,
                     "duration_actual": w.duration_actual,
-                    "distance_planned_km": w.distance_planned / 1000 if w.distance_planned else None,
-                    "distance_actual_km": w.distance_actual / 1000 if w.distance_actual else None,
+                    "distance_planned_km": _m_to_km(w.distance_planned),
+                    "distance_actual_km": _m_to_km(w.distance_actual),
                     "tss": w.tss_actual or w.tss_planned,
                     "description": w.description,
                 }
@@ -193,8 +204,8 @@ async def tp_get_workout(workout_id: str) -> dict[str, Any]:
                     "tss_actual": workout.tss_actual,
                     "if_planned": workout.if_planned,
                     "if_actual": workout.if_actual,
-                    "distance_planned_km": workout.distance_planned / 1000 if workout.distance_planned else None,
-                    "distance_actual_km": workout.distance_actual / 1000 if workout.distance_actual else None,
+                    "distance_planned_km": _m_to_km(workout.distance_planned),
+                    "distance_actual_km": _m_to_km(workout.distance_actual),
                     "avg_power": workout.avg_power,
                     "normalized_power": workout.normalized_power,
                     "avg_hr": workout.avg_hr,
@@ -277,7 +288,7 @@ async def tp_create_workout(
         if params.description:
             payload["description"] = params.description
         if params.distance_km is not None:
-            payload["distancePlanned"] = params.distance_km * 1000  # API expects metres
+            payload["distancePlanned"] = _km_to_m(params.distance_km)
         if params.tss_planned is not None:
             payload["tssPlanned"] = params.tss_planned
 


### PR DESCRIPTION
## Summary

- Extract `_m_to_km()` and `_km_to_m()` helpers to replace 5 inline distance conversions
- Fix bug: falsy check (`if x else None`) treated `0.0` distance as `None` - now uses `is not None`
- Restore consistent validator naming (`coerce_string` across all models)

Found by `/simplify` review of PR #14 changes.

## Test plan
- [x] All 169 tests pass
- [x] Lint clean