### PR TITLE
Improve settings tool descriptions for reliable tool selection

### DIFF
--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -391,16 +391,22 @@ TOOLS = [
     ),
     Tool(
         name="tp_update_ftp",
-        description="Update FTP and recalculate Coggan 5-zone power model.",
+        description=(
+            "Set the athlete's FTP (Functional Threshold Power) and recalculate power zones. "
+            "Use when the user says 'set FTP to X', 'update FTP', or 'my FTP is X watts'."
+        ),
         inputSchema={
             "type": "object",
-            "properties": {"ftp": {"type": "integer", "description": "FTP in watts"}},
+            "properties": {"ftp": {"type": "integer", "description": "New FTP value in watts (e.g. 138, 250, 310)"}},
             "required": ["ftp"],
         },
     ),
     Tool(
         name="tp_update_hr_zones",
-        description="Update heart rate zones.",
+        description=(
+            "Set heart rate zones. "
+            "Use when the user says 'set threshold HR', 'update max HR', or 'my resting HR is X'."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
@@ -414,7 +420,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_update_speed_zones",
-        description="Update run/swim pace zones.",
+        description=(
+            "Set run or swim threshold pace and recalculate pace zones. "
+            "Use when the user says 'set run pace to X', 'my threshold pace is X'."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
@@ -426,7 +435,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_update_nutrition",
-        description="Update daily planned calories.",
+        description=(
+            "Set daily planned calories. "
+            "Use when the user says 'set calories to X' or 'update my calorie target'."
+        ),
         inputSchema={
             "type": "object",
             "properties": {"planned_calories": {"type": "integer"}},


### PR DESCRIPTION
## Summary
- Enriches tool descriptions for `tp_update_ftp`, `tp_update_hr_zones`, `tp_update_speed_zones`, and `tp_update_nutrition` with explicit trigger phrases
- Fixes an issue where Claude sees all 52 tools but won't call the settings update tools because the descriptions are too terse to match user intent (e.g. "set my FTP to 138")

## Problem
With 52 tools registered, Claude needs clear signal in the description to confidently select the right tool. The old descriptions like `"Update FTP and recalculate Coggan 5-zone power model."` didn't include the natural-language patterns users actually say, so Claude would respond "I can't update your FTP" even though the tool was available.

## Changes
| Tool | Before | After |
|------|--------|-------|
| `tp_update_ftp` | "Update FTP and recalculate Coggan 5-zone power model." | "Set the athlete's FTP (Functional Threshold Power) and recalculate power zones. Use when the user says 'set FTP to X', 'update FTP', or 'my FTP is X watts'." |
| `tp_update_hr_zones` | "Update heart rate zones." | "Set heart rate zones. Use when the user says 'set threshold HR', 'update max HR', or 'my resting HR is X'." |
| `tp_update_speed_zones` | "Update run/swim pace zones." | "Set run or swim threshold pace and recalculate pace zones. Use when the user says 'set run pace to X', 'my threshold pace is X'." |
| `tp_update_nutrition` | "Update daily planned calories." | "Set daily planned calories. Use when the user says 'set calories to X' or 'update my calorie target'." |

## Test plan
- [x] All 12 settings tests pass
- [x] Server loads all 52 tools correctly
- [ ] Restart Claude Desktop and ask "set my FTP to 138" — Claude should now call `tp_update_ftp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)