### PR TITLE
Fix off-by-one workout date bug (UTC-to-local timezone conversion)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+TrainingPeaks MCP Server — a Python MCP server enabling AI assistants to interact with TrainingPeaks via 52+ tools. Uses browser cookie authentication (no official API key required).
+
+## Commands
+
+```bash
+# Setup
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev,browser]"
+
+# Run server
+tp-mcp serve
+
+# Authentication
+tp-mcp auth --from-browser auto   # Extract from browser
+tp-mcp auth-status
+
+# Lint & type check
+ruff check src/
+mypy src/
+
+# Tests
+pytest tests/ -v
+pytest tests/test_tools/test_workouts.py::test_name -v   # Single test
+```
+
+## Architecture
+
+Layered design: **MCP Server → Tools → HTTP Client → Auth**
+
+```
+src/tp_mcp/
+├── server.py          # Tool registration, MCP stdio transport
+├── cli.py             # CLI entrypoint (auth, serve, config commands)
+├── client/
+│   ├── http.py        # TPClient: async httpx, token refresh, rate limiting
+│   └── models.py      # Pydantic response models
+├── auth/
+│   ├── storage.py     # Credential hierarchy: env var → keyring → encrypted file
+│   ├── keyring.py     # OS keyring integration
+│   ├── encrypted.py   # AES-256-GCM fallback storage
+│   ├── browser.py     # Cookie extraction from Chrome/Firefox/Safari/Edge
+│   └── validator.py   # Cookie validation via API
+└── tools/
+    ├── _validation.py  # Shared Pydantic input validators
+    ├── workouts.py     # CRUD + comments, copy, reorder
+    ├── structure.py    # LLM-friendly step format → TP wire format, IF/TSS calc
+    ├── analyze.py      # Time-series, zones, laps, power/pace distribution
+    ├── events.py       # Calendar events, races, availability, notes
+    ├── settings.py     # FTP, HR/speed zones, nutrition
+    ├── metrics.py      # Weight, HRV, sleep, steps, SpO2, etc.
+    ├── equipment.py    # Bikes, shoes
+    ├── library.py      # Workout templates
+    ├── fitness.py      # CTL/ATL/TSB trends
+    ├── peaks.py        # Power/running PRs
+    └── ...             # weekly_summary, atp, profile, auth_status, etc.
+```
+
+## Tool Pattern
+
+Every tool follows this structure:
+```python
+async def tp_<action>(param: str) -> dict[str, Any]:
+    try:
+        params = SomeInput(param=param)
+    except ValidationError as e:
+        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": format_validation_error(e)}
+
+    async with TPClient() as client:
+        athlete_id = await client.ensure_athlete_id()
+        if not athlete_id:
+            return {"isError": True, "error_code": "AUTH_INVALID", "message": "..."}
+
+        response = await client.get(f"/endpoint/{athlete_id}")
+        if response.is_error:
+            return {"isError": True, "error_code": response.error_code.value, "message": response.message}
+
+        return {"success": True, "data": response.data}
+```
+
+## Key Details
+
+**HTTP Client (`client/http.py`):**
+- Base URL: `https://tpapi.trainingpeaks.com`
+- Exchanges session cookie for OAuth token at `/users/v3/token`; tokens cached in memory, refreshed 60s before expiry
+- Rate limit: 150ms minimum between requests
+- Timeout: 30s
+
+**Sport type IDs** are hardcoded in `tools/workouts.py` as `SPORT_TYPE_MAP` — not queryable from the API. Values are `(sportTypeId, subSportTypeId)` tuples.
+
+**Workout structure format** (`tools/structure.py`): Tools accept a simplified step-based JSON format that `structure.py` converts to the TP wire format, computing IF/TSS automatically.
+
+**Auth security:** Tool results are scrubbed for credential-related keys before returning to Claude. Credentials never appear in tool output.
+
+**Input validation:** All tools use Pydantic models from `tools/_validation.py`. Date ranges max out at 90 days. Use `format_validation_error()` for user-friendly messages.
+
+## Configuration
+
+- `pyproject.toml`: build (hatchling), deps, ruff (line-length=120), mypy, pytest (`asyncio_mode = "auto"`)
+- CI: `.github/workflows/ci.yml` — runs ruff, mypy, pytest on Python 3.10–3.14

--- a/src/tp_mcp/client/models.py
+++ b/src/tp_mcp/client/models.py
@@ -7,7 +7,7 @@ when returned to AI assistants.
 from datetime import date as date_type
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class UserProfile(BaseModel):
@@ -47,6 +47,15 @@ class WorkoutSummary(BaseModel):
     distance_actual: float | None = Field(default=None, alias="distance")
     completed: bool | None = Field(default=None)
     description: str | None = None
+
+    @field_validator("workout_date", mode="before")
+    @classmethod
+    def strip_time_component(cls, v: Any) -> Any:
+        """Strip time/timezone from workoutDay so date is taken from the date
+        string directly, not converted through local system timezone."""
+        if isinstance(v, str) and "T" in v:
+            return v.split("T")[0]
+        return v
 
     @property
     def date(self) -> date_type:
@@ -116,6 +125,15 @@ class WorkoutDetail(BaseModel):
     elevation_gain: float | None = Field(default=None, alias="elevationGain")
     completed: bool | None = Field(default=None)
     structure: dict[str, Any] | None = None
+
+    @field_validator("workout_date", mode="before")
+    @classmethod
+    def strip_time_component(cls, v: Any) -> Any:
+        """Strip time/timezone from workoutDay so date is taken from the date
+        string directly, not converted through local system timezone."""
+        if isinstance(v, str) and "T" in v:
+            return v.split("T")[0]
+        return v
 
     @property
     def date(self) -> date_type:


### PR DESCRIPTION
## Summary

- `WorkoutSummary` and `WorkoutDetail` in `models.py` relied on Pydantic v2's default `datetime` → `date` coercion, which converts timezone-aware datetime strings to local system time before extracting the date
- The TP API returns `workoutDay` as a UTC datetime string (e.g. `"2024-03-24T00:00:00Z"`); on systems in a negative UTC offset (e.g. Eastern, UTC-5) this shifted the extracted date one day earlier than the TP calendar
- Added a `field_validator(mode="before")` to both models that strips the time/timezone component before Pydantic parses it, consistent with the approach already used in `peaks.py:124`

## Test plan

- [ ] All existing model and workout tool tests pass (`pytest tests/test_client/test_models.py tests/test_tools/test_workouts.py`)
- [ ] Verify `tp_get_workouts` returns dates matching the TrainingPeaks calendar on a system in a UTC-negative timezone (e.g. Eastern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)