### PR TITLE
Fix off-by-one workout date bug (UTC timezone conversion)

### DIFF
--- a/src/tp_mcp/client/models.py
+++ b/src/tp_mcp/client/models.py
@@ -5,9 +5,20 @@ when returned to AI assistants.
 """
 
 from datetime import date as date_type
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+
+
+def _strip_datetime_to_date(v: Any) -> Any:
+    """Strip time/timezone from a datetime string so Pydantic takes the date
+    component directly, avoiding local-timezone conversion."""
+    if isinstance(v, str) and "T" in v:
+        return v.split("T")[0]
+    return v
+
+
+DateOnly = Annotated[date_type, BeforeValidator(_strip_datetime_to_date)]
 
 
 class UserProfile(BaseModel):
@@ -35,7 +46,7 @@ class WorkoutSummary(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     id: int = Field(alias="workoutId")
-    workout_date: date_type = Field(alias="workoutDay")
+    workout_date: DateOnly = Field(alias="workoutDay")
     title: str | None = None
     workout_type: str | int | None = Field(default=None, alias="workoutTypeValueId")
     sport: str | None = Field(default=None, alias="workoutTypeFamilyId")
@@ -93,7 +104,7 @@ class WorkoutDetail(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     id: int = Field(alias="workoutId")
-    workout_date: date_type = Field(alias="workoutDay")
+    workout_date: DateOnly = Field(alias="workoutDay")
     title: str | None = None
     sport: str | None = Field(default=None, alias="workoutTypeFamilyId")
     workout_type: str | int | None = Field(default=None, alias="workoutTypeValueId")
@@ -166,7 +177,7 @@ class PeakData(BaseModel):
     duration: str  # e.g., "5s", "1m", "5m", "20m", "60m"
     duration_seconds: int
     value: float  # watts for power, pace for running
-    peak_date: date_type
+    peak_date: DateOnly
     activity_id: int | None = None
 
     @property

--- a/tests/test_client/test_models.py
+++ b/tests/test_client/test_models.py
@@ -3,6 +3,7 @@
 from datetime import date
 
 from tp_mcp.client.models import (
+    PeakData,
     UserProfile,
     WorkoutDetail,
     WorkoutSummary,
@@ -165,3 +166,44 @@ class TestParseWorkoutList:
         """Test parsing empty workout list."""
         workouts = parse_workout_list([])
         assert len(workouts) == 0
+
+
+class TestDateTimezoneStripping:
+    """UTC datetime strings must not shift date via local-timezone conversion."""
+
+    def test_workout_summary_utc_midnight(self):
+        summary = WorkoutSummary.model_validate({
+            "workoutId": 1,
+            "workoutDay": "2024-03-24T00:00:00Z",
+        })
+        assert summary.workout_date == date(2024, 3, 24)
+
+    def test_workout_summary_utc_with_offset(self):
+        summary = WorkoutSummary.model_validate({
+            "workoutId": 1,
+            "workoutDay": "2024-03-24T00:00:00+00:00",
+        })
+        assert summary.workout_date == date(2024, 3, 24)
+
+    def test_workout_summary_plain_date_unchanged(self):
+        summary = WorkoutSummary.model_validate({
+            "workoutId": 1,
+            "workoutDay": "2024-03-24",
+        })
+        assert summary.workout_date == date(2024, 3, 24)
+
+    def test_workout_detail_utc_midnight(self):
+        detail = WorkoutDetail.model_validate({
+            "workoutId": 1,
+            "workoutDay": "2024-03-24T00:00:00Z",
+        })
+        assert detail.workout_date == date(2024, 3, 24)
+
+    def test_peak_data_utc_midnight(self):
+        peak = PeakData(
+            duration="20m",
+            duration_seconds=1200,
+            value=300.0,
+            peak_date="2024-03-24T00:00:00Z",
+        )
+        assert peak.peak_date == date(2024, 3, 24)


### PR DESCRIPTION
## Summary

- TP API returns `workoutDay` as UTC datetime (e.g. `"2024-03-24T00:00:00Z"`); Pydantic v2's default datetime-to-date coercion converts through local system timezone first, shifting the date one day earlier on UTC-negative systems
- Introduced a shared `DateOnly` annotated type with a `BeforeValidator` that strips the time/timezone component before Pydantic parses it
- Applied to `WorkoutSummary`, `WorkoutDetail`, and `PeakData` (which was also vulnerable)
- Added 5 test cases covering UTC midnight, UTC offset, and plain date inputs

Supersedes #31 by @charlesg — same root fix, with deduplication, broader coverage, and tests.

## Test plan

- [x] All 298 existing tests pass
- [x] 5 new timezone-stripping tests pass
- [x] ruff + mypy clean