### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ Restart Claude Desktop. You're ready to go!
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/jamsusmaximus-trainingpeaks-mcp).
+
 ## Structured Workouts
 
 Create workouts with full interval structure. The server auto-computes duration, IF, and TSS from the structure:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/jamsusmaximus-trainingpeaks-mcp).