### PR TITLE
fix: widen json parameter type to accept list payloads

### DIFF
--- a/src/tp_mcp/client/http.py
+++ b/src/tp_mcp/client/http.py
@@ -291,7 +291,7 @@ class TPClient:
         self,
         method: str,
         endpoint: str,
-        json: dict[str, Any] | None = None,
+        json: dict[str, Any] | list[Any] | None = None,
         params: dict[str, Any] | None = None,
         _retry_on_401: bool = True,
     ) -> APIResponse:
@@ -424,7 +424,7 @@ class TPClient:
         """
         return await self._request("GET", endpoint, params=params)
 
-    async def post(self, endpoint: str, json: dict[str, Any] | None = None) -> APIResponse:
+    async def post(self, endpoint: str, json: dict[str, Any] | list[Any] | None = None) -> APIResponse:
         """Make a POST request.
 
         Args:
@@ -436,7 +436,7 @@ class TPClient:
         """
         return await self._request("POST", endpoint, json=json)
 
-    async def put(self, endpoint: str, json: dict[str, Any] | None = None) -> APIResponse:
+    async def put(self, endpoint: str, json: dict[str, Any] | list[Any] | None = None) -> APIResponse:
         """Make a PUT request.
 
         Args:


### PR DESCRIPTION
## Summary

- Widens `json` parameter on `TPClient._request()`, `.post()`, and `.put()` from `dict[str, Any] | None` to `dict[str, Any] | list[Any] | None`
- Fixes the type inaccuracy flagged in #42 / PR #37 review — the FTP power-zones endpoint correctly sends a list payload, but the type hints didn't reflect this
- No behaviour change; httpx already accepts any JSON-serialisable value at runtime

Closes #42

## Test plan

- [x] Verify existing tests still pass
- [x] Confirm power-zones PUT call (list payload) passes type checking with `mypy` / `pyright`

🤖 Generated with [Claude Code](https://claude.com/claude-code)