### PR TITLE
Support structured workout updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Ask your AI assistant things like:
 | `tp_get_workouts` | List workouts in a date range (max 90 days) |
 | `tp_get_workout` | Get full details for a single workout |
 | `tp_create_workout` | Create a workout with optional interval structure, auto-computed IF/TSS |
-| `tp_update_workout` | Update any field of an existing workout |
+| `tp_update_workout` | Update any field of an existing workout, including structured intervals |
 | `tp_delete_workout` | Delete a workout |
 | `tp_copy_workout` | Copy a workout to a new date (preserves structure and planned fields) |
 | `tp_reorder_workouts` | Reorder workouts on a given day |
@@ -212,7 +212,7 @@ Create workouts with full interval structure. The server auto-computes duration,
 }
 ```
 
-The LLM builds this JSON naturally from conversation - just say "build me 4x8min sweet spot with 2min rest".
+The LLM builds this JSON naturally from conversation - just say "build me 4x8min sweet spot with 2min rest". The same simplified `structure` format also works with `tp_update_workout`.
 
 ## What is MCP?
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,30 @@ Create workouts with full interval structure. The server auto-computes duration,
 }
 ```
 
-The LLM builds this JSON naturally from conversation - just say "build me 4x8min sweet spot with 2min rest". The same simplified `structure` format also works with `tp_update_workout`.
+The LLM builds this JSON naturally from conversation - just say "build me 4x8min sweet spot with 2min rest".
+
+You can use the same simplified `structure` object with `tp_update_workout`:
+
+```json
+{
+  "workout_id": "3658666303",
+  "duration_minutes": 57,
+  "tss_planned": 62.3,
+  "structure": {
+    "primaryIntensityMetric": "percentOfThresholdHr",
+    "steps": [
+      {"name": "Einlaufen", "duration_seconds": 900, "intensity_min": 65, "intensity_max": 80, "intensityClass": "warmUp"},
+      {"type": "repetition", "name": "4x5min zügig kontrolliert", "reps": 4, "steps": [
+        {"name": "Intervall", "duration_seconds": 300, "intensity_min": 89, "intensity_max": 94, "intensityClass": "active"},
+        {"name": "Trabpause", "duration_seconds": 180, "intensity_min": 65, "intensity_max": 83, "intensityClass": "rest"}
+      ]},
+      {"name": "Auslaufen", "duration_seconds": 600, "intensity_min": 65, "intensity_max": 80, "intensityClass": "coolDown"}
+    ]
+  }
+}
+```
+
+If `duration_minutes` and `tss_planned` are omitted, they are derived from the structure. If you pass them explicitly, they override the derived values.
 
 ## What is MCP?
 

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -212,7 +212,11 @@ TOOLS = [
     ),
     Tool(
         name="tp_update_workout",
-        description="Update fields of an existing workout. Fetches existing, merges, then saves.",
+        description=(
+            "Update fields of an existing workout. Supports the same simplified "
+            "interval structure format as tp_create_workout, then fetches existing, "
+            "merges, and saves."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
@@ -230,7 +234,10 @@ TOOLS = [
                 "coach_comment": {"type": "string"},
                 "feeling": {"type": "integer", "description": "0-10"},
                 "rpe": {"type": "integer", "description": "1-10"},
-                "structure": {"type": ["object", "string"]},
+                "structure": {
+                    "type": ["object", "string"],
+                    "description": STRUCTURE_DESCRIPTION,
+                },
             },
             "required": ["workout_id"],
         },

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -41,6 +41,23 @@ def _extract_file_infos(raw_data: dict, key: str) -> list[dict]:
         })
     return normalized
 
+
+def _prepare_structure_payload(
+    structure: dict[str, Any] | str | None,
+) -> tuple[dict[str, Any] | None, float | None, float | None, float | None, str | None]:
+    """Parse simplified structure input and derive TP payload values."""
+    if structure is None:
+        return None, None, None, None, None
+
+    try:
+        parsed_structure = parse_structure_input(structure)
+        wire_structure = build_wire_structure(parsed_structure)
+        structure_if, structure_tss, total_seconds = compute_if_tss(parsed_structure)
+        return wire_structure, total_seconds / 60.0, structure_if, structure_tss, None
+    except (ValidationError, ValueError) as e:
+        msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
+        return None, None, None, None, f"Invalid structure: {msg}"
+
 # Maps sport name to (workoutTypeFamilyId, workoutTypeValueId)
 # IDs confirmed from GET /fitness/v6/workouttypes
 SPORT_TYPE_MAP: dict[str, tuple[int, int]] = {
@@ -321,25 +338,15 @@ async def tp_create_workout(
 
     family_id, type_id = SPORT_TYPE_MAP[params.sport]
 
-    # If structure is provided, parse it and compute derived values
-    wire_structure = None
-    structure_duration_minutes = None
-    structure_if = None
-    structure_tss = None
-
-    if params.structure is not None:
-        try:
-            parsed_structure = parse_structure_input(params.structure)
-            wire_structure = build_wire_structure(parsed_structure)
-            structure_if, structure_tss, total_seconds = compute_if_tss(parsed_structure)
-            structure_duration_minutes = total_seconds / 60.0
-        except (ValidationError, ValueError) as e:
-            msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
-            return {
-                "isError": True,
-                "error_code": "VALIDATION_ERROR",
-                "message": f"Invalid structure: {msg}",
-            }
+    wire_structure, structure_duration_minutes, structure_if, structure_tss, structure_error = (
+        _prepare_structure_payload(params.structure)
+    )
+    if structure_error is not None:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": structure_error,
+        }
 
     # Use explicit duration if provided, otherwise use structure-computed
     effective_duration: float | None = float(params.duration_minutes) if params.duration_minutes is not None else None
@@ -472,6 +479,28 @@ async def tp_update_workout(
             "message": msg,
         }
 
+    wire_structure, structure_duration_minutes, structure_if, structure_tss, structure_error = (
+        _prepare_structure_payload(params.structure)
+    )
+    if structure_error is not None:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": structure_error,
+        }
+
+    effective_duration = params.duration_minutes
+    if effective_duration is None and structure_duration_minutes is not None:
+        effective_duration = structure_duration_minutes
+
+    effective_tss = params.tss_planned
+    if effective_tss is None and structure_tss is not None:
+        effective_tss = structure_tss
+
+    effective_if = None
+    if params.structure is not None and params.tss_planned is None and structure_if is not None:
+        effective_if = structure_if
+
     async with TPClient() as client:
         athlete_id = await client.ensure_athlete_id()
         if not athlete_id:
@@ -514,12 +543,12 @@ async def tp_update_workout(
             existing["description"] = params.description
         if params.date is not None:
             existing["workoutDay"] = f"{params.date.isoformat()}T00:00:00"
-        if params.duration_minutes is not None:
-            existing["totalTimePlanned"] = params.duration_minutes / 60.0
+        if effective_duration is not None:
+            existing["totalTimePlanned"] = effective_duration / 60.0
         if params.distance_km is not None:
             existing["distancePlanned"] = _km_to_m(params.distance_km)
-        if params.tss_planned is not None:
-            existing["tssPlanned"] = params.tss_planned
+        if effective_tss is not None:
+            existing["tssPlanned"] = effective_tss
         if params.tags is not None:
             existing["tags"] = params.tags
         if params.athlete_comment is not None:
@@ -531,11 +560,11 @@ async def tp_update_workout(
         if params.rpe is not None:
             existing["rpe"] = params.rpe
         if params.structure is not None:
-            # If structure is a dict (from GET response), serialise to JSON string
-            if isinstance(params.structure, dict):
-                existing["structure"] = json.dumps(params.structure)
+            existing["structure"] = json.dumps(wire_structure)
+            if effective_if is not None:
+                existing["ifPlanned"] = effective_if
             else:
-                existing["structure"] = params.structure
+                existing.pop("ifPlanned", None)
 
         # PUT updated workout
         put_endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{params.workout_id}"

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from tp_mcp.client.http import APIResponse, ErrorCode
+from tp_mcp.client.http import APIResponse
 from tp_mcp.tools.workouts import (
     tp_add_workout_comment,
     tp_copy_workout,
@@ -25,9 +25,27 @@ class TestCreateWorkoutWithStructure:
         structure = {
             "primaryIntensityMetric": "percentOfFtp",
             "steps": [
-                {"name": "WU", "duration_seconds": 600, "intensity_min": 40, "intensity_max": 55, "intensityClass": "warmUp"},
-                {"name": "Main", "duration_seconds": 1200, "intensity_min": 85, "intensity_max": 95, "intensityClass": "active"},
-                {"name": "CD", "duration_seconds": 600, "intensity_min": 40, "intensity_max": 55, "intensityClass": "coolDown"},
+                {
+                    "name": "WU",
+                    "duration_seconds": 600,
+                    "intensity_min": 40,
+                    "intensity_max": 55,
+                    "intensityClass": "warmUp",
+                },
+                {
+                    "name": "Main",
+                    "duration_seconds": 1200,
+                    "intensity_min": 85,
+                    "intensity_max": 95,
+                    "intensityClass": "active",
+                },
+                {
+                    "name": "CD",
+                    "duration_seconds": 600,
+                    "intensity_min": 40,
+                    "intensity_max": 55,
+                    "intensityClass": "coolDown",
+                },
             ],
         }
         create_response = APIResponse(
@@ -65,7 +83,13 @@ class TestCreateWorkoutWithStructure:
         """Explicit duration should override structure-computed duration."""
         structure = {
             "steps": [
-                {"name": "WU", "duration_seconds": 600, "intensity_min": 50, "intensity_max": 60, "intensityClass": "warmUp"},
+                {
+                    "name": "WU",
+                    "duration_seconds": 600,
+                    "intensity_min": 50,
+                    "intensity_max": 60,
+                    "intensityClass": "warmUp",
+                },
             ],
         }
         create_response = APIResponse(
@@ -222,10 +246,36 @@ class TestUpdateWorkout:
 
     @pytest.mark.asyncio
     async def test_update_with_structure_serialises(self):
-        """Structure dict should be JSON-serialised for PUT."""
+        """Simplified structure should be converted to TP wire format for PUT."""
         existing = {"workoutId": 1001}
         get_response = APIResponse(success=True, data=existing)
         put_response = APIResponse(success=True, data=None)
+        structure = {
+            "primaryIntensityMetric": "percentOfFtp",
+            "steps": [
+                {
+                    "name": "WU",
+                    "duration_seconds": 600,
+                    "intensity_min": 40,
+                    "intensity_max": 55,
+                    "intensityClass": "warmUp",
+                },
+                {
+                    "name": "Main",
+                    "duration_seconds": 1200,
+                    "intensity_min": 85,
+                    "intensity_max": 95,
+                    "intensityClass": "active",
+                },
+                {
+                    "name": "CD",
+                    "duration_seconds": 600,
+                    "intensity_min": 40,
+                    "intensity_max": 55,
+                    "intensityClass": "coolDown",
+                },
+            ],
+        }
 
         with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
             mock_instance = AsyncMock()
@@ -236,12 +286,79 @@ class TestUpdateWorkout:
 
             result = await tp_update_workout(
                 workout_id="1001",
-                structure={"structure": [{"type": "step"}]},
+                structure=structure,
             )
 
         assert result["success"] is True
         put_payload = mock_instance.put.call_args[1]["json"]
         assert isinstance(put_payload["structure"], str)
+        parsed = json.loads(put_payload["structure"])
+        assert "structure" in parsed
+        assert "polyline" in parsed
+        assert abs(put_payload["totalTimePlanned"] - 40.0 / 60.0) < 0.01
+        assert put_payload["tssPlanned"] > 0
+        assert put_payload["ifPlanned"] > 0
+
+    @pytest.mark.asyncio
+    async def test_update_with_structure_explicit_duration_and_tss_override(self):
+        """Explicit duration and TSS should win over derived structure values."""
+        existing = {
+            "workoutId": 1001,
+            "ifPlanned": 0.91,
+        }
+        get_response = APIResponse(success=True, data=existing)
+        put_response = APIResponse(success=True, data=None)
+        structure = {
+            "steps": [
+                {
+                    "name": "WU",
+                    "duration_seconds": 600,
+                    "intensity_min": 50,
+                    "intensity_max": 60,
+                    "intensityClass": "warmUp",
+                },
+            ],
+        }
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(
+                workout_id="1001",
+                duration_minutes=90,
+                tss_planned=77,
+                structure=structure,
+            )
+
+        assert result["success"] is True
+        put_payload = mock_instance.put.call_args[1]["json"]
+        assert put_payload["totalTimePlanned"] == 90 / 60.0
+        assert put_payload["tssPlanned"] == 77
+        assert "ifPlanned" not in put_payload
+
+    @pytest.mark.asyncio
+    async def test_update_with_invalid_structure_returns_validation_error(self):
+        """Invalid simplified structure should fail before PUT."""
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock()
+            mock_instance.put = AsyncMock()
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(
+                workout_id="1001",
+                structure={"structure": [{"type": "step"}]},
+            )
+
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+        mock_instance.get.assert_not_called()
+        mock_instance.put.assert_not_called()
 
 
 class TestDeleteWorkout:
@@ -353,7 +470,7 @@ class TestCopyWorkout:
             mock_instance.post = AsyncMock(return_value=post_response)
             mock_client.return_value.__aenter__.return_value = mock_instance
 
-            result = await tp_copy_workout("1001", "2026-04-01", title="New Title")
+            await tp_copy_workout("1001", "2026-04-01", title="New Title")
 
         payload = mock_instance.post.call_args[1]["json"]
         assert payload["title"] == "New Title"


### PR DESCRIPTION
## Summary

Merges #35 from @cygnusb with conflict resolution and German-to-English step name translation.

- Extends `tp_update_workout` to accept simplified interval structure (same format as `tp_create_workout`)
- Refactors shared structure-parsing logic into `_prepare_structure_payload` helper
- Translates README example step names from German to English
- Resolves merge conflicts with #34 and #39

Closes #35