### PR TITLE
Add workout file operations (upload, download, delete)

### DIFF
--- a/src/tp_mcp/client/__init__.py
+++ b/src/tp_mcp/client/__init__.py
@@ -7,6 +7,7 @@ from tp_mcp.client.http import (
     ErrorCode,
     NotFoundError,
     RateLimitError,
+    RawResponse,
     TPClient,
 )
 from tp_mcp.client.models import (
@@ -38,6 +39,7 @@ __all__ = [
     "PeakData",
     "PeaksResponse",
     "RateLimitError",
+    "RawResponse",
     "TPClient",
     "UserProfile",
     "WorkoutAnalysis",

--- a/src/tp_mcp/client/http.py
+++ b/src/tp_mcp/client/http.py
@@ -70,6 +70,23 @@ class APIResponse:
 
 
 @dataclass
+class RawResponse:
+    """Wrapper for raw binary API responses."""
+
+    success: bool
+    content: bytes = field(default_factory=bytes)
+    content_type: str | None = None
+    content_disposition: str | None = None
+    error_code: ErrorCode | None = None
+    message: str = ""
+
+    @property
+    def is_error(self) -> bool:
+        """Check if response is an error."""
+        return not self.success
+
+
+@dataclass
 class TokenCache:
     """In-memory cache for OAuth access token."""
 
@@ -438,6 +455,89 @@ class TPClient:
             APIResponse.
         """
         return await self._request("DELETE", endpoint)
+
+    async def get_raw(self, endpoint: str, params: dict[str, Any] | None = None) -> RawResponse:
+        """Make an authenticated GET request and return the raw binary response.
+
+        Handles token refresh and retries on 401 exactly once, mirroring _request logic.
+
+        Args:
+            endpoint: API endpoint.
+            params: Query parameters.
+
+        Returns:
+            RawResponse with binary content and headers, or error.
+        """
+        await self._ensure_client()
+        assert self._client is not None
+
+        token_result = await self._ensure_access_token()
+        if not token_result.success:
+            return RawResponse(
+                success=False,
+                error_code=token_result.error_code,
+                message=token_result.message,
+            )
+
+        await self._throttle()
+
+        url = f"{self.base_url}{endpoint}"
+        headers = {**self._get_headers(), "Accept": "*/*"}
+
+        try:
+            response = await self._client.request("GET", url=url, headers=headers, params=params)
+
+            if response.status_code == 401:
+                self._token_cache.clear()
+                token_result = await self._ensure_access_token()
+                if not token_result.success:
+                    return RawResponse(
+                        success=False,
+                        error_code=token_result.error_code,
+                        message=token_result.message,
+                    )
+                await self._throttle()
+                headers = {**self._get_headers(), "Accept": "*/*"}
+                response = await self._client.request("GET", url=url, headers=headers, params=params)
+
+        except httpx.TimeoutException:
+            return RawResponse(
+                success=False,
+                error_code=ErrorCode.NETWORK_ERROR,
+                message="Request timed out. Check your network connection.",
+            )
+        except httpx.RequestError as e:
+            return RawResponse(
+                success=False,
+                error_code=ErrorCode.NETWORK_ERROR,
+                message=f"Network error: {e}",
+            )
+
+        if response.status_code == 401:
+            return RawResponse(
+                success=False,
+                error_code=ErrorCode.AUTH_EXPIRED,
+                message="Session expired or invalid. Run 'tp-mcp auth' to re-authenticate.",
+            )
+        if response.status_code == 404:
+            return RawResponse(
+                success=False,
+                error_code=ErrorCode.NOT_FOUND,
+                message="Resource not found.",
+            )
+        if response.status_code != 200:
+            return RawResponse(
+                success=False,
+                error_code=ErrorCode.API_ERROR,
+                message=f"API error: {response.status_code} - {response.text}",
+            )
+
+        return RawResponse(
+            success=True,
+            content=response.content,
+            content_type=response.headers.get("Content-Type"),
+            content_disposition=response.headers.get("Content-Disposition"),
+        )
 
     @property
     def athlete_id(self) -> int | None:

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -19,9 +19,6 @@ from tp_mcp.tools import (
     tp_analyze_workout,
     tp_auth_status,
     tp_copy_workout,
-    tp_delete_workout_file,
-    tp_download_workout_file,
-    tp_upload_workout_file,
     tp_create_availability,
     tp_create_equipment,
     tp_create_event,
@@ -35,6 +32,8 @@ from tp_mcp.tools import (
     tp_delete_library,
     tp_delete_note,
     tp_delete_workout,
+    tp_delete_workout_file,
+    tp_download_workout_file,
     tp_get_athlete_settings,
     tp_get_atp,
     tp_get_availability,
@@ -69,6 +68,7 @@ from tp_mcp.tools import (
     tp_update_nutrition,
     tp_update_speed_zones,
     tp_update_workout,
+    tp_upload_workout_file,
     tp_validate_structure,
 )
 from tp_mcp.tools.workouts import SPORT_TYPE_MAP
@@ -301,14 +301,20 @@ TOOLS = [
                 "workout_id": {"type": "string", "description": "Workout ID"},
                 "file_path": {"type": "string", "description": "Path to file on disk"},
                 "file_data_base64": {"type": "string", "description": "Base64-encoded file bytes"},
-                "workout_day": {"type": "string", "description": "YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS. Auto-fetched if omitted."},
+                "workout_day": {
+                    "type": "string",
+                    "description": "YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS. Auto-fetched if omitted.",
+                },
             },
             "required": ["workout_id"],
         },
     ),
     Tool(
         name="tp_download_workout_file",
-        description="Download a workout file by file_id. Get file_id from tp_get_workout device_files/attachment_files.",
+        description=(
+            "Download a workout file by file_id."
+            " Get file_id from tp_get_workout device_files/attachment_files."
+        ),
         inputSchema={
             "type": "object",
             "properties": {

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -19,6 +19,9 @@ from tp_mcp.tools import (
     tp_analyze_workout,
     tp_auth_status,
     tp_copy_workout,
+    tp_delete_workout_file,
+    tp_download_workout_file,
+    tp_upload_workout_file,
     tp_create_availability,
     tp_create_equipment,
     tp_create_event,
@@ -286,6 +289,46 @@ TOOLS = [
                 "comment": {"type": "string"},
             },
             "required": ["workout_id", "comment"],
+        },
+    ),
+    # --- Workout Files ---
+    Tool(
+        name="tp_upload_workout_file",
+        description="Upload a workout file (.fit, .tcx, .gpx) to an existing workout.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "workout_id": {"type": "string", "description": "Workout ID"},
+                "file_path": {"type": "string", "description": "Path to file on disk"},
+                "file_data_base64": {"type": "string", "description": "Base64-encoded file bytes"},
+                "workout_day": {"type": "string", "description": "YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS. Auto-fetched if omitted."},
+            },
+            "required": ["workout_id"],
+        },
+    ),
+    Tool(
+        name="tp_download_workout_file",
+        description="Download a workout file by file_id. Get file_id from tp_get_workout device_files/attachment_files.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "workout_id": {"type": "string", "description": "Workout ID"},
+                "file_id": {"type": "string", "description": "File ID from tp_get_workout"},
+                "output_path": {"type": "string", "description": "Directory or full path to save file"},
+            },
+            "required": ["workout_id", "file_id"],
+        },
+    ),
+    Tool(
+        name="tp_delete_workout_file",
+        description="Delete a workout file by file_id. Get file_id from tp_get_workout device_files/attachment_files.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "workout_id": {"type": "string", "description": "Workout ID"},
+                "file_id": {"type": "string", "description": "File ID from tp_get_workout"},
+            },
+            "required": ["workout_id", "file_id"],
         },
     ),
     Tool(
@@ -866,6 +909,30 @@ async def _h_get_comments(args): return await tp_get_workout_comments(workout_id
 @_handler("tp_add_workout_comment")
 async def _h_add_comment(args):
     return await tp_add_workout_comment(workout_id=args["workout_id"], comment=args["comment"])
+
+@_handler("tp_upload_workout_file")
+async def _h_upload_workout_file(args):
+    return await tp_upload_workout_file(
+        workout_id=args["workout_id"],
+        file_path=args.get("file_path"),
+        file_data_base64=args.get("file_data_base64"),
+        workout_day=args.get("workout_day"),
+    )
+
+@_handler("tp_download_workout_file")
+async def _h_download_workout_file(args):
+    return await tp_download_workout_file(
+        workout_id=args["workout_id"],
+        file_id=args["file_id"],
+        output_path=args.get("output_path"),
+    )
+
+@_handler("tp_delete_workout_file")
+async def _h_delete_workout_file(args):
+    return await tp_delete_workout_file(
+        workout_id=args["workout_id"],
+        file_id=args["file_id"],
+    )
 
 @_handler("tp_validate_structure")
 async def _h_validate_structure(args): return await tp_validate_structure(structure=args["structure"])

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -47,12 +47,12 @@ from tp_mcp.tools.settings import (
 )
 from tp_mcp.tools.structure import tp_validate_structure
 from tp_mcp.tools.weekly_summary import tp_get_weekly_summary
-from tp_mcp.tools.workout_types import tp_get_workout_types
 from tp_mcp.tools.workout_files import (
     tp_delete_workout_file,
     tp_download_workout_file,
     tp_upload_workout_file,
 )
+from tp_mcp.tools.workout_types import tp_get_workout_types
 from tp_mcp.tools.workouts import (
     tp_add_workout_comment,
     tp_copy_workout,

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -48,6 +48,11 @@ from tp_mcp.tools.settings import (
 from tp_mcp.tools.structure import tp_validate_structure
 from tp_mcp.tools.weekly_summary import tp_get_weekly_summary
 from tp_mcp.tools.workout_types import tp_get_workout_types
+from tp_mcp.tools.workout_files import (
+    tp_delete_workout_file,
+    tp_download_workout_file,
+    tp_upload_workout_file,
+)
 from tp_mcp.tools.workouts import (
     tp_add_workout_comment,
     tp_copy_workout,
@@ -78,6 +83,8 @@ __all__ = [
     "tp_delete_library",
     "tp_delete_note",
     "tp_delete_workout",
+    "tp_delete_workout_file",
+    "tp_download_workout_file",
     "tp_get_athlete_settings",
     "tp_get_atp",
     "tp_get_availability",
@@ -112,5 +119,6 @@ __all__ = [
     "tp_update_nutrition",
     "tp_update_speed_zones",
     "tp_update_workout",
+    "tp_upload_workout_file",
     "tp_validate_structure",
 ]

--- a/src/tp_mcp/tools/workout_files.py
+++ b/src/tp_mcp/tools/workout_files.py
@@ -131,7 +131,11 @@ async def tp_upload_workout_file(
     async with TPClient() as client:
         athlete_id = await client.ensure_athlete_id()
         if not athlete_id:
-            return {"isError": True, "error_code": "AUTH_INVALID", "message": "Could not get athlete ID. Re-authenticate."}
+            return {
+                "isError": True,
+                "error_code": "AUTH_INVALID",
+                "message": "Could not get athlete ID. Re-authenticate.",
+            }
 
         resolved_workout_day: str
         if workout_day:
@@ -201,12 +205,20 @@ async def tp_download_workout_file(
     if not _is_numeric_id(workout_id):
         return {"isError": True, "error_code": "VALIDATION_ERROR", "message": "workout_id must be a numeric ID."}
     if not _is_numeric_id(file_id, allow_negative=True):
-        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": "file_id must be a numeric ID (can be negative)."}
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": "file_id must be a numeric ID (can be negative).",
+        }
 
     async with TPClient() as client:
         athlete_id = await client.ensure_athlete_id()
         if not athlete_id:
-            return {"isError": True, "error_code": "AUTH_INVALID", "message": "Could not get athlete ID. Re-authenticate."}
+            return {
+                "isError": True,
+                "error_code": "AUTH_INVALID",
+                "message": "Could not get athlete ID. Re-authenticate.",
+            }
 
         token_result = await client._ensure_access_token()
         if not token_result.success:
@@ -227,7 +239,11 @@ async def tp_download_workout_file(
         try:
             response = await client._client.request("GET", url=url, headers=headers)
         except httpx.TimeoutException:
-            return {"isError": True, "error_code": "NETWORK_ERROR", "message": "Request timed out. Check your network connection."}
+            return {
+                "isError": True,
+                "error_code": "NETWORK_ERROR",
+                "message": "Request timed out. Check your network connection.",
+            }
         except httpx.RequestError as e:
             return {"isError": True, "error_code": "NETWORK_ERROR", "message": f"Network error: {e}"}
 
@@ -290,12 +306,20 @@ async def tp_delete_workout_file(workout_id: str, file_id: str) -> dict[str, Any
     if not _is_numeric_id(workout_id):
         return {"isError": True, "error_code": "VALIDATION_ERROR", "message": "workout_id must be a numeric ID."}
     if not _is_numeric_id(file_id, allow_negative=True):
-        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": "file_id must be a numeric ID (can be negative)."}
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": "file_id must be a numeric ID (can be negative).",
+        }
 
     async with TPClient() as client:
         athlete_id = await client.ensure_athlete_id()
         if not athlete_id:
-            return {"isError": True, "error_code": "AUTH_INVALID", "message": "Could not get athlete ID. Re-authenticate."}
+            return {
+                "isError": True,
+                "error_code": "AUTH_INVALID",
+                "message": "Could not get athlete ID. Re-authenticate.",
+            }
 
         endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{workout_id}/filedata/{file_id}"
         response = await client.delete(endpoint)

--- a/src/tp_mcp/tools/workout_files.py
+++ b/src/tp_mcp/tools/workout_files.py
@@ -1,0 +1,309 @@
+"""Workout file upload, download, and delete tools."""
+
+import base64
+import gzip
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from tp_mcp.client import TPClient
+
+FILE_DATA_DIR = Path(tempfile.gettempdir()) / "tp-mcp" / "files"
+
+
+def _is_numeric_id(value: str, *, allow_negative: bool = False) -> bool:
+    """Return True when value is a numeric ID string."""
+    if value is None:
+        return False
+    text = str(value).strip()
+    if not text:
+        return False
+    if allow_negative:
+        return text.lstrip("-").isdigit()
+    return text.isdigit()
+
+
+def _normalize_workout_day(workout_day: str) -> str:
+    """Convert YYYY-MM-DD to TP datetime format, pass through if already datetime."""
+    value = workout_day.strip()
+    if "T" in value:
+        return value
+    return f"{value}T00:00:00"
+
+
+def _gzip_if_needed(file_bytes: bytes) -> bytes:
+    """Ensure upload payload uses gzip bytes as expected by TP filedata endpoint."""
+    if len(file_bytes) >= 2 and file_bytes[0] == 0x1F and file_bytes[1] == 0x8B:
+        return file_bytes
+    return gzip.compress(file_bytes)
+
+
+def _parse_content_disposition_filename(value: str | None) -> str | None:
+    """Extract filename from Content-Disposition header."""
+    if not value:
+        return None
+    lower = value.lower()
+    token = "filename="
+    idx = lower.find(token)
+    if idx == -1:
+        return None
+    filename = value[idx + len(token):].strip().strip('"').strip("'")
+    return Path(filename).name if filename else None
+
+
+def _save_workout_file(workout_id: str, file_id: str, filename: str, data: bytes) -> str:
+    """Persist downloaded workout file and return absolute path."""
+    FILE_DATA_DIR.mkdir(parents=True, exist_ok=True)
+    fallback_name = f"workout_{workout_id}_file_{file_id}.fit.gz"
+    safe_name = Path(filename).name if filename else fallback_name
+    path = FILE_DATA_DIR / safe_name
+    path.write_bytes(data)
+    return str(path.resolve())
+
+
+async def tp_upload_workout_file(
+    workout_id: str,
+    file_path: str | None = None,
+    file_data_base64: str | None = None,
+    workout_day: str | None = None,
+) -> dict[str, Any]:
+    """Upload a workout file (.fit, .tcx, .gpx) to an existing workout.
+
+    Args:
+        workout_id: The workout ID.
+        file_path: Path to the file on disk (mutually exclusive with file_data_base64).
+        file_data_base64: Base64-encoded file bytes (mutually exclusive with file_path).
+        workout_day: Workout date (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS). If omitted, fetched from the workout.
+
+    Returns:
+        Dict with upload confirmation or error.
+    """
+    if not _is_numeric_id(workout_id):
+        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": "workout_id must be a numeric ID."}
+    if not file_path and not file_data_base64:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": "Provide either file_path or file_data_base64.",
+        }
+    if file_path and file_data_base64:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": "Provide only one of file_path or file_data_base64.",
+        }
+
+    raw_bytes: bytes
+    file_name: str
+    if file_path:
+        try:
+            raw_bytes = Path(file_path).read_bytes()
+        except OSError as e:
+            return {
+                "isError": True,
+                "error_code": "VALIDATION_ERROR",
+                "message": f"Could not read file_path: {e}",
+            }
+        file_name = Path(file_path).name
+    else:
+        try:
+            raw_bytes = base64.b64decode(file_data_base64 or "", validate=True)
+        except (ValueError, TypeError) as e:
+            return {
+                "isError": True,
+                "error_code": "VALIDATION_ERROR",
+                "message": f"file_data_base64 is invalid base64: {e}",
+            }
+        file_name = f"workout_{workout_id}.fit.gz"
+
+    if not raw_bytes:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": "Uploaded file content must not be empty.",
+        }
+
+    gzipped = _gzip_if_needed(raw_bytes)
+    payload_data = base64.b64encode(gzipped).decode("ascii")
+
+    async with TPClient() as client:
+        athlete_id = await client.ensure_athlete_id()
+        if not athlete_id:
+            return {"isError": True, "error_code": "AUTH_INVALID", "message": "Could not get athlete ID. Re-authenticate."}
+
+        resolved_workout_day: str
+        if workout_day:
+            resolved_workout_day = _normalize_workout_day(workout_day)
+        else:
+            get_endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{workout_id}"
+            get_response = await client.get(get_endpoint)
+            if get_response.is_error:
+                return {
+                    "isError": True,
+                    "error_code": get_response.error_code.value if get_response.error_code else "API_ERROR",
+                    "message": f"Failed to fetch workout for upload: {get_response.message}",
+                }
+            workout_payload = get_response.data if isinstance(get_response.data, dict) else {}
+            existing_day = workout_payload.get("workoutDay")
+            if not existing_day:
+                return {
+                    "isError": True,
+                    "error_code": "API_ERROR",
+                    "message": "Could not determine workoutDay for upload. Provide workout_day explicitly.",
+                }
+            resolved_workout_day = _normalize_workout_day(str(existing_day))
+
+        endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{workout_id}/filedata"
+        response = await client.post(
+            endpoint,
+            json={
+                "workoutDay": resolved_workout_day,
+                "data": payload_data,
+                "fileName": file_name,
+                "uploadClient": "TP Web App",
+            },
+        )
+
+        if response.is_error:
+            return {
+                "isError": True,
+                "error_code": response.error_code.value if response.error_code else "API_ERROR",
+                "message": response.message,
+            }
+
+        resp_data = response.data if isinstance(response.data, dict) else {}
+        return {
+            "workout_id": str(resp_data.get("workoutId", workout_id)),
+            "uploaded_bytes": len(raw_bytes),
+            "uploaded_gzip_bytes": len(gzipped),
+            "workout_day": resolved_workout_day,
+            "message": "Workout file uploaded successfully.",
+        }
+
+
+async def tp_download_workout_file(
+    workout_id: str,
+    file_id: str,
+    output_path: str | None = None,
+) -> dict[str, Any]:
+    """Download a workout file by file_id.
+
+    Args:
+        workout_id: The workout ID.
+        file_id: The file ID (from device_files or attachment_files in tp_get_workout).
+        output_path: Optional path to save the file. Can be a directory or full file path.
+
+    Returns:
+        Dict with file info and saved path, or error.
+    """
+    if not _is_numeric_id(workout_id):
+        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": "workout_id must be a numeric ID."}
+    if not _is_numeric_id(file_id, allow_negative=True):
+        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": "file_id must be a numeric ID (can be negative)."}
+
+    async with TPClient() as client:
+        athlete_id = await client.ensure_athlete_id()
+        if not athlete_id:
+            return {"isError": True, "error_code": "AUTH_INVALID", "message": "Could not get athlete ID. Re-authenticate."}
+
+        token_result = await client._ensure_access_token()
+        if not token_result.success:
+            return {
+                "isError": True,
+                "error_code": token_result.error_code.value if token_result.error_code else "AUTH_INVALID",
+                "message": token_result.message or "Failed to obtain access token.",
+            }
+
+        await client._ensure_client()
+        await client._throttle()
+        assert client._client is not None
+
+        endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{workout_id}/rawfiledata/{file_id}"
+        url = f"{client.base_url}{endpoint}"
+        headers = {"Authorization": f"Bearer {client._token_cache.access_token}", "Accept": "*/*"}
+
+        try:
+            response = await client._client.request("GET", url=url, headers=headers)
+        except httpx.TimeoutException:
+            return {"isError": True, "error_code": "NETWORK_ERROR", "message": "Request timed out. Check your network connection."}
+        except httpx.RequestError as e:
+            return {"isError": True, "error_code": "NETWORK_ERROR", "message": f"Network error: {e}"}
+
+        if response.status_code == 401:
+            return {
+                "isError": True,
+                "error_code": "AUTH_EXPIRED",
+                "message": "Session expired or invalid. Run 'tp-mcp auth' to re-authenticate.",
+            }
+        if response.status_code == 404:
+            return {"isError": True, "error_code": "NOT_FOUND", "message": f"Workout file {file_id} not found."}
+        if response.status_code != 200:
+            return {
+                "isError": True,
+                "error_code": "API_ERROR",
+                "message": f"API error: {response.status_code} - {response.text}",
+            }
+
+        filename = _parse_content_disposition_filename(response.headers.get("Content-Disposition"))
+        content = response.content
+        if output_path:
+            target = Path(output_path)
+            if target.exists() and target.is_dir():
+                save_name = filename or f"workout_{workout_id}_file_{file_id}.fit.gz"
+                file_out = (target / Path(save_name).name).resolve()
+            else:
+                file_out = target.resolve()
+            file_out.parent.mkdir(parents=True, exist_ok=True)
+            file_out.write_bytes(content)
+            saved_to = str(file_out)
+        else:
+            saved_to = _save_workout_file(
+                workout_id=workout_id,
+                file_id=file_id,
+                filename=filename or "",
+                data=content,
+            )
+
+        return {
+            "workout_id": workout_id,
+            "file_id": file_id,
+            "file_name": filename,
+            "content_type": response.headers.get("Content-Type"),
+            "size_bytes": len(content),
+            "saved_to": saved_to,
+            "message": "Workout file downloaded successfully.",
+        }
+
+
+async def tp_delete_workout_file(workout_id: str, file_id: str) -> dict[str, Any]:
+    """Delete a workout file.
+
+    Args:
+        workout_id: The workout ID.
+        file_id: The file ID (from device_files or attachment_files in tp_get_workout).
+
+    Returns:
+        Dict with confirmation or error.
+    """
+    if not _is_numeric_id(workout_id):
+        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": "workout_id must be a numeric ID."}
+    if not _is_numeric_id(file_id, allow_negative=True):
+        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": "file_id must be a numeric ID (can be negative)."}
+
+    async with TPClient() as client:
+        athlete_id = await client.ensure_athlete_id()
+        if not athlete_id:
+            return {"isError": True, "error_code": "AUTH_INVALID", "message": "Could not get athlete ID. Re-authenticate."}
+
+        endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{workout_id}/filedata/{file_id}"
+        response = await client.delete(endpoint)
+        if response.is_error:
+            return {
+                "isError": True,
+                "error_code": response.error_code.value if response.error_code else "API_ERROR",
+                "message": response.message,
+            }
+
+        return {"workout_id": workout_id, "file_id": file_id, "message": "Workout file deleted successfully."}

--- a/src/tp_mcp/tools/workout_files.py
+++ b/src/tp_mcp/tools/workout_files.py
@@ -6,8 +6,6 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-import httpx
-
 from tp_mcp.client import TPClient
 
 FILE_DATA_DIR = Path(tempfile.gettempdir()) / "tp-mcp" / "files"
@@ -220,49 +218,19 @@ async def tp_download_workout_file(
                 "message": "Could not get athlete ID. Re-authenticate.",
             }
 
-        token_result = await client._ensure_access_token()
-        if not token_result.success:
-            return {
-                "isError": True,
-                "error_code": token_result.error_code.value if token_result.error_code else "AUTH_INVALID",
-                "message": token_result.message or "Failed to obtain access token.",
-            }
-
-        await client._ensure_client()
-        await client._throttle()
-        assert client._client is not None
-
         endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{workout_id}/rawfiledata/{file_id}"
-        url = f"{client.base_url}{endpoint}"
-        headers = {"Authorization": f"Bearer {client._token_cache.access_token}", "Accept": "*/*"}
+        response = await client.get_raw(endpoint)
 
-        try:
-            response = await client._client.request("GET", url=url, headers=headers)
-        except httpx.TimeoutException:
+        if response.is_error:
+            if response.error_code is not None and response.error_code.value == "NOT_FOUND":
+                return {"isError": True, "error_code": "NOT_FOUND", "message": f"Workout file {file_id} not found."}
             return {
                 "isError": True,
-                "error_code": "NETWORK_ERROR",
-                "message": "Request timed out. Check your network connection.",
-            }
-        except httpx.RequestError as e:
-            return {"isError": True, "error_code": "NETWORK_ERROR", "message": f"Network error: {e}"}
-
-        if response.status_code == 401:
-            return {
-                "isError": True,
-                "error_code": "AUTH_EXPIRED",
-                "message": "Session expired or invalid. Run 'tp-mcp auth' to re-authenticate.",
-            }
-        if response.status_code == 404:
-            return {"isError": True, "error_code": "NOT_FOUND", "message": f"Workout file {file_id} not found."}
-        if response.status_code != 200:
-            return {
-                "isError": True,
-                "error_code": "API_ERROR",
-                "message": f"API error: {response.status_code} - {response.text}",
+                "error_code": response.error_code.value if response.error_code else "API_ERROR",
+                "message": response.message,
             }
 
-        filename = _parse_content_disposition_filename(response.headers.get("Content-Disposition"))
+        filename = _parse_content_disposition_filename(response.content_disposition)
         content = response.content
         if output_path:
             target = Path(output_path)
@@ -286,7 +254,7 @@ async def tp_download_workout_file(
             "workout_id": workout_id,
             "file_id": file_id,
             "file_name": filename,
-            "content_type": response.headers.get("Content-Type"),
+            "content_type": response.content_type,
             "size_bytes": len(content),
             "saved_to": saved_to,
             "message": "Workout file downloaded successfully.",

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -202,10 +202,18 @@ async def tp_get_workout(workout_id: str) -> dict[str, Any]:
                 "message": f"Workout {workout_id} not found",
             }
 
+        # Fetch /details endpoint for file infos (not included in main endpoint)
+        details_endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{validated.workout_id}/details"
+        details_response = await client.get(details_endpoint)
+        details_raw = (
+            details_response.data
+            if details_response.success and isinstance(details_response.data, dict)
+            else {}
+        )
+
         try:
             workout = parse_workout_detail(response.data)
 
-            raw = response.data if isinstance(response.data, dict) else {}
             return {
                 "id": str(workout.id),
                 "date": workout.date.isoformat(),
@@ -232,8 +240,8 @@ async def tp_get_workout(workout_id: str) -> dict[str, Any]:
                     "calories": workout.calories,
                 },
                 "completed": workout.completed,
-                "device_files": _extract_file_infos(raw, "workoutDeviceFileInfos"),
-                "attachment_files": _extract_file_infos(raw, "attachmentFileInfos"),
+                "device_files": _extract_file_infos(details_raw, "workoutDeviceFileInfos"),
+                "attachment_files": _extract_file_infos(details_raw, "attachmentFileInfos"),
             }
 
         except Exception:

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -22,6 +22,25 @@ from tp_mcp.tools.structure import (
 
 logger = logging.getLogger("tp-mcp")
 
+
+def _extract_file_infos(raw_data: dict, key: str) -> list[dict]:
+    """Normalize TP workout file metadata arrays."""
+    infos = raw_data.get(key)
+    if not isinstance(infos, list):
+        return []
+    normalized = []
+    for item in infos:
+        if not isinstance(item, dict):
+            continue
+        file_id = item.get("fileId")
+        normalized.append({
+            "file_id": str(file_id) if file_id is not None else None,
+            "file_system_id": item.get("fileSystemId"),
+            "file_name": item.get("fileName"),
+            "uploaded_at": item.get("dateUploaded"),
+        })
+    return normalized
+
 # Maps sport name to (workoutTypeFamilyId, workoutTypeValueId)
 # IDs confirmed from GET /fitness/v6/workouttypes
 SPORT_TYPE_MAP: dict[str, tuple[int, int]] = {
@@ -186,6 +205,7 @@ async def tp_get_workout(workout_id: str) -> dict[str, Any]:
         try:
             workout = parse_workout_detail(response.data)
 
+            raw = response.data if isinstance(response.data, dict) else {}
             return {
                 "id": str(workout.id),
                 "date": workout.date.isoformat(),
@@ -212,6 +232,8 @@ async def tp_get_workout(workout_id: str) -> dict[str, Any]:
                     "calories": workout.calories,
                 },
                 "completed": workout.completed,
+                "device_files": _extract_file_infos(raw, "workoutDeviceFileInfos"),
+                "attachment_files": _extract_file_infos(raw, "attachmentFileInfos"),
             }
 
         except Exception:

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -91,6 +91,9 @@ class TestListTools:
             "tp_update_library_item",
             "tp_schedule_library_workout",
             "tp_list_athletes",
+            "tp_upload_workout_file",
+            "tp_download_workout_file",
+            "tp_delete_workout_file",
         }
         assert v2_tools.issubset(names)
         assert len(names) == len(core_tools) + len(v2_tools)


### PR DESCRIPTION
## Summary

- Add `tp_upload_workout_file` tool to upload `.fit`, `.tcx`, `.gpx` files to an existing workout
- Add `tp_download_workout_file` tool to download a workout file by file_id
- Add `tp_delete_workout_file` tool to delete a workout file by file_id
- Expose `device_files` and `attachment_files` in `tp_get_workout` response so file IDs can be retrieved

## Test plan

- [x] Upload a `.fit` file to a workout via `tp_upload_workout_file`
- [x] Verify `tp_get_workout` returns `device_files`/`attachment_files` with correct file IDs
- [x] Download a file via `tp_download_workout_file` using a file ID from above
- [x] Delete a file via `tp_delete_workout_file` and confirm it no longer appears

## Changelog

- Fix ruff lint errors: sorted imports in `server.py` and `tools/__init__.py`, wrapped long lines in `workout_files.py` and `server.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)