### PR TITLE
Fix tp_update_ftp against live TrainingPeaks powerzones endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Ask your AI assistant things like:
 | Tool | Description |
 |------|-------------|
 | `tp_get_athlete_settings` | Get FTP, thresholds, zones, profile |
-| `tp_update_ftp` | Update FTP and recalculate Coggan 5-zone model |
+| `tp_update_ftp` | Update FTP and recalculate the default power zones |
 | `tp_update_hr_zones` | Update heart rate zones |
 | `tp_update_speed_zones` | Update run/swim pace zones |
 | `tp_update_nutrition` | Update daily planned calories |

--- a/src/tp_mcp/client/http.py
+++ b/src/tp_mcp/client/http.py
@@ -373,6 +373,9 @@ class TPClient:
             except Exception:
                 return APIResponse(success=True, data=None)
 
+        if response.status_code == 204:
+            return APIResponse(success=True, data=None)
+
         if response.status_code == 401:
             # Don't auto-clear - could be temporary. User can run 'tp-mcp auth-clear' if needed.
             return APIResponse(

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -442,7 +442,7 @@ TOOLS = [
     ),
     Tool(
         name="tp_update_ftp",
-        description="Update FTP and recalculate Coggan 5-zone power model.",
+        description="Update FTP and recalculate the default power zones.",
         inputSchema={
             "type": "object",
             "properties": {"ftp": {"type": "integer", "description": "FTP in watts"}},

--- a/src/tp_mcp/tools/settings.py
+++ b/src/tp_mcp/tools/settings.py
@@ -11,14 +11,15 @@ from tp_mcp.tools._validation import format_validation_error
 
 logger = logging.getLogger("tp-mcp")
 
-# Coggan 5-zone power model boundaries (% of FTP)
-COGGAN_ZONES = [
-    ("Z1 Active Recovery", 0, 55),
-    ("Z2 Endurance", 56, 75),
-    ("Z3 Tempo", 76, 90),
-    ("Z4 Threshold", 91, 105),
-    ("Z5 VO2max", 106, 150),
+POWER_ZONE_LABELS = [
+    "Recovery",
+    "Endurance",
+    "Tempo",
+    "Threshold",
+    "VO2 Max",
+    "Anaerobic Capacity",
 ]
+POWER_ZONE_MAXIMUM = 2000
 
 
 class FTPInput(BaseModel):
@@ -120,7 +121,7 @@ async def tp_get_athlete_settings() -> dict[str, Any]:
 
 
 async def tp_update_ftp(ftp: int) -> dict[str, Any]:
-    """Update FTP and recalculate Coggan 5-zone power model.
+    """Update FTP and recalculate the athlete's default power zones.
 
     Args:
         ftp: Functional Threshold Power in watts.
@@ -147,19 +148,100 @@ async def tp_update_ftp(ftp: int) -> dict[str, Any]:
                 "message": "Could not get athlete ID. Re-authenticate.",
             }
 
-        # Build Coggan zones
-        zones = []
-        for name, low_pct, high_pct in COGGAN_ZONES:
-            zones.append({
-                "name": name,
-                "minimum": round(params.ftp * low_pct / 100.0),
-                "maximum": round(params.ftp * high_pct / 100.0),
-            })
+        settings_endpoint = f"/fitness/v1/athletes/{athlete_id}/settings"
+        settings_response = await client.get(settings_endpoint)
+        if settings_response.is_error:
+            return {
+                "isError": True,
+                "error_code": settings_response.error_code.value if settings_response.error_code else "API_ERROR",
+                "message": settings_response.message,
+            }
 
-        payload = {
+        if not settings_response.data or not isinstance(settings_response.data, dict):
+            return {
+                "isError": True,
+                "error_code": "API_ERROR",
+                "message": "No settings data returned.",
+            }
+
+        power_zones = settings_response.data.get("powerZones")
+        if not isinstance(power_zones, list) or not power_zones:
+            return {
+                "isError": True,
+                "error_code": "API_ERROR",
+                "message": "No power zones found in athlete settings.",
+            }
+
+        target_index = next(
+            (idx for idx, zone_group in enumerate(power_zones)
+             if isinstance(zone_group, dict) and zone_group.get("workoutTypeId") == 0),
+            0,
+        )
+        target_zone_group = power_zones[target_index]
+        if not isinstance(target_zone_group, dict):
+            return {
+                "isError": True,
+                "error_code": "API_ERROR",
+                "message": "Unexpected power zone format returned by TrainingPeaks.",
+            }
+
+        existing_labels = []
+        existing_zones = target_zone_group.get("zones")
+        if isinstance(existing_zones, list):
+            existing_labels = [
+                zone.get("label")
+                for zone in existing_zones
+                if isinstance(zone, dict) and zone.get("label")
+            ]
+        labels = existing_labels if len(existing_labels) == len(POWER_ZONE_LABELS) else POWER_ZONE_LABELS
+
+        current_threshold = target_zone_group.get("threshold")
+        zone_maxima: list[int] = []
+        if isinstance(current_threshold, (int, float)) and current_threshold > 0 and isinstance(existing_zones, list):
+            existing_maxima: list[int] = []
+            for zone in existing_zones[:-1]:
+                if not isinstance(zone, dict):
+                    existing_maxima = []
+                    break
+                maximum = zone.get("maximum")
+                if not isinstance(maximum, (int, float)):
+                    existing_maxima = []
+                    break
+                existing_maxima.append(int(maximum))
+            if len(existing_maxima) == len(labels) - 1:
+                zone_maxima = [round(params.ftp * (maximum / current_threshold)) for maximum in existing_maxima]
+
+        if not zone_maxima:
+            zone_maxima = [
+                round(params.ftp * ratio)
+                for ratio in (0.56, 0.76, 0.91, 1.06, 1.21)
+            ]
+        zones = []
+        lower_bound = 0
+        for label, upper_bound in zip(labels[:-1], zone_maxima, strict=False):
+            zones.append({
+                "label": label,
+                "minimum": lower_bound,
+                "maximum": upper_bound,
+            })
+            lower_bound = upper_bound + 1
+        zones.append({
+            "label": labels[-1],
+            "minimum": lower_bound,
+            "maximum": POWER_ZONE_MAXIMUM,
+        })
+
+        updated_zone_group = {
             "threshold": params.ftp,
+            "calculationMethod": target_zone_group.get("calculationMethod"),
+            "workoutTypeId": target_zone_group.get("workoutTypeId"),
             "zones": zones,
         }
+        if "zoneCalculatorId" in target_zone_group:
+            updated_zone_group["zoneCalculatorId"] = target_zone_group.get("zoneCalculatorId")
+
+        payload = list(power_zones)
+        payload[target_index] = updated_zone_group
 
         endpoint = f"/fitness/v2/athletes/{athlete_id}/powerzones"
         response = await client.put(endpoint, json=payload)
@@ -174,6 +256,7 @@ async def tp_update_ftp(ftp: int) -> dict[str, Any]:
         return {
             "success": True,
             "ftp": params.ftp,
+            "workout_type_id": updated_zone_group["workoutTypeId"],
             "zones": zones,
         }
 

--- a/tests/test_client/test_http.py
+++ b/tests/test_client/test_http.py
@@ -3,6 +3,7 @@
 import time
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 
 from tp_mcp.client.http import MIN_REQUEST_INTERVAL, APIResponse, TPClient
@@ -185,3 +186,18 @@ class TestSharedTokenCache:
         assert TPClient._shared_token_cache is None
         TPClient()
         assert TPClient._shared_token_cache is not None
+
+
+class TestHandleResponse:
+    """Tests for HTTP response handling."""
+
+    def test_204_is_success(self):
+        """204 No Content responses should be treated as successful writes."""
+        client = TPClient()
+
+        response = httpx.Response(status_code=204)
+
+        result = client._handle_response(response)
+
+        assert result.success is True
+        assert result.data is None

--- a/tests/test_tools/test_settings.py
+++ b/tests/test_tools/test_settings.py
@@ -32,11 +32,37 @@ class TestGetAthleteSettings:
 class TestUpdateFTP:
     @pytest.mark.asyncio
     async def test_coggan_zones_320w(self):
-        """FTP 320W should produce correct Coggan zone boundaries."""
+        """FTP 320W should scale the existing default power zone model."""
         response = APIResponse(success=True, data=None)
+        settings = {
+            "powerZones": [
+                {
+                    "zoneCalculatorId": None,
+                    "threshold": 280,
+                    "calculationMethod": 5,
+                    "workoutTypeId": 0,
+                    "zones": [
+                        {"label": "Recovery", "minimum": 0, "maximum": 156},
+                        {"label": "Endurance", "minimum": 157, "maximum": 212},
+                        {"label": "Tempo", "minimum": 213, "maximum": 254},
+                        {"label": "Threshold", "minimum": 255, "maximum": 296},
+                        {"label": "VO2 Max", "minimum": 297, "maximum": 338},
+                        {"label": "Anaerobic Capacity", "minimum": 339, "maximum": 2000},
+                    ],
+                },
+                {
+                    "zoneCalculatorId": None,
+                    "threshold": 300,
+                    "calculationMethod": 4,
+                    "workoutTypeId": 3,
+                    "zones": [{"label": str(i), "minimum": i, "maximum": i} for i in range(1, 7)],
+                },
+            ],
+        }
         with patch("tp_mcp.tools.settings.TPClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=APIResponse(success=True, data=settings))
             mock_instance.put = AsyncMock(return_value=response)
             mock_client.return_value.__aenter__.return_value = mock_instance
 
@@ -45,16 +71,23 @@ class TestUpdateFTP:
         assert result["success"] is True
         assert result["ftp"] == 320
         zones = result["zones"]
-        assert len(zones) == 5
-        # Z1: 0-55% of 320 = 0-176
+        assert len(zones) == 6
+        # Existing maxima [156, 212, 254, 296, 338] are scaled from 280W to 320W
         assert zones[0]["minimum"] == 0
-        assert zones[0]["maximum"] == 176
-        # Z2: 56-75% = 179-240
+        assert zones[0]["maximum"] == 178
         assert zones[1]["minimum"] == 179
-        assert zones[1]["maximum"] == 240
-        # Z4: 91-105% = 291-336
+        assert zones[1]["maximum"] == 242
         assert zones[3]["minimum"] == 291
-        assert zones[3]["maximum"] == 336
+        assert zones[3]["maximum"] == 338
+        assert zones[5]["minimum"] == 387
+        assert zones[5]["maximum"] == 2000
+
+        payload = mock_instance.put.call_args[1]["json"]
+        assert len(payload) == 2
+        assert payload[0]["threshold"] == 320
+        assert payload[0]["workoutTypeId"] == 0
+        assert payload[0]["zones"] == zones
+        assert payload[1] == settings["powerZones"][1]
 
     @pytest.mark.asyncio
     async def test_ftp_validation(self):


### PR DESCRIPTION
Fixes #28

## Summary
- send the full `powerZones` array to `/fitness/v2/athletes/{id}/powerzones` instead of a single zone group
- preserve and scale the athlete's existing default power zone model when updating FTP
- treat HTTP `204 No Content` as a successful API response
- update tests and tool descriptions to match the live API behavior

## Verification
- reproduced the original `API error: 500` against the live TrainingPeaks API
- verified `tp_update_ftp(227)` succeeds live after the fix
- `uv run ruff check src/`
- `uv run mypy src/`
- `uv run pytest tests/ -v`