### PR TITLE
Refactor _prepare_structure_payload to return StructurePayload NamedTuple

### DIFF
--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -63,7 +63,13 @@ def _prepare_structure_payload(
         parsed_structure = parse_structure_input(structure)
         wire_structure = build_wire_structure(parsed_structure)
         structure_if, structure_tss, total_seconds = compute_if_tss(parsed_structure)
-        return StructurePayload(wire_structure, total_seconds / 60.0, structure_if, structure_tss, None)
+        return StructurePayload(
+            wire_structure=wire_structure,
+            duration_minutes=total_seconds / 60.0,
+            intensity_factor=structure_if,
+            tss=structure_tss,
+            error=None,
+        )
     except (ValidationError, ValueError) as e:
         msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
         return StructurePayload(None, None, None, None, f"Invalid structure: {msg}")

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -4,7 +4,7 @@ import json
 import logging
 from datetime import date as date_type
 from datetime import datetime as datetime_type
-from typing import Any, Literal
+from typing import Any, Literal, NamedTuple
 
 from pydantic import ValidationError
 
@@ -23,6 +23,14 @@ from tp_mcp.tools.structure import (
 )
 
 logger = logging.getLogger("tp-mcp")
+
+
+class StructurePayload(NamedTuple):
+    wire_structure: dict | None
+    duration_minutes: float | None
+    tss: float | None
+    intensity_factor: float | None
+    error: str | None
 
 
 def _extract_file_infos(raw_data: dict, key: str) -> list[dict]:
@@ -46,19 +54,19 @@ def _extract_file_infos(raw_data: dict, key: str) -> list[dict]:
 
 def _prepare_structure_payload(
     structure: dict[str, Any] | str | None,
-) -> tuple[dict[str, Any] | None, float | None, float | None, float | None, str | None]:
+) -> StructurePayload:
     """Parse simplified structure input and derive TP payload values."""
     if structure is None:
-        return None, None, None, None, None
+        return StructurePayload(None, None, None, None, None)
 
     try:
         parsed_structure = parse_structure_input(structure)
         wire_structure = build_wire_structure(parsed_structure)
         structure_if, structure_tss, total_seconds = compute_if_tss(parsed_structure)
-        return wire_structure, total_seconds / 60.0, structure_if, structure_tss, None
+        return StructurePayload(wire_structure, total_seconds / 60.0, structure_if, structure_tss, None)
     except (ValidationError, ValueError) as e:
         msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
-        return None, None, None, None, f"Invalid structure: {msg}"
+        return StructurePayload(None, None, None, None, f"Invalid structure: {msg}")
 
 
 def _validate_structured_workout(structured_workout: dict[str, Any]) -> str | None:
@@ -420,14 +428,12 @@ async def tp_create_workout(
 
     family_id, type_id = SPORT_TYPE_MAP[params.sport]
 
-    wire_structure, structure_duration_minutes, structure_if, structure_tss, structure_error = (
-        _prepare_structure_payload(params.structure)
-    )
-    if structure_error is not None:
+    structure_payload = _prepare_structure_payload(params.structure)
+    if structure_payload.error is not None:
         return {
             "isError": True,
             "error_code": "VALIDATION_ERROR",
-            "message": structure_error,
+            "message": structure_payload.error,
         }
     raw_structure_payload, raw_structure_error = _encode_structured_workout(
         params.structured_workout,
@@ -441,18 +447,18 @@ async def tp_create_workout(
 
     # Use explicit duration if provided, otherwise use structure-computed
     effective_duration: float | None = float(params.duration_minutes) if params.duration_minutes is not None else None
-    if effective_duration is None and structure_duration_minutes is not None:
-        effective_duration = structure_duration_minutes
+    if effective_duration is None and structure_payload.duration_minutes is not None:
+        effective_duration = structure_payload.duration_minutes
 
     # Use explicit TSS if provided, otherwise use structure-computed
     effective_tss = params.tss_planned
-    if effective_tss is None and structure_tss is not None:
-        effective_tss = structure_tss
+    if effective_tss is None and structure_payload.tss is not None:
+        effective_tss = structure_payload.tss
 
     # Use structure IF if no explicit TSS was given
     effective_if = None
-    if params.tss_planned is None and structure_if is not None:
-        effective_if = structure_if
+    if params.tss_planned is None and structure_payload.intensity_factor is not None:
+        effective_if = structure_payload.intensity_factor
 
     async with TPClient() as client:
         athlete_id = await client.ensure_athlete_id()
@@ -486,8 +492,8 @@ async def tp_create_workout(
             payload["tssPlanned"] = effective_tss
         if effective_if is not None:
             payload["ifPlanned"] = effective_if
-        if wire_structure is not None:
-            payload["structure"] = json.dumps(wire_structure)
+        if structure_payload.wire_structure is not None:
+            payload["structure"] = json.dumps(structure_payload.wire_structure)
         elif raw_structure_payload is not None:
             payload["structure"] = raw_structure_payload
         if params.tags is not None:
@@ -579,14 +585,12 @@ async def tp_update_workout(
             "message": msg,
         }
 
-    wire_structure, structure_duration_minutes, structure_if, structure_tss, structure_error = (
-        _prepare_structure_payload(params.structure)
-    )
-    if structure_error is not None:
+    structure_payload = _prepare_structure_payload(params.structure)
+    if structure_payload.error is not None:
         return {
             "isError": True,
             "error_code": "VALIDATION_ERROR",
-            "message": structure_error,
+            "message": structure_payload.error,
         }
     raw_structure_payload, raw_structure_error = _encode_structured_workout(
         params.structured_workout,
@@ -599,16 +603,16 @@ async def tp_update_workout(
         }
 
     effective_duration = params.duration_minutes
-    if effective_duration is None and structure_duration_minutes is not None:
-        effective_duration = structure_duration_minutes
+    if effective_duration is None and structure_payload.duration_minutes is not None:
+        effective_duration = structure_payload.duration_minutes
 
     effective_tss = params.tss_planned
-    if effective_tss is None and structure_tss is not None:
-        effective_tss = structure_tss
+    if effective_tss is None and structure_payload.tss is not None:
+        effective_tss = structure_payload.tss
 
     effective_if = None
-    if params.structure is not None and params.tss_planned is None and structure_if is not None:
-        effective_if = structure_if
+    if params.structure is not None and params.tss_planned is None and structure_payload.intensity_factor is not None:
+        effective_if = structure_payload.intensity_factor
 
     async with TPClient() as client:
         athlete_id = await client.ensure_athlete_id()
@@ -675,7 +679,7 @@ async def tp_update_workout(
         if params.rpe is not None:
             existing["rpe"] = params.rpe
         if params.structure is not None:
-            existing["structure"] = json.dumps(wire_structure)
+            existing["structure"] = json.dumps(structure_payload.wire_structure)
             if effective_if is not None:
                 existing["ifPlanned"] = effective_if
             else:

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -28,8 +28,8 @@ logger = logging.getLogger("tp-mcp")
 class StructurePayload(NamedTuple):
     wire_structure: dict | None
     duration_minutes: float | None
-    tss: float | None
     intensity_factor: float | None
+    tss: float | None
     error: str | None
 
 

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -69,9 +69,12 @@ class TestCreateWorkoutWithStructure:
         # Duration auto-computed from structure: 2400s = 40min = 0.667 hours
         assert "totalTimePlanned" in payload
         assert abs(payload["totalTimePlanned"] - 40.0 / 60.0) < 0.01
-        # TSS auto-computed
-        assert "tssPlanned" in payload
-        assert payload["tssPlanned"] > 0
+        # TSS and IF auto-computed with correct semantic mapping (issue #41)
+        assert payload["tssPlanned"] == pytest.approx(39.6, abs=0.1)
+        assert payload["ifPlanned"] == pytest.approx(0.771, abs=0.001)
+        # Guard against IF/TSS swap: IF must be < 1, TSS must be >> 1
+        assert payload["ifPlanned"] < 1
+        assert payload["tssPlanned"] > 1
         # Structure serialised to JSON string
         assert isinstance(payload["structure"], str)
         parsed = json.loads(payload["structure"])
@@ -425,8 +428,11 @@ class TestUpdateWorkout:
         assert "structure" in parsed
         assert "polyline" in parsed
         assert abs(put_payload["totalTimePlanned"] - 40.0 / 60.0) < 0.01
-        assert put_payload["tssPlanned"] > 0
-        assert put_payload["ifPlanned"] > 0
+        # Exact IF/TSS values with swap guard (issue #41)
+        assert put_payload["tssPlanned"] == pytest.approx(39.6, abs=0.1)
+        assert put_payload["ifPlanned"] == pytest.approx(0.771, abs=0.001)
+        assert put_payload["ifPlanned"] < 1
+        assert put_payload["tssPlanned"] > 1
 
     @pytest.mark.asyncio
     async def test_update_with_structure_explicit_duration_and_tss_override(self):


### PR DESCRIPTION
## Summary

- Introduces `StructurePayload(NamedTuple)` with named fields `wire_structure`, `duration_minutes`, `intensity_factor`, `tss`, `error`
- Updates `_prepare_structure_payload()` to return `StructurePayload` using keyword arguments, eliminating positional field-order risk
- Updates both call sites (create and update) to use named attribute access instead of positional unpacking
- Tightens existing regression tests to assert exact `tssPlanned` and `ifPlanned` values with swap guards

Fixes #41

## Test plan

- [x] All 330 unit tests pass (`uv run pytest tests/ -x -q`)
- [x] Live create test: workout created with `if_planned=0.771`, `tss_planned=39.6` (correct fields, no swap)
- [x] Live update test: workout updated with structure, no errors
- [x] Existing IF/TSS regression tests in `test_new_workouts.py` assert exact values and guard against field swaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)