### PR TITLE
Fix auth-status showing None for email and athlete ID

### DIFF
--- a/src/tp_mcp/auth/validator.py
+++ b/src/tp_mcp/auth/validator.py
@@ -63,11 +63,41 @@ async def validate_auth(cookie: str) -> AuthResult:
 
             if response.status_code == 200:
                 data = response.json()
+                token_info = data.get("token", {})
+                access_token = token_info.get("access_token")
+
+                # Token endpoint only returns the token, not user info.
+                # Fetch user profile with the access token.
+                email = None
+                athlete_id = None
+                user_id = None
+
+                if access_token:
+                    try:
+                        user_resp = await client.get(
+                            f"{TP_API_BASE}/users/v3/user",
+                            headers={
+                                "Authorization": f"Bearer {access_token}",
+                                "Accept": "application/json",
+                            },
+                        )
+                        if user_resp.status_code == 200:
+                            user_data = user_resp.json().get("user", {})
+                            email = user_data.get("email")
+                            user_id = user_data.get("userId")
+                            athletes = user_data.get("athletes", [])
+                            if athletes:
+                                athlete_id = athletes[0].get("athleteId")
+                            if not athlete_id:
+                                athlete_id = user_data.get("personId")
+                    except httpx.RequestError:
+                        pass  # User info is best-effort; auth is still valid
+
                 return AuthResult(
                     status=AuthStatus.VALID,
-                    athlete_id=data.get("athleteId"),
-                    user_id=data.get("userId"),
-                    email=data.get("username"),  # TP returns email as username
+                    athlete_id=athlete_id,
+                    user_id=user_id,
+                    email=email,
                     message="Authentication valid",
                 )
             elif response.status_code == 401:

--- a/tests/test_auth/test_validator.py
+++ b/tests/test_auth/test_validator.py
@@ -13,17 +13,29 @@ class TestValidateAuth:
     @pytest.mark.asyncio
     async def test_valid_auth(self):
         """Test validation with valid cookie."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "athleteId": 123,
-            "userId": 456,
-            "username": "test@example.com",
+        # Token endpoint returns only token data
+        token_response = MagicMock()
+        token_response.status_code = 200
+        token_response.json.return_value = {
+            "success": True,
+            "token": {"access_token": "test_token", "expires_in": 3600},
+        }
+
+        # User endpoint returns profile info
+        user_response = MagicMock()
+        user_response.status_code = 200
+        user_response.json.return_value = {
+            "user": {
+                "email": "test@example.com",
+                "userId": 456,
+                "personId": 789,
+                "athletes": [{"athleteId": 123}],
+            }
         }
 
         with patch("tp_mcp.auth.validator.httpx.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
-            mock_instance.get.return_value = mock_response
+            mock_instance.get.side_effect = [token_response, user_response]
             mock_client.return_value.__aenter__.return_value = mock_instance
 
             result = await validate_auth("valid_cookie")


### PR DESCRIPTION
## Summary

- Fix `tp-mcp auth-status` always showing `Email: None` and `Athlete ID: None` even when authenticated
- Closes #25

## Root cause

The `/users/v3/token` endpoint only returns `{"success": true, "token": {...}}`. The `validate_auth` function was reading `athleteId`, `userId`, and `username` from this response where they never existed.

## Fix

After getting the token, `validate_auth` now makes a follow-up call to `/users/v3/user` with the access token to fetch the user profile. If the profile call fails, auth is still reported as valid - user info is best-effort.

## Test plan

- [x] `tp-mcp auth-status` now shows correct email and athlete ID
- [x] Updated test mock to match actual TP API response format (token endpoint returns token only, user endpoint returns profile)
- [x] All 293 tests pass