### PR TITLE
fix: use correct daily_data key in weekly summary fitness extraction

### DIFF
--- a/src/tp_mcp/tools/weekly_summary.py
+++ b/src/tp_mcp/tools/weekly_summary.py
@@ -74,9 +74,9 @@ async def tp_get_weekly_summary(week_of: str | None = None) -> dict[str, Any]:
     # Extract end-of-week fitness metrics
     end_of_week_fitness = None
     if not fitness_result.get("isError"):
-        trend = fitness_result.get("trend", [])
-        if trend:
-            end_of_week_fitness = trend[-1]
+        daily_data = fitness_result.get("daily_data", [])
+        if daily_data:
+            end_of_week_fitness = daily_data[-1]
 
     return {
         "week": {"start": monday.isoformat(), "end": sunday.isoformat()},

--- a/tests/test_tools/test_atp_and_summary.py
+++ b/tests/test_tools/test_atp_and_summary.py
@@ -91,7 +91,7 @@ class TestWeeklySummary:
                 "count": 2,
             }
             mock_fitness.return_value = {
-                "trend": [
+                "daily_data": [
                     {"date": "2026-03-22", "ctl": 65, "atl": 72, "tsb": -7},
                 ],
             }
@@ -110,7 +110,7 @@ class TestWeeklySummary:
              patch("tp_mcp.tools.weekly_summary.tp_get_fitness") as mock_fitness:
 
             mock_workouts.return_value = {"workouts": [], "count": 0}
-            mock_fitness.return_value = {"trend": []}
+            mock_fitness.return_value = {"daily_data": []}
 
             result = await tp_get_weekly_summary()
 


### PR DESCRIPTION
## Summary

`tp_get_weekly_summary` reads `fitness_result.get(\"trend\", [])` but `tp_get_fitness` actually returns a `daily_data` key (see `tools/fitness.py:122`). As a result, `end_of_week_fitness` was always `None` and the weekly summary always returned `\"fitness\": None`.

The existing test happened to pass because its mock used the same wrong key (`\"trend\"`) that the code read, so both sides agreed on a key that does not exist in the real `tp_get_fitness` output.

## Changes

- `src/tp_mcp/tools/weekly_summary.py` — read `\"daily_data\"` instead of `\"trend\"`
- `tests/test_tools/test_atp_and_summary.py` — update mocks to match the real shape returned by `tp_get_fitness`

## Test plan

- [x] Full test suite passes (338 passed in 10.86s)
- [x] `test_atp_and_summary.py` still asserts `result[\"fitness\"][\"ctl\"] == 65` — now via the real `daily_data` path
- [x] Diff is minimal and surgical (5 insertions, 5 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)