### PR TITLE
Add raw structured workout round-trip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ask your AI assistant things like:
 | `tp_get_workouts` | List workouts in a date range (max 90 days) |
 | `tp_get_workout` | Get full details for a single workout |
 | `tp_create_workout` | Create a workout with optional interval structure, auto-computed IF/TSS |
-| `tp_update_workout` | Update any field of an existing workout |
+| `tp_update_workout` | Update any field of an existing workout, including structured intervals |
 | `tp_delete_workout` | Delete a workout |
 | `tp_copy_workout` | Copy a workout to a new date (preserves structure and planned fields) |
 | `tp_reorder_workouts` | Reorder workouts on a given day |
@@ -212,7 +212,7 @@ Create workouts with full interval structure. The server auto-computes duration,
 }
 ```
 
-The LLM builds this JSON naturally from conversation - just say "build me 4x8min sweet spot with 2min rest".
+The LLM builds this JSON naturally from conversation - just say "build me 4x8min sweet spot with 2min rest". The same simplified `structure` format also works with `tp_update_workout`.
 
 ## What is MCP?
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,30 @@ Create workouts with full interval structure. The server auto-computes duration,
 }
 ```
 
-The LLM builds this JSON naturally from conversation - just say "build me 4x8min sweet spot with 2min rest". The same simplified `structure` format also works with `tp_update_workout`.
+The LLM builds this JSON naturally from conversation - just say "build me 4x8min sweet spot with 2min rest".
+
+You can use the same simplified `structure` object with `tp_update_workout`:
+
+```json
+{
+  "workout_id": "3658666303",
+  "duration_minutes": 57,
+  "tss_planned": 62.3,
+  "structure": {
+    "primaryIntensityMetric": "percentOfThresholdHr",
+    "steps": [
+      {"name": "Einlaufen", "duration_seconds": 900, "intensity_min": 65, "intensity_max": 80, "intensityClass": "warmUp"},
+      {"type": "repetition", "name": "4x5min zügig kontrolliert", "reps": 4, "steps": [
+        {"name": "Intervall", "duration_seconds": 300, "intensity_min": 89, "intensity_max": 94, "intensityClass": "active"},
+        {"name": "Trabpause", "duration_seconds": 180, "intensity_min": 65, "intensity_max": 83, "intensityClass": "rest"}
+      ]},
+      {"name": "Auslaufen", "duration_seconds": 600, "intensity_min": 65, "intensity_max": 80, "intensityClass": "coolDown"}
+    ]
+  }
+}
+```
+
+If `duration_minutes` and `tss_planned` are omitted, they are derived from the structure. If you pass them explicitly, they override the derived values.
 
 ## What is MCP?
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,23 @@ You can use the same simplified `structure` object with `tp_update_workout`:
 
 If `duration_minutes` and `tss_planned` are omitted, they are derived from the structure. If you pass them explicitly, they override the derived values.
 
+For advanced round-trip use cases, `tp_create_workout` and `tp_update_workout` also accept a native `structured_workout` payload in TrainingPeaks builder format. When a workout already has a native structure, `tp_get_workout` returns it as `structured_workout`.
+
+```json
+{
+  "workout_id": "3658666303",
+  "structured_workout": {
+    "structure": [],
+    "polyline": [],
+    "primaryLengthMetric": "duration",
+    "primaryIntensityMetric": "percentOfFtp",
+    "primaryIntensityTargetOrRange": "range"
+  }
+}
+```
+
+Use either `structure` or `structured_workout` in a single create/update call, not both.
+
 ## What is MCP?
 
 [Model Context Protocol](https://modelcontextprotocol.io) is an open standard for connecting AI assistants to external data sources. MCP servers expose tools that AI models can call to fetch real-time data, enabling assistants like Claude to access your Training Peaks account through natural language.

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -113,6 +113,12 @@ STRUCTURE_DESCRIPTION = (
     " Intensity values are % of threshold (FTP/HR/pace)."
     " Optional per-step: cadence_min, cadence_max (rpm)."
 )
+RAW_STRUCTURE_DESCRIPTION = (
+    "Native TrainingPeaks structured workout payload in builder format. "
+    "Use this only when you already have a TP structure object with keys like "
+    "structure, polyline, primaryLengthMetric, primaryIntensityMetric, and "
+    "primaryIntensityTargetOrRange."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -179,8 +185,9 @@ TOOLS = [
     Tool(
         name="tp_create_workout",
         description=(
-            "Create a planned workout with optional interval structure. "
-            "Duration auto-computed from structure if not provided."
+            "Create a planned workout with optional simplified interval structure "
+            "or native TrainingPeaks structured_workout payload. Duration is "
+            "auto-computed only from simplified structure when not provided."
         ),
         inputSchema={
             "type": "object",
@@ -199,6 +206,10 @@ TOOLS = [
                     "type": ["object", "string"],
                     "description": STRUCTURE_DESCRIPTION,
                 },
+                "structured_workout": {
+                    "type": "object",
+                    "description": RAW_STRUCTURE_DESCRIPTION,
+                },
                 "subtype_id": {
                     "type": "integer",
                     "description": "Workout subtype ID from tp_get_workout_types",
@@ -214,8 +225,8 @@ TOOLS = [
         name="tp_update_workout",
         description=(
             "Update fields of an existing workout. Supports the same simplified "
-            "interval structure format as tp_create_workout, then fetches existing, "
-            "merges, and saves."
+            "interval structure format as tp_create_workout plus an optional native "
+            "structured_workout payload, then fetches existing, merges, and saves."
         ),
         inputSchema={
             "type": "object",
@@ -237,6 +248,10 @@ TOOLS = [
                 "structure": {
                     "type": ["object", "string"],
                     "description": STRUCTURE_DESCRIPTION,
+                },
+                "structured_workout": {
+                    "type": "object",
+                    "description": RAW_STRUCTURE_DESCRIPTION,
                 },
             },
             "required": ["workout_id"],
@@ -916,6 +931,7 @@ async def _h_create_workout(args):
         duration_minutes=args.get("duration_minutes"),
         description=args.get("description"), distance_km=args.get("distance_km"),
         tss_planned=args.get("tss_planned"), structure=args.get("structure"),
+        structured_workout=args.get("structured_workout"),
         subtype_id=args.get("subtype_id"), tags=args.get("tags"),
         feeling=args.get("feeling"), rpe=args.get("rpe"),
     )
@@ -931,6 +947,7 @@ async def _h_update_workout(args):
         tags=args.get("tags"), athlete_comment=args.get("athlete_comment"),
         coach_comment=args.get("coach_comment"), feeling=args.get("feeling"),
         rpe=args.get("rpe"), structure=args.get("structure"),
+        structured_workout=args.get("structured_workout"),
     )
 
 @_handler("tp_delete_workout")

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -212,7 +212,11 @@ TOOLS = [
     ),
     Tool(
         name="tp_update_workout",
-        description="Update fields of an existing workout. Fetches existing, merges, then saves.",
+        description=(
+            "Update fields of an existing workout. Supports the same simplified "
+            "interval structure format as tp_create_workout, then fetches existing, "
+            "merges, and saves."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
@@ -230,7 +234,10 @@ TOOLS = [
                 "coach_comment": {"type": "string"},
                 "feeling": {"type": "integer", "description": "0-10"},
                 "rpe": {"type": "integer", "description": "1-10"},
-                "structure": {"type": ["object", "string"]},
+                "structure": {
+                    "type": ["object", "string"],
+                    "description": STRUCTURE_DESCRIPTION,
+                },
             },
             "required": ["workout_id"],
         },

--- a/src/tp_mcp/tools/_validation.py
+++ b/src/tp_mcp/tools/_validation.py
@@ -61,6 +61,7 @@ class CreateWorkoutInput(BaseModel):
     distance_km: float | None = Field(default=None, gt=0, le=1000)
     tss_planned: float | None = Field(default=None, gt=0, le=2000)
     structure: Any = None
+    structured_workout: Any = None
     subtype_id: int | None = Field(default=None, gt=0)
     tags: str | None = Field(default=None, max_length=500)
     feeling: int | None = Field(default=None, ge=0, le=10)
@@ -85,8 +86,16 @@ class CreateWorkoutInput(BaseModel):
 
     @model_validator(mode="after")
     def check_duration_or_structure(self) -> "CreateWorkoutInput":
-        if self.duration_minutes is None and self.structure is None:
-            raise ValueError("Either duration_minutes or structure must be provided")
+        if self.structure is not None and self.structured_workout is not None:
+            raise ValueError("Provide only one of structure or structured_workout")
+        if (
+            self.duration_minutes is None
+            and self.structure is None
+            and self.structured_workout is None
+        ):
+            raise ValueError(
+                "Either duration_minutes, structure, or structured_workout must be provided",
+            )
         return self
 
 
@@ -108,6 +117,7 @@ class UpdateWorkoutInput(BaseModel):
     feeling: int | None = Field(default=None, ge=0, le=10)
     rpe: int | None = Field(default=None, ge=1, le=10)
     structure: Any = None
+    structured_workout: Any = None
 
     @field_validator("workout_id", mode="before")
     @classmethod
@@ -136,6 +146,12 @@ class UpdateWorkoutInput(BaseModel):
             valid = ", ".join(SPORT_TYPE_MAP.keys())
             raise ValueError(f"Invalid sport '{v}'. Valid: {valid}")
         return v
+
+    @model_validator(mode="after")
+    def check_structure_inputs(self) -> "UpdateWorkoutInput":
+        if self.structure is not None and self.structured_workout is not None:
+            raise ValueError("Provide only one of structure or structured_workout")
+        return self
 
 
 class SingleDateInput(BaseModel):

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -58,6 +58,58 @@ def _prepare_structure_payload(
         msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
         return None, None, None, None, f"Invalid structure: {msg}"
 
+
+def _validate_structured_workout(structured_workout: dict[str, Any]) -> str | None:
+    """Validate the minimum schema needed to round-trip TP native structures."""
+    required = {
+        "structure",
+        "polyline",
+        "primaryLengthMetric",
+        "primaryIntensityMetric",
+        "primaryIntensityTargetOrRange",
+    }
+    missing = required - set(structured_workout.keys())
+    if missing:
+        return (
+            "structured_workout is missing required fields: "
+            f"{', '.join(sorted(missing))}"
+        )
+    if not isinstance(structured_workout.get("structure"), list):
+        return "structured_workout.structure must be a list."
+    return None
+
+
+def _encode_structured_workout(
+    structured_workout: dict[str, Any] | None,
+) -> tuple[str | None, str | None]:
+    """Serialize a TP native workout structure for write endpoints."""
+    if structured_workout is None:
+        return None, None
+
+    error = _validate_structured_workout(structured_workout)
+    if error:
+        return None, error
+
+    try:
+        return json.dumps(structured_workout), None
+    except (TypeError, ValueError) as e:
+        return None, f"structured_workout must be JSON-serializable: {e}"
+
+
+def _decode_structured_workout(raw_structure: Any) -> dict[str, Any] | None:
+    """Decode TP native workout structure from API responses."""
+    if raw_structure is None:
+        return None
+    if isinstance(raw_structure, dict):
+        return raw_structure
+    if isinstance(raw_structure, str):
+        try:
+            parsed = json.loads(raw_structure)
+        except (TypeError, ValueError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
 # Maps sport name to (workoutTypeFamilyId, workoutTypeValueId)
 # IDs confirmed from GET /fitness/v6/workouttypes
 SPORT_TYPE_MAP: dict[str, tuple[int, int]] = {
@@ -229,7 +281,11 @@ async def tp_get_workout(workout_id: str) -> dict[str, Any]:
         )
 
         try:
-            workout = parse_workout_detail(response.data)
+            raw_data = dict(response.data) if isinstance(response.data, dict) else {}
+            structured_workout = _decode_structured_workout(raw_data.get("structure"))
+            if structured_workout is not None:
+                raw_data["structure"] = structured_workout
+            workout = parse_workout_detail(raw_data)
 
             return {
                 "id": str(workout.id),
@@ -257,6 +313,7 @@ async def tp_get_workout(workout_id: str) -> dict[str, Any]:
                     "calories": workout.calories,
                 },
                 "completed": workout.completed,
+                "structured_workout": structured_workout,
                 "device_files": _extract_file_infos(details_raw, "workoutDeviceFileInfos"),
                 "attachment_files": _extract_file_infos(details_raw, "attachmentFileInfos"),
             }
@@ -289,6 +346,7 @@ async def tp_create_workout(
     distance_km: float | None = None,
     tss_planned: float | None = None,
     structure: dict[str, Any] | str | None = None,
+    structured_workout: dict[str, Any] | None = None,
     subtype_id: int | None = None,
     tags: str | None = None,
     feeling: int | None = None,
@@ -305,6 +363,7 @@ async def tp_create_workout(
         distance_km: Optional planned distance in kilometres.
         tss_planned: Optional planned Training Stress Score.
         structure: Optional interval structure (dict or JSON string).
+        structured_workout: Optional native TP structured workout payload.
         subtype_id: Optional workout subtype ID (e.g. Road Bike=3).
         tags: Optional comma-separated tags string.
         feeling: Optional feeling score (0-10).
@@ -323,6 +382,7 @@ async def tp_create_workout(
             distance_km=distance_km,
             tss_planned=tss_planned,
             structure=structure,
+            structured_workout=structured_workout,
             subtype_id=subtype_id,
             tags=tags,
             feeling=feeling,
@@ -346,6 +406,15 @@ async def tp_create_workout(
             "isError": True,
             "error_code": "VALIDATION_ERROR",
             "message": structure_error,
+        }
+    raw_structure_payload, raw_structure_error = _encode_structured_workout(
+        params.structured_workout,
+    )
+    if raw_structure_error is not None:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": raw_structure_error,
         }
 
     # Use explicit duration if provided, otherwise use structure-computed
@@ -395,6 +464,8 @@ async def tp_create_workout(
             payload["ifPlanned"] = effective_if
         if wire_structure is not None:
             payload["structure"] = json.dumps(wire_structure)
+        elif raw_structure_payload is not None:
+            payload["structure"] = raw_structure_payload
         if params.tags is not None:
             payload["tags"] = params.tags
         if params.feeling is not None:
@@ -445,10 +516,14 @@ async def tp_update_workout(
     feeling: int | None = None,
     rpe: int | None = None,
     structure: dict[str, Any] | str | None = None,
+    structured_workout: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Update fields of an existing workout.
 
     TP API requires full workout object on PUT - fetches existing, merges, then PUTs.
+
+    Supports either simplified ``structure`` input or a native
+    ``structured_workout`` payload, but not both in the same call.
 
     Returns:
         Dict with updated workout details or error.
@@ -470,6 +545,7 @@ async def tp_update_workout(
             feeling=feeling,
             rpe=rpe,
             structure=structure,
+            structured_workout=structured_workout,
         )
     except (ValidationError, ValueError) as e:
         msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
@@ -487,6 +563,15 @@ async def tp_update_workout(
             "isError": True,
             "error_code": "VALIDATION_ERROR",
             "message": structure_error,
+        }
+    raw_structure_payload, raw_structure_error = _encode_structured_workout(
+        params.structured_workout,
+    )
+    if raw_structure_error is not None:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": raw_structure_error,
         }
 
     effective_duration = params.duration_minutes
@@ -565,6 +650,8 @@ async def tp_update_workout(
                 existing["ifPlanned"] = effective_if
             else:
                 existing.pop("ifPlanned", None)
+        elif raw_structure_payload is not None:
+            existing["structure"] = raw_structure_payload
 
         # PUT updated workout
         put_endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{params.workout_id}"

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -41,6 +41,23 @@ def _extract_file_infos(raw_data: dict, key: str) -> list[dict]:
         })
     return normalized
 
+
+def _prepare_structure_payload(
+    structure: dict[str, Any] | str | None,
+) -> tuple[dict[str, Any] | None, float | None, float | None, float | None, str | None]:
+    """Parse simplified structure input and derive TP payload values."""
+    if structure is None:
+        return None, None, None, None, None
+
+    try:
+        parsed_structure = parse_structure_input(structure)
+        wire_structure = build_wire_structure(parsed_structure)
+        structure_if, structure_tss, total_seconds = compute_if_tss(parsed_structure)
+        return wire_structure, total_seconds / 60.0, structure_if, structure_tss, None
+    except (ValidationError, ValueError) as e:
+        msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
+        return None, None, None, None, f"Invalid structure: {msg}"
+
 # Maps sport name to (workoutTypeFamilyId, workoutTypeValueId)
 # IDs confirmed from GET /fitness/v6/workouttypes
 SPORT_TYPE_MAP: dict[str, tuple[int, int]] = {
@@ -321,25 +338,15 @@ async def tp_create_workout(
 
     family_id, type_id = SPORT_TYPE_MAP[params.sport]
 
-    # If structure is provided, parse it and compute derived values
-    wire_structure = None
-    structure_duration_minutes = None
-    structure_if = None
-    structure_tss = None
-
-    if params.structure is not None:
-        try:
-            parsed_structure = parse_structure_input(params.structure)
-            wire_structure = build_wire_structure(parsed_structure)
-            structure_if, structure_tss, total_seconds = compute_if_tss(parsed_structure)
-            structure_duration_minutes = total_seconds / 60.0
-        except (ValidationError, ValueError) as e:
-            msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
-            return {
-                "isError": True,
-                "error_code": "VALIDATION_ERROR",
-                "message": f"Invalid structure: {msg}",
-            }
+    wire_structure, structure_duration_minutes, structure_if, structure_tss, structure_error = (
+        _prepare_structure_payload(params.structure)
+    )
+    if structure_error is not None:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": structure_error,
+        }
 
     # Use explicit duration if provided, otherwise use structure-computed
     effective_duration: float | None = float(params.duration_minutes) if params.duration_minutes is not None else None
@@ -472,6 +479,28 @@ async def tp_update_workout(
             "message": msg,
         }
 
+    wire_structure, structure_duration_minutes, structure_if, structure_tss, structure_error = (
+        _prepare_structure_payload(params.structure)
+    )
+    if structure_error is not None:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": structure_error,
+        }
+
+    effective_duration = params.duration_minutes
+    if effective_duration is None and structure_duration_minutes is not None:
+        effective_duration = structure_duration_minutes
+
+    effective_tss = params.tss_planned
+    if effective_tss is None and structure_tss is not None:
+        effective_tss = structure_tss
+
+    effective_if = None
+    if params.structure is not None and params.tss_planned is None and structure_if is not None:
+        effective_if = structure_if
+
     async with TPClient() as client:
         athlete_id = await client.ensure_athlete_id()
         if not athlete_id:
@@ -514,12 +543,12 @@ async def tp_update_workout(
             existing["description"] = params.description
         if params.date is not None:
             existing["workoutDay"] = f"{params.date.isoformat()}T00:00:00"
-        if params.duration_minutes is not None:
-            existing["totalTimePlanned"] = params.duration_minutes / 60.0
+        if effective_duration is not None:
+            existing["totalTimePlanned"] = effective_duration / 60.0
         if params.distance_km is not None:
             existing["distancePlanned"] = _km_to_m(params.distance_km)
-        if params.tss_planned is not None:
-            existing["tssPlanned"] = params.tss_planned
+        if effective_tss is not None:
+            existing["tssPlanned"] = effective_tss
         if params.tags is not None:
             existing["tags"] = params.tags
         if params.athlete_comment is not None:
@@ -531,11 +560,11 @@ async def tp_update_workout(
         if params.rpe is not None:
             existing["rpe"] = params.rpe
         if params.structure is not None:
-            # If structure is a dict (from GET response), serialise to JSON string
-            if isinstance(params.structure, dict):
-                existing["structure"] = json.dumps(params.structure)
+            existing["structure"] = json.dumps(wire_structure)
+            if effective_if is not None:
+                existing["ifPlanned"] = effective_if
             else:
-                existing["structure"] = params.structure
+                existing.pop("ifPlanned", None)
 
         # PUT updated workout
         put_endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{params.workout_id}"

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -100,14 +100,24 @@ class TestListTools:
 
     @pytest.mark.asyncio
     async def test_create_workout_schema_includes_new_fields(self):
-        """The tp_create_workout schema should advertise distance_km and tss_planned."""
+        """The tp_create_workout schema should advertise optional structured_workout support."""
         tools = await list_tools()
         cw = next(t for t in tools if t.name == "tp_create_workout")
         props = cw.inputSchema["properties"]
         assert "distance_km" in props
         assert "tss_planned" in props
+        assert "structured_workout" in props
         assert "distance_km" not in cw.inputSchema["required"]
         assert "tss_planned" not in cw.inputSchema["required"]
+        assert "structured_workout" not in cw.inputSchema["required"]
+
+    @pytest.mark.asyncio
+    async def test_update_workout_schema_includes_structured_workout(self):
+        tools = await list_tools()
+        uw = next(t for t in tools if t.name == "tp_update_workout")
+        props = uw.inputSchema["properties"]
+        assert "structure" in props
+        assert "structured_workout" in props
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from tp_mcp.client.http import APIResponse, ErrorCode
+from tp_mcp.client.http import APIResponse
 from tp_mcp.tools.workouts import (
     tp_add_workout_comment,
     tp_copy_workout,
@@ -25,9 +25,27 @@ class TestCreateWorkoutWithStructure:
         structure = {
             "primaryIntensityMetric": "percentOfFtp",
             "steps": [
-                {"name": "WU", "duration_seconds": 600, "intensity_min": 40, "intensity_max": 55, "intensityClass": "warmUp"},
-                {"name": "Main", "duration_seconds": 1200, "intensity_min": 85, "intensity_max": 95, "intensityClass": "active"},
-                {"name": "CD", "duration_seconds": 600, "intensity_min": 40, "intensity_max": 55, "intensityClass": "coolDown"},
+                {
+                    "name": "WU",
+                    "duration_seconds": 600,
+                    "intensity_min": 40,
+                    "intensity_max": 55,
+                    "intensityClass": "warmUp",
+                },
+                {
+                    "name": "Main",
+                    "duration_seconds": 1200,
+                    "intensity_min": 85,
+                    "intensity_max": 95,
+                    "intensityClass": "active",
+                },
+                {
+                    "name": "CD",
+                    "duration_seconds": 600,
+                    "intensity_min": 40,
+                    "intensity_max": 55,
+                    "intensityClass": "coolDown",
+                },
             ],
         }
         create_response = APIResponse(
@@ -65,7 +83,13 @@ class TestCreateWorkoutWithStructure:
         """Explicit duration should override structure-computed duration."""
         structure = {
             "steps": [
-                {"name": "WU", "duration_seconds": 600, "intensity_min": 50, "intensity_max": 60, "intensityClass": "warmUp"},
+                {
+                    "name": "WU",
+                    "duration_seconds": 600,
+                    "intensity_min": 50,
+                    "intensity_max": 60,
+                    "intensityClass": "warmUp",
+                },
             ],
         }
         create_response = APIResponse(
@@ -222,10 +246,36 @@ class TestUpdateWorkout:
 
     @pytest.mark.asyncio
     async def test_update_with_structure_serialises(self):
-        """Structure dict should be JSON-serialised for PUT."""
+        """Simplified structure should be converted to TP wire format for PUT."""
         existing = {"workoutId": 1001}
         get_response = APIResponse(success=True, data=existing)
         put_response = APIResponse(success=True, data=None)
+        structure = {
+            "primaryIntensityMetric": "percentOfFtp",
+            "steps": [
+                {
+                    "name": "WU",
+                    "duration_seconds": 600,
+                    "intensity_min": 40,
+                    "intensity_max": 55,
+                    "intensityClass": "warmUp",
+                },
+                {
+                    "name": "Main",
+                    "duration_seconds": 1200,
+                    "intensity_min": 85,
+                    "intensity_max": 95,
+                    "intensityClass": "active",
+                },
+                {
+                    "name": "CD",
+                    "duration_seconds": 600,
+                    "intensity_min": 40,
+                    "intensity_max": 55,
+                    "intensityClass": "coolDown",
+                },
+            ],
+        }
 
         with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
             mock_instance = AsyncMock()
@@ -236,12 +286,79 @@ class TestUpdateWorkout:
 
             result = await tp_update_workout(
                 workout_id="1001",
-                structure={"structure": [{"type": "step"}]},
+                structure=structure,
             )
 
         assert result["success"] is True
         put_payload = mock_instance.put.call_args[1]["json"]
         assert isinstance(put_payload["structure"], str)
+        parsed = json.loads(put_payload["structure"])
+        assert "structure" in parsed
+        assert "polyline" in parsed
+        assert abs(put_payload["totalTimePlanned"] - 40.0 / 60.0) < 0.01
+        assert put_payload["tssPlanned"] > 0
+        assert put_payload["ifPlanned"] > 0
+
+    @pytest.mark.asyncio
+    async def test_update_with_structure_explicit_duration_and_tss_override(self):
+        """Explicit duration and TSS should win over derived structure values."""
+        existing = {
+            "workoutId": 1001,
+            "ifPlanned": 0.91,
+        }
+        get_response = APIResponse(success=True, data=existing)
+        put_response = APIResponse(success=True, data=None)
+        structure = {
+            "steps": [
+                {
+                    "name": "WU",
+                    "duration_seconds": 600,
+                    "intensity_min": 50,
+                    "intensity_max": 60,
+                    "intensityClass": "warmUp",
+                },
+            ],
+        }
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(
+                workout_id="1001",
+                duration_minutes=90,
+                tss_planned=77,
+                structure=structure,
+            )
+
+        assert result["success"] is True
+        put_payload = mock_instance.put.call_args[1]["json"]
+        assert put_payload["totalTimePlanned"] == 90 / 60.0
+        assert put_payload["tssPlanned"] == 77
+        assert "ifPlanned" not in put_payload
+
+    @pytest.mark.asyncio
+    async def test_update_with_invalid_structure_returns_validation_error(self):
+        """Invalid simplified structure should fail before PUT."""
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock()
+            mock_instance.put = AsyncMock()
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(
+                workout_id="1001",
+                structure={"structure": [{"type": "step"}]},
+            )
+
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+        mock_instance.get.assert_not_called()
+        mock_instance.put.assert_not_called()
 
 
 class TestDeleteWorkout:
@@ -353,7 +470,7 @@ class TestCopyWorkout:
             mock_instance.post = AsyncMock(return_value=post_response)
             mock_client.return_value.__aenter__.return_value = mock_instance
 
-            result = await tp_copy_workout("1001", "2026-04-01", title="New Title")
+            await tp_copy_workout("1001", "2026-04-01", title="New Title")
 
         payload = mock_instance.post.call_args[1]["json"]
         assert payload["title"] == "New Title"

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -180,12 +180,71 @@ class TestCreateWorkoutWithStructure:
 
     @pytest.mark.asyncio
     async def test_create_without_duration_or_structure(self):
-        """Should fail if neither duration nor structure provided."""
+        """Should fail if no duration, simplified structure, or raw structure provided."""
         result = await tp_create_workout(
             date_str="2026-03-01", sport="Run", title="No Duration",
         )
         assert result["isError"] is True
         assert result["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_create_with_structured_workout_serialises(self):
+        """Raw structured_workout should be serialized unchanged for POST."""
+        structured_workout = {
+            "structure": [],
+            "polyline": [],
+            "primaryLengthMetric": "duration",
+            "primaryIntensityMetric": "percentOfFtp",
+            "primaryIntensityTargetOrRange": "range",
+        }
+        create_response = APIResponse(
+            success=True,
+            data={"workoutId": 7005, "title": "Structured Raw", "workoutDay": "2026-03-01T00:00:00"},
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=create_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_create_workout(
+                date_str="2026-03-01",
+                sport="Bike",
+                title="Structured Raw",
+                structured_workout=structured_workout,
+            )
+
+        assert result["success"] is True
+        payload = mock_instance.post.call_args[1]["json"]
+        assert json.loads(payload["structure"]) == structured_workout
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_both_structure_inputs(self):
+        """Simplified structure and raw structured_workout cannot be combined."""
+        result = await tp_create_workout(
+            date_str="2026-03-01",
+            sport="Bike",
+            title="Conflict",
+            structure={"steps": [{"name": "WU", "duration_seconds": 60, "intensity_min": 50, "intensity_max": 60}]},
+            structured_workout={"structure": []},
+        )
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+        assert "Provide only one of structure or structured_workout" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_invalid_structured_workout(self):
+        """Raw structured_workout should be validated before POST."""
+        result = await tp_create_workout(
+            date_str="2026-03-01",
+            sport="Bike",
+            title="Bad Structured Raw",
+            structured_workout={"structure": []},
+        )
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+        assert "structured_workout" in result["message"]
 
 
 class TestUpdateWorkout:
@@ -359,6 +418,59 @@ class TestUpdateWorkout:
         assert result["error_code"] == "VALIDATION_ERROR"
         mock_instance.get.assert_not_called()
         mock_instance.put.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_with_structured_workout_serialises(self):
+        """Raw structured_workout should be serialized unchanged for PUT."""
+        existing = {"workoutId": 1001}
+        get_response = APIResponse(success=True, data=existing)
+        put_response = APIResponse(success=True, data=None)
+        structured_workout = {
+            "structure": [],
+            "polyline": [],
+            "primaryLengthMetric": "duration",
+            "primaryIntensityMetric": "percentOfFtp",
+            "primaryIntensityTargetOrRange": "range",
+        }
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(
+                workout_id="1001",
+                structured_workout=structured_workout,
+            )
+
+        assert result["success"] is True
+        put_payload = mock_instance.put.call_args[1]["json"]
+        assert json.loads(put_payload["structure"]) == structured_workout
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_both_structure_inputs(self):
+        """Simplified structure and raw structured_workout cannot be combined."""
+        result = await tp_update_workout(
+            workout_id="1001",
+            structure={"steps": [{"name": "WU", "duration_seconds": 60, "intensity_min": 50, "intensity_max": 60}]},
+            structured_workout={"structure": []},
+        )
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+        assert "Provide only one of structure or structured_workout" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_invalid_structured_workout(self):
+        """Raw structured_workout should be validated before PUT."""
+        result = await tp_update_workout(
+            workout_id="1001",
+            structured_workout={"structure": []},
+        )
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+        assert "structured_workout" in result["message"]
 
 
 class TestDeleteWorkout:

--- a/tests/test_tools/test_workouts.py
+++ b/tests/test_tools/test_workouts.py
@@ -1,5 +1,6 @@
 """Tests for workout tools."""
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -106,6 +107,53 @@ class TestTpGetWorkout:
         assert result["id"] == "1001"
         assert result["title"] == "Test Workout"
         assert result["metrics"]["avg_power"] == 200
+
+    @pytest.mark.asyncio
+    async def test_get_workout_includes_structured_workout(self, mock_api_responses):
+        """Structured workout payload should be returned when present."""
+        workout_data = dict(mock_api_responses["workout_detail"])
+        workout_data["structure"] = {
+            "structure": [],
+            "polyline": [],
+            "primaryLengthMetric": "duration",
+            "primaryIntensityMetric": "percentOfFtp",
+            "primaryIntensityTargetOrRange": "range",
+        }
+        workout_response = APIResponse(success=True, data=workout_data)
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=workout_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_get_workout("1001")
+
+        assert result["structured_workout"] == workout_data["structure"]
+
+    @pytest.mark.asyncio
+    async def test_get_workout_decodes_structured_workout_string(self, mock_api_responses):
+        """Structured workout JSON strings should be decoded in responses."""
+        workout_data = dict(mock_api_responses["workout_detail"])
+        structured_workout = {
+            "structure": [],
+            "polyline": [],
+            "primaryLengthMetric": "duration",
+            "primaryIntensityMetric": "percentOfFtp",
+            "primaryIntensityTargetOrRange": "range",
+        }
+        workout_data["structure"] = json.dumps(structured_workout)
+        workout_response = APIResponse(success=True, data=workout_data)
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=workout_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_get_workout("1001")
+
+        assert result["structured_workout"] == structured_workout
 
     @pytest.mark.asyncio
     async def test_get_workout_not_found(self):


### PR DESCRIPTION
## Summary
This adds an additive raw structured workout mechanism on top of the simplified `structure` format.

The MCP API remains backward compatible:
- `structure` keeps its existing simplified step-based meaning
- `structured_workout` is added as a new optional field for native TrainingPeaks builder payloads
- `tp_get_workout` now returns `structured_workout` when a native structure is present

## Important review note
This PR is stacked on top of #35.
Until #35 is merged, this PR will also include the commits from that open branch in GitHub's compare view.
After #35 merges, this branch can be rebased onto `main` to leave only the raw round-trip changes.

## Changes
- add `structured_workout` to `tp_create_workout` and `tp_update_workout`
- keep `structure` unchanged for the simplified step-based format
- reject calls that provide both `structure` and `structured_workout`
- validate and serialize native TP structured workout payloads for write endpoints
- decode API workout structures and return them as `structured_workout` from `tp_get_workout`
- document advanced raw structured workout usage in the README

## Validation
- `.venv/bin/ruff check src/tp_mcp/tools/_validation.py src/tp_mcp/tools/workouts.py src/tp_mcp/server.py tests/test_tools/test_workouts.py tests/test_tools/test_new_workouts.py tests/test_server_functional.py README.md`
- `.venv/bin/pytest tests/test_tools/test_workouts.py tests/test_tools/test_new_workouts.py tests/test_tools/test_structure.py tests/test_server_functional.py -q`

## Behavior
- simplified `structure` still auto-derives duration, TSS, and IF as before
- raw `structured_workout` is passed through unchanged
- `tp_get_workout` now exposes native TP structure for round-trip workflows