### PR TITLE
Support planned workout start times via startTimePlanned

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Connect TrainingPeaks to Claude and other AI assistants via the Model Context Pr
 
 Ask your AI assistant things like:
 - "Build me a 4x8min threshold session for Tuesday with warm-up and cool-down"
+- "Schedule my mobility session for April 14, 2026 at 16:45"
 - "Compare my FTP progression this year vs last year"
 - "Copy last week's long ride to this Saturday"
 - "Log my weight at 74.5kg and sleep at 7.5 hours"
@@ -29,8 +30,8 @@ Ask your AI assistant things like:
 |------|-------------|
 | `tp_get_workouts` | List workouts in a date range (max 90 days) |
 | `tp_get_workout` | Get full details for a single workout |
-| `tp_create_workout` | Create a workout with optional interval structure, auto-computed IF/TSS |
-| `tp_update_workout` | Update any field of an existing workout |
+| `tp_create_workout` | Create a workout with optional interval structure, auto-computed IF/TSS, and optional planned start time |
+| `tp_update_workout` | Update any field of an existing workout, including planned start time |
 | `tp_delete_workout` | Delete a workout |
 | `tp_copy_workout` | Copy a workout to a new date (preserves structure and planned fields) |
 | `tp_reorder_workouts` | Reorder workouts on a given day |
@@ -213,6 +214,29 @@ Create workouts with full interval structure. The server auto-computes duration,
 ```
 
 The LLM builds this JSON naturally from conversation - just say "build me 4x8min sweet spot with 2min rest".
+
+For planned workout scheduling, `tp_create_workout` and `tp_update_workout` accept:
+
+- `YYYY-MM-DD` for all-day planning on a calendar date
+- `YYYY-MM-DDTHH:MM:SS` for a planned start time on that date
+
+TrainingPeaks stores planned workout times separately from the calendar day. Internally this means:
+
+- `workoutDay` stays at midnight for the selected date
+- `startTimePlanned` stores the planned start time
+- planned end time is derived from `startTimePlanned + totalTimePlanned`
+
+Example with a planned start time:
+
+```json
+{
+  "date": "2026-04-14T16:45:00",
+  "sport": "Strength",
+  "title": "Core & Mobility",
+  "duration_minutes": 60,
+  "description": "Core-Stabilisation und Dehnung."
+}
+```
 
 ## What is MCP?
 

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -180,7 +180,7 @@ TOOLS = [
         inputSchema={
             "type": "object",
             "properties": {
-                "date": {"type": "string", "description": "YYYY-MM-DD"},
+                "date": {"type": "string", "description": "YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS"},
                 "sport": {"type": "string", "enum": list(SPORT_TYPE_MAP.keys())},
                 "title": {"type": "string", "description": "Workout title"},
                 "duration_minutes": {
@@ -216,7 +216,7 @@ TOOLS = [
                 "subtype_id": {"type": "integer"},
                 "title": {"type": "string"},
                 "description": {"type": "string"},
-                "date": {"type": "string", "description": "YYYY-MM-DD"},
+                "date": {"type": "string", "description": "YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS"},
                 "duration_minutes": {"type": "number"},
                 "distance_km": {"type": "number"},
                 "tss_planned": {"type": "number"},

--- a/src/tp_mcp/tools/_validation.py
+++ b/src/tp_mcp/tools/_validation.py
@@ -1,6 +1,7 @@
 """Pydantic input validation models for tool arguments."""
 
 from datetime import date as date_type
+from datetime import datetime as datetime_type
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
@@ -53,7 +54,7 @@ class DateRangeInput(BaseModel):
 class CreateWorkoutInput(BaseModel):
     """Validates input for workout creation."""
 
-    date: date_type
+    date: date_type | datetime_type
     sport: str
     title: str = Field(min_length=1, max_length=200)
     duration_minutes: int | None = Field(default=None, ge=1, le=1440)
@@ -70,6 +71,8 @@ class CreateWorkoutInput(BaseModel):
     @classmethod
     def coerce_date_string(cls, v: object) -> object:
         if isinstance(v, str):
+            if "T" in v or " " in v:
+                return datetime_type.fromisoformat(v)
             return date_type.fromisoformat(v)
         return v
 
@@ -98,7 +101,7 @@ class UpdateWorkoutInput(BaseModel):
     subtype_id: int | None = Field(default=None, gt=0)
     title: str | None = Field(default=None, min_length=1, max_length=200)
     description: str | None = None
-    date: date_type | None = None
+    date: date_type | datetime_type | None = None
     duration_minutes: float | None = Field(default=None, ge=0, le=1440)
     distance_km: float | None = Field(default=None, ge=0, le=1000)
     tss_planned: float | None = Field(default=None, ge=0, le=2000)
@@ -122,6 +125,8 @@ class UpdateWorkoutInput(BaseModel):
         if v is None:
             return v
         if isinstance(v, str):
+            if "T" in v or " " in v:
+                return datetime_type.fromisoformat(v)
             return date_type.fromisoformat(v)
         return v
 

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+from datetime import date as date_type
+from datetime import datetime as datetime_type
 from typing import Any, Literal
 
 from pydantic import ValidationError
@@ -40,6 +42,26 @@ SPORT_TYPE_MAP: dict[str, tuple[int, int]] = {
     "Walk": (13, 13),
     "Other": (100, 100),
 }
+
+
+def _format_workout_day(value: date_type | datetime_type) -> str:
+    """Format a workout day value for the TrainingPeaks API."""
+    day = value.date() if isinstance(value, datetime_type) else value
+    return f"{day.isoformat()}T00:00:00"
+
+
+def _format_start_time_planned(value: datetime_type) -> str:
+    """Format a planned start time for the TrainingPeaks API."""
+    return value.isoformat(timespec="seconds")
+
+
+def _shift_start_time_planned(existing_start_time: str, target_day: date_type) -> str | None:
+    """Move an existing planned start time to a new day, preserving its time-of-day."""
+    try:
+        start_dt = datetime_type.fromisoformat(existing_start_time)
+    except ValueError:
+        return None
+    return datetime_type.combine(target_day, start_dt.timetz()).isoformat(timespec="seconds")
 
 
 async def tp_get_workouts(
@@ -250,7 +272,7 @@ async def tp_create_workout(
     """Create a planned workout.
 
     Args:
-        date_str: Workout date in ISO format (YYYY-MM-DD).
+        date_str: Workout date in ISO format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS).
         sport: Sport type (see SPORT_TYPE_MAP for valid values).
         title: Workout title.
         duration_minutes: Planned duration in minutes (optional if structure provided).
@@ -337,11 +359,13 @@ async def tp_create_workout(
 
         payload: dict[str, Any] = {
             "athleteId": athlete_id,
-            "workoutDay": f"{params.date.isoformat()}T00:00:00",
+            "workoutDay": _format_workout_day(params.date),
             "workoutTypeFamilyId": family_id,
             "workoutTypeValueId": type_id,
             "title": params.title,
         }
+        if isinstance(params.date, datetime_type):
+            payload["startTimePlanned"] = _format_start_time_planned(params.date)
         if params.subtype_id is not None:
             payload["workoutSubTypeId"] = params.subtype_id
 
@@ -387,7 +411,7 @@ async def tp_create_workout(
             "success": True,
             "workout_id": response.data.get("workoutId"),
             "title": response.data.get("title", title),
-            "date": response.data.get("workoutDay", date_str),
+            "date": response.data.get("startTimePlanned") or response.data.get("workoutDay", date_str),
             "sport": sport,
         }
 
@@ -483,7 +507,13 @@ async def tp_update_workout(
         if params.description is not None:
             existing["description"] = params.description
         if params.date is not None:
-            existing["workoutDay"] = f"{params.date.isoformat()}T00:00:00"
+            existing["workoutDay"] = _format_workout_day(params.date)
+            if isinstance(params.date, datetime_type):
+                existing["startTimePlanned"] = _format_start_time_planned(params.date)
+            elif existing.get("startTimePlanned"):
+                shifted_start = _shift_start_time_planned(existing["startTimePlanned"], params.date)
+                if shifted_start is not None:
+                    existing["startTimePlanned"] = shifted_start
         if params.duration_minutes is not None:
             existing["totalTimePlanned"] = params.duration_minutes / 60.0
         if params.distance_km is not None:

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -105,6 +105,16 @@ class TestListTools:
         assert "distance_km" not in cw.inputSchema["required"]
         assert "tss_planned" not in cw.inputSchema["required"]
 
+    @pytest.mark.asyncio
+    async def test_workout_tools_schema_advertises_datetime_dates(self):
+        """Create/update workout schemas should document datetime support."""
+        tools = await list_tools()
+        create_tool = next(t for t in tools if t.name == "tp_create_workout")
+        update_tool = next(t for t in tools if t.name == "tp_update_workout")
+
+        assert "YYYY-MM-DDTHH:MM:SS" in create_tool.inputSchema["properties"]["date"]["description"]
+        assert "YYYY-MM-DDTHH:MM:SS" in update_tool.inputSchema["properties"]["date"]["description"]
+
 
 # ---------------------------------------------------------------------------
 # call_tool: unknown tool
@@ -355,6 +365,38 @@ class TestCreateWorkoutDispatch:
         assert "tssPlanned" not in payload
 
     @pytest.mark.asyncio
+    async def test_datetime_date_reaches_api_payload(self):
+        """Create should pass an explicit start time through the MCP handler."""
+        create_response = APIResponse(
+            success=True,
+            data={
+                "workoutId": 9003,
+                "title": "Evening Run",
+                "workoutDay": "2026-01-10T00:00:00",
+                "startTimePlanned": "2026-01-10T18:15:00",
+            },
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=create_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = _parse_result(
+                await call_tool(
+                    "tp_create_workout",
+                    {"date": "2026-01-10T18:15:00", "sport": "Run", "title": "Evening Run", "duration_minutes": 45},
+                )
+            )
+
+        assert result["success"] is True
+        assert result["date"] == "2026-01-10T18:15:00"
+        payload = mock_instance.post.call_args[1]["json"]
+        assert payload["workoutDay"] == "2026-01-10T00:00:00"
+        assert payload["startTimePlanned"] == "2026-01-10T18:15:00"
+
+    @pytest.mark.asyncio
     async def test_success_with_distance_and_tss(self):
         """Create with distance_km and tss_planned - verify they reach the API payload."""
         create_response = APIResponse(
@@ -414,6 +456,47 @@ class TestCreateWorkoutDispatch:
         )
         assert result["isError"] is True
         assert result["error_code"] == "VALIDATION_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# call_tool: tp_update_workout
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateWorkoutDispatch:
+    """Functional tests for tp_update_workout through server dispatch."""
+
+    @pytest.mark.asyncio
+    async def test_datetime_date_reaches_api_payload(self):
+        """Update should accept ISO datetime strings and preserve the time."""
+        existing = {
+            "workoutId": 1001,
+            "workoutDay": "2026-04-13T00:00:00",
+            "startTimePlanned": "2026-04-13T09:30:00",
+            "title": "Original",
+        }
+        get_response = APIResponse(success=True, data=existing)
+        put_response = APIResponse(success=True, data=None)
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = _parse_result(
+                await call_tool(
+                    "tp_update_workout",
+                    {"workout_id": "1001", "date": "2026-04-14T16:45:00", "description": "Kräftigung"},
+                )
+            )
+
+        assert result["success"] is True
+        payload = mock_instance.put.call_args[1]["json"]
+        assert payload["workoutDay"] == "2026-04-14T00:00:00"
+        assert payload["startTimePlanned"] == "2026-04-14T16:45:00"
+        assert payload["description"] == "Kräftigung"
 
     @pytest.mark.asyncio
     async def test_negative_tss_rejected(self):

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -221,6 +221,76 @@ class TestUpdateWorkout:
         assert put_payload["workoutTypeValueId"] == 2
 
     @pytest.mark.asyncio
+    async def test_update_date_only_sets_midnight(self):
+        """Date-only updates should keep the existing midnight behavior."""
+        existing = {"workoutId": 1001, "workoutDay": "2026-03-01T00:00:00"}
+        get_response = APIResponse(success=True, data=existing)
+        put_response = APIResponse(success=True, data=None)
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(workout_id="1001", date="2026-04-14")
+
+        assert result["success"] is True
+        put_payload = mock_instance.put.call_args[1]["json"]
+        assert put_payload["workoutDay"] == "2026-04-14T00:00:00"
+
+    @pytest.mark.asyncio
+    async def test_update_date_only_preserves_existing_planned_start_time(self):
+        """Date-only updates should move an existing planned start to the new day."""
+        existing = {
+            "workoutId": 1001,
+            "workoutDay": "2026-03-01T00:00:00",
+            "startTimePlanned": "2026-03-01T16:45:00",
+        }
+        get_response = APIResponse(success=True, data=existing)
+        put_response = APIResponse(success=True, data=None)
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(workout_id="1001", date="2026-04-14")
+
+        assert result["success"] is True
+        put_payload = mock_instance.put.call_args[1]["json"]
+        assert put_payload["workoutDay"] == "2026-04-14T00:00:00"
+        assert put_payload["startTimePlanned"] == "2026-04-14T16:45:00"
+
+    @pytest.mark.asyncio
+    async def test_update_datetime_preserves_time(self):
+        """Datetime updates should forward the scheduled time to TrainingPeaks."""
+        existing = {
+            "workoutId": 1001,
+            "workoutDay": "2026-03-01T00:00:00",
+            "startTimePlanned": "2026-03-01T09:30:00",
+        }
+        get_response = APIResponse(success=True, data=existing)
+        put_response = APIResponse(success=True, data=None)
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(workout_id="1001", date="2026-04-14T16:45:00")
+
+        assert result["success"] is True
+        put_payload = mock_instance.put.call_args[1]["json"]
+        assert put_payload["workoutDay"] == "2026-04-14T00:00:00"
+        assert put_payload["startTimePlanned"] == "2026-04-14T16:45:00"
+
+    @pytest.mark.asyncio
     async def test_update_with_structure_serialises(self):
         """Structure dict should be JSON-serialised for PUT."""
         existing = {"workoutId": 1001}

--- a/tests/test_tools/test_validation.py
+++ b/tests/test_tools/test_validation.py
@@ -8,6 +8,7 @@ from tp_mcp.tools._validation import (
     DateRangeInput,
     FitnessInput,
     PeaksInput,
+    UpdateWorkoutInput,
     WorkoutIdInput,
     format_validation_error,
 )
@@ -74,6 +75,15 @@ class TestCreateWorkoutInput:
         )
         assert result.sport == "Run"
         assert result.duration_minutes == 60
+
+    def test_valid_datetime(self):
+        result = CreateWorkoutInput(
+            date="2025-06-01T09:30:00",
+            sport="Run",
+            title="Morning Run",
+            duration_minutes=60,
+        )
+        assert result.date.isoformat() == "2025-06-01T09:30:00"
 
     def test_empty_title(self):
         with pytest.raises(ValidationError):
@@ -170,6 +180,24 @@ class TestPeaksInput:
     def test_invalid_pr_type(self):
         with pytest.raises(ValidationError, match="invalid_type"):
             PeaksInput(sport="Bike", pr_type="invalid_type")
+
+
+class TestUpdateWorkoutInput:
+    """Tests for UpdateWorkoutInput validation."""
+
+    def test_accepts_date_only(self):
+        result = UpdateWorkoutInput(workout_id="123", date="2026-04-14")
+        assert result.date is not None
+        assert result.date.isoformat() == "2026-04-14"
+
+    def test_accepts_datetime(self):
+        result = UpdateWorkoutInput(workout_id="123", date="2026-04-14T16:45:00")
+        assert result.date is not None
+        assert result.date.isoformat() == "2026-04-14T16:45:00"
+
+    def test_rejects_invalid_datetime(self):
+        with pytest.raises(ValidationError):
+            UpdateWorkoutInput(workout_id="123", date="2026-04-14 99:45:00")
 
 
 class TestFitnessInput:

--- a/tests/test_tools/test_workouts.py
+++ b/tests/test_tools/test_workouts.py
@@ -172,6 +172,38 @@ class TestTpCreateWorkout:
         assert payload["totalTimePlanned"] == 1.0  # 60 min -> 1.0 hours
 
     @pytest.mark.asyncio
+    async def test_create_workout_datetime_preserves_time(self):
+        """Datetime input should schedule the workout with the provided time."""
+        create_response = APIResponse(
+            success=True,
+            data={
+                "workoutId": 5002,
+                "title": "Afternoon Run",
+                "workoutDay": "2026-01-10T00:00:00",
+                "startTimePlanned": "2026-01-10T16:45:00",
+            },
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=create_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_create_workout(
+                date_str="2026-01-10T16:45:00",
+                sport="Run",
+                title="Afternoon Run",
+                duration_minutes=45,
+            )
+
+        assert result["success"] is True
+        assert result["date"] == "2026-01-10T16:45:00"
+        payload = mock_instance.post.call_args[1]["json"]
+        assert payload["workoutDay"] == "2026-01-10T00:00:00"
+        assert payload["startTimePlanned"] == "2026-01-10T16:45:00"
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "sport,expected_family,expected_value",
         [


### PR DESCRIPTION
## Summary

Planned workout times in TrainingPeaks are not stored in `workoutDay`.
The web app keeps `workoutDay` at midnight and writes the actual planned start
time to `startTimePlanned`.

This PR updates workout create/update behavior to match the web client.

## Changes

- accept ISO datetimes for workout `date` input
- keep `workoutDay` as the calendar day at `T00:00:00`
- write planned workout times to `startTimePlanned`
- preserve an existing planned start time when moving a workout by date only
- return `startTimePlanned` in create responses when available
- update schema descriptions, tests, and README for datetime support

## Behavior

Before:
- `2026-04-14T16:45:00` either failed validation or was written incorrectly to `workoutDay`

After:
- `workoutDay = 2026-04-14T00:00:00`
- `startTimePlanned = 2026-04-14T16:45:00`

## Verification

- focused test run: `120 passed`
- live verification against workout `3658616688`
- confirmed browser save payload uses `startTimePlanned`, not `workoutDay`

## Notes

TrainingPeaks appears to derive planned end time from:
- `startTimePlanned`
- `totalTimePlanned`

There is no separate `endTimePlanned` field in the workout payload observed so far.
