### PR TITLE
Add pair/unpair workout tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Ask your AI assistant things like:
 - "Set my FTP to 310 and update my power zones"
 - "Add a calendar note for next Monday: rest day, travel"
 
-## Tools (52)
+## Tools (54)
 
 ### Workouts
 | Tool | Description |
@@ -34,6 +34,8 @@ Ask your AI assistant things like:
 | `tp_delete_workout` | Delete a workout |
 | `tp_copy_workout` | Copy a workout to a new date (preserves structure and planned fields) |
 | `tp_reorder_workouts` | Reorder workouts on a given day |
+| `tp_pair_workout` | Pair a completed workout with a planned workout (merges into one) |
+| `tp_unpair_workout` | Unpair a workout (splits into separate completed and planned workouts) |
 | `tp_validate_structure` | Validate interval structure without creating a workout |
 | `tp_get_workout_comments` | Get comments on a workout |
 | `tp_add_workout_comment` | Add a comment to a workout |

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -4,7 +4,7 @@
 MVP - Complete & Production Ready
 
 ## Last Updated
-2026-01-09
+2026-04-03
 
 ## Completed Tasks
 
@@ -52,8 +52,24 @@ MVP - Complete & Production Ready
 
 ### Future (V1)
 - [x] TOOL-08 - tp_create_workout (basic: date, sport, title, duration; structured workouts deferred)
+- [x] TOOL-11 - tp_pair_workout (pair completed workout with planned workout via combine endpoint)
+- [x] TOOL-12 - tp_unpair_workout (split paired workout into completed + planned via split endpoint)
 - [ ] TOOL-09 - tp_move_workout
 - [ ] TOOL-10 - tp_get_health_metrics (sleep, resting HR, HRV, weight)
+
+## Recent Changes (2026-04-03)
+
+### Pair/Unpair Workout Tools
+Added `tp_pair_workout` and `tp_unpair_workout` tools that use the TrainingPeaks
+combine/split API endpoints. These allow pairing a completed workout with a planned
+workout (merging them into one calendar entry) and unpairing them back into separate
+entries. All data is preserved in both directions — comments, metrics, planned fields.
+
+API endpoints discovered by reverse-engineering the TrainingPeaks web app:
+- Pair: `POST /fitness/v6/athletes/{id}/commands/workouts/combine`
+- Unpair: `POST /fitness/v6/athletes/{id}/commands/workouts/{workoutId}/split`
+
+9 unit tests added. Live tested against a real TrainingPeaks account.
 
 ## Recent Changes (2026-01-09)
 
@@ -85,6 +101,8 @@ Verified against live TrainingPeaks API (2026-01-09):
 | `/users/v3/user` | User profile (nested: `{ user: { personId } }`) |
 | `/fitness/v6/athletes/{id}/workouts/{start}/{end}` | Workout list |
 | `/fitness/v6/athletes/{id}/workouts/{workoutId}` | Single workout |
+| `/fitness/v6/athletes/{id}/commands/workouts/combine` | Pair workouts (POST, body: `{athleteId, completedWorkoutId, plannedWorkoutId}`) |
+| `/fitness/v6/athletes/{id}/commands/workouts/{workoutId}/split` | Unpair workout (POST, empty body) |
 | `/personalrecord/v2/athletes/{id}/workouts/{workoutId}` | PRs per workout |
 | `/personalrecord/v2/athletes/{id}/{Sport}?prType=...` | Sport-specific PRs |
 | `/fitness/v1/athletes/{id}/reporting/performancedata/{start}/{end}` | CTL/ATL/TSB (POST) |

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -59,6 +59,7 @@ from tp_mcp.tools import (
     tp_get_workouts,
     tp_list_athletes,
     tp_log_metrics,
+    tp_pair_workout,
     tp_refresh_auth,
     tp_reorder_workouts,
     tp_schedule_library_workout,
@@ -69,6 +70,7 @@ from tp_mcp.tools import (
     tp_update_library_item,
     tp_update_nutrition,
     tp_update_speed_zones,
+    tp_unpair_workout,
     tp_update_workout,
     tp_upload_workout_file,
     tp_validate_structure,
@@ -270,6 +272,44 @@ TOOLS = [
                 },
             },
             "required": ["workout_ids"],
+        },
+    ),
+    Tool(
+        name="tp_unpair_workout",
+        description=(
+            "Unpair a workout. Detaches the completed workout file from the "
+            "planned workout, creating two separate workouts. No data is lost."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "workout_id": {
+                    "type": "string",
+                    "description": "The ID of the paired workout to unpair.",
+                },
+            },
+            "required": ["workout_id"],
+        },
+    ),
+    Tool(
+        name="tp_pair_workout",
+        description=(
+            "Pair a completed workout with a planned workout. Attaches the "
+            "completed data to the planned workout, merging them into one."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "completed_workout_id": {
+                    "type": "string",
+                    "description": "The ID of the completed (actual) workout.",
+                },
+                "planned_workout_id": {
+                    "type": "string",
+                    "description": "The ID of the planned workout to pair with.",
+                },
+            },
+            "required": ["completed_workout_id", "planned_workout_id"],
         },
     ),
     Tool(
@@ -938,6 +978,16 @@ async def _h_copy_workout(args):
 
 @_handler("tp_reorder_workouts")
 async def _h_reorder(args): return await tp_reorder_workouts(workout_ids=args["workout_ids"])
+
+@_handler("tp_unpair_workout")
+async def _h_unpair(args): return await tp_unpair_workout(workout_id=args["workout_id"])
+
+@_handler("tp_pair_workout")
+async def _h_pair(args):
+    return await tp_pair_workout(
+        completed_workout_id=args["completed_workout_id"],
+        planned_workout_id=args["planned_workout_id"],
+    )
 
 @_handler("tp_get_workout_comments")
 async def _h_get_comments(args): return await tp_get_workout_comments(workout_id=args["workout_id"])

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -61,7 +61,9 @@ from tp_mcp.tools.workouts import (
     tp_get_workout,
     tp_get_workout_comments,
     tp_get_workouts,
+    tp_pair_workout,
     tp_reorder_workouts,
+    tp_unpair_workout,
     tp_update_workout,
 )
 
@@ -109,9 +111,11 @@ __all__ = [
     "tp_list_athletes",
     "tp_get_workouts",
     "tp_log_metrics",
+    "tp_pair_workout",
     "tp_refresh_auth",
     "tp_reorder_workouts",
     "tp_schedule_library_workout",
+    "tp_unpair_workout",
     "tp_update_equipment",
     "tp_update_event",
     "tp_update_ftp",

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -886,3 +886,150 @@ async def tp_add_workout_comment(workout_id: str, comment: str) -> dict[str, Any
             "success": True,
             "message": "Comment added.",
         }
+
+
+async def tp_unpair_workout(workout_id: str) -> dict[str, Any]:
+    """Unpair (split) a paired workout into separate completed and planned workouts.
+
+    Detaches the completed workout file from the planned workout,
+    creating two independent workouts on the same day. No data is lost.
+
+    Args:
+        workout_id: The ID of the paired workout to unpair.
+
+    Returns:
+        Dict with completed workout(s) and new planned workout info, or error.
+    """
+    try:
+        validated = WorkoutIdInput(workout_id=workout_id)
+    except (ValidationError, ValueError) as e:
+        msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": msg,
+        }
+
+    async with TPClient() as client:
+        athlete_id = await client.ensure_athlete_id()
+        if not athlete_id:
+            return {
+                "isError": True,
+                "error_code": "AUTH_INVALID",
+                "message": "Could not get athlete ID. Re-authenticate.",
+            }
+
+        endpoint = (
+            f"/fitness/v6/athletes/{athlete_id}"
+            f"/commands/workouts/{validated.workout_id}/split"
+        )
+        response = await client.post(endpoint)
+
+        if response.is_error:
+            return {
+                "isError": True,
+                "error_code": response.error_code.value if response.error_code else "API_ERROR",
+                "message": response.message,
+            }
+
+        if not isinstance(response.data, dict):
+            return {
+                "isError": True,
+                "error_code": "API_ERROR",
+                "message": "Unexpected response format from API.",
+            }
+
+        completed = response.data.get("completedWorkouts", [])
+        planned = response.data.get("plannedWorkout")
+
+        completed_ids = [w.get("workoutId") for w in completed if isinstance(w, dict)]
+        planned_id = planned.get("workoutId") if isinstance(planned, dict) else None
+
+        return {
+            "success": True,
+            "message": f"Workout {validated.workout_id} unpaired.",
+            "completed_workout_ids": completed_ids,
+            "planned_workout_id": planned_id,
+            "completed_workouts": completed,
+            "planned_workout": planned,
+        }
+
+
+async def tp_pair_workout(
+    completed_workout_id: str,
+    planned_workout_id: str,
+) -> dict[str, Any]:
+    """Pair (combine) a completed workout with a planned workout.
+
+    Attaches the completed workout data to the planned workout,
+    merging them into a single paired workout. All data from both
+    workouts is preserved.
+
+    Args:
+        completed_workout_id: The ID of the completed (actual) workout.
+        planned_workout_id: The ID of the planned workout to pair with.
+
+    Returns:
+        Dict with merged workout info, or error.
+    """
+    try:
+        validated_completed = WorkoutIdInput(workout_id=completed_workout_id)
+    except (ValidationError, ValueError) as e:
+        msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": f"Invalid completed_workout_id: {msg}",
+        }
+
+    try:
+        validated_planned = WorkoutIdInput(workout_id=planned_workout_id)
+    except (ValidationError, ValueError) as e:
+        msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": f"Invalid planned_workout_id: {msg}",
+        }
+
+    async with TPClient() as client:
+        athlete_id = await client.ensure_athlete_id()
+        if not athlete_id:
+            return {
+                "isError": True,
+                "error_code": "AUTH_INVALID",
+                "message": "Could not get athlete ID. Re-authenticate.",
+            }
+
+        endpoint = f"/fitness/v6/athletes/{athlete_id}/commands/workouts/combine"
+        payload = {
+            "athleteId": int(athlete_id),
+            "completedWorkoutId": int(validated_completed.workout_id),
+            "plannedWorkoutId": int(validated_planned.workout_id),
+        }
+        response = await client.post(endpoint, json=payload)
+
+        if response.is_error:
+            return {
+                "isError": True,
+                "error_code": response.error_code.value if response.error_code else "API_ERROR",
+                "message": response.message,
+            }
+
+        if not isinstance(response.data, dict):
+            return {
+                "isError": True,
+                "error_code": "API_ERROR",
+                "message": "Unexpected response format from API.",
+            }
+
+        return {
+            "success": True,
+            "message": (
+                f"Workout {validated_completed.workout_id} paired with "
+                f"planned workout {validated_planned.workout_id}."
+            ),
+            "workout_id": response.data.get("workoutId"),
+            "title": response.data.get("title"),
+            "workout": response.data,
+        }

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -94,6 +94,8 @@ class TestListTools:
             "tp_upload_workout_file",
             "tp_download_workout_file",
             "tp_delete_workout_file",
+            "tp_pair_workout",
+            "tp_unpair_workout",
         }
         assert v2_tools.issubset(names)
         assert len(names) == len(core_tools) + len(v2_tools)

--- a/tests/test_tools/test_workouts.py
+++ b/tests/test_tools/test_workouts.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from tp_mcp.client.http import APIResponse, ErrorCode
-from tp_mcp.tools.workouts import tp_create_workout, tp_get_workout, tp_get_workouts
+from tp_mcp.tools.workouts import tp_create_workout, tp_get_workout, tp_get_workouts, tp_pair_workout, tp_unpair_workout
 
 
 class TestTpGetWorkouts:
@@ -376,3 +376,171 @@ class TestTpCreateWorkout:
 
         assert result["isError"] is True
         assert result["error_code"] == "API_ERROR"
+
+
+class TestTpUnpairWorkout:
+    """Tests for tp_unpair_workout tool."""
+
+    @pytest.mark.asyncio
+    async def test_unpair_success(self):
+        """Test successful unpair of a paired workout."""
+        split_response = APIResponse(
+            success=True,
+            data={
+                "completedWorkouts": [
+                    {"workoutId": 111, "title": None, "totalTime": 0.75},
+                ],
+                "plannedWorkout": {
+                    "workoutId": 222,
+                    "title": "EASY run",
+                    "totalTimePlanned": 0.75,
+                },
+            },
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=split_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_unpair_workout(workout_id="111")
+
+        assert result["success"] is True
+        assert result["completed_workout_ids"] == [111]
+        assert result["planned_workout_id"] == 222
+        mock_instance.post.assert_called_once()
+        call_args = mock_instance.post.call_args
+        assert "/commands/workouts/111/split" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_unpair_invalid_id(self):
+        """Test unpair with invalid workout ID."""
+        result = await tp_unpair_workout(workout_id="abc")
+
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_unpair_auth_error(self):
+        """Test unpair when not authenticated."""
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=None)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_unpair_workout(workout_id="111")
+
+        assert result["isError"] is True
+        assert result["error_code"] == "AUTH_INVALID"
+
+    @pytest.mark.asyncio
+    async def test_unpair_api_error(self):
+        """Test unpair when API returns an error."""
+        error_response = APIResponse(
+            success=False, error_code=ErrorCode.API_ERROR, message="Server error"
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=error_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_unpair_workout(workout_id="111")
+
+        assert result["isError"] is True
+        assert result["error_code"] == "API_ERROR"
+
+
+class TestTpPairWorkout:
+    """Tests for tp_pair_workout tool."""
+
+    @pytest.mark.asyncio
+    async def test_pair_success(self):
+        """Test successful pairing of completed + planned workouts."""
+        combine_response = APIResponse(
+            success=True,
+            data={
+                "workoutId": 111,
+                "title": "EASY run",
+                "totalTime": 0.75,
+                "totalTimePlanned": 0.75,
+            },
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=combine_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_pair_workout(
+                completed_workout_id="111", planned_workout_id="222"
+            )
+
+        assert result["success"] is True
+        assert result["workout_id"] == 111
+        assert result["title"] == "EASY run"
+        mock_instance.post.assert_called_once()
+        call_args = mock_instance.post.call_args
+        assert "/commands/workouts/combine" in call_args[0][0]
+        payload = call_args[1]["json"]
+        assert payload["athleteId"] == 123
+        assert payload["completedWorkoutId"] == 111
+        assert payload["plannedWorkoutId"] == 222
+
+    @pytest.mark.asyncio
+    async def test_pair_invalid_completed_id(self):
+        """Test pair with invalid completed workout ID."""
+        result = await tp_pair_workout(
+            completed_workout_id="abc", planned_workout_id="222"
+        )
+
+        assert result["isError"] is True
+        assert "completed_workout_id" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_pair_invalid_planned_id(self):
+        """Test pair with invalid planned workout ID."""
+        result = await tp_pair_workout(
+            completed_workout_id="111", planned_workout_id="abc"
+        )
+
+        assert result["isError"] is True
+        assert "planned_workout_id" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_pair_auth_error(self):
+        """Test pair when not authenticated."""
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=None)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_pair_workout(
+                completed_workout_id="111", planned_workout_id="222"
+            )
+
+        assert result["isError"] is True
+        assert result["error_code"] == "AUTH_INVALID"
+
+    @pytest.mark.asyncio
+    async def test_pair_api_error(self):
+        """Test pair when API returns an error."""
+        error_response = APIResponse(
+            success=False, error_code=ErrorCode.NOT_FOUND, message="Not found"
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=error_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_pair_workout(
+                completed_workout_id="111", planned_workout_id="222"
+            )
+
+        assert result["isError"] is True
+        assert result["error_code"] == "NOT_FOUND"


### PR DESCRIPTION
## Summary

Add `tp_pair_workout` and `tp_unpair_workout` tools that allow pairing a completed workout with a planned workout (merging them into one calendar entry) and splitting them back into separate entries.

## Changes

- **`tp_pair_workout`** — Pairs a completed workout with a planned workout via the TrainingPeaks combine endpoint (`POST /fitness/v6/athletes/{id}/commands/workouts/combine`). Merges both into a single calendar entry, preserving all data.
- **`tp_unpair_workout`** — Splits a paired workout back into separate completed and planned workouts via the split endpoint (`POST /fitness/v6/athletes/{id}/commands/workouts/{workoutId}/split`). No data is lost.

### Files changed

| File | Change |
|------|--------|
| `src/tp_mcp/tools/workouts.py` | Added `tp_pair_workout` and `tp_unpair_workout` tool implementations |
| `src/tp_mcp/tools/__init__.py` | Exported new tools |
| `src/tp_mcp/server.py` | Registered MCP tool definitions and handlers |
| `tests/test_tools/test_workouts.py` | 9 unit tests covering success, validation errors, auth failures, and API errors |
| `tests/test_server_functional.py` | Added new tools to the registered tools list |
| `README.md` | Updated tool count (52 → 54) and added tools to the table |
| `docs/PROGRESS.md` | Updated progress tracking and API endpoint documentation |

## Testing

- 9 unit tests added covering both tools (success paths, validation errors, auth failures, API errors)
- Live tested against a real TrainingPeaks account

## Notes

Please **squash merge** this PR to keep a clean commit history on main.
