### PR TITLE
feat(workouts): expose tss_planned and tss_actual separately

### DIFF
--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -242,6 +242,8 @@ async def tp_get_workouts(
                     "distance_planned_km": w.distance_planned / 1000 if w.distance_planned else None,
                     "distance_actual_km": w.distance_actual / 1000 if w.distance_actual else None,
                     "tss": w.tss_actual or w.tss_planned,
+                    "tss_planned": w.tss_planned,
+                    "tss_actual": w.tss_actual,
                     "description": w.description,
                 }
                 for w in workouts

--- a/tests/test_tools/test_workouts.py
+++ b/tests/test_tools/test_workouts.py
@@ -30,6 +30,36 @@ class TestTpGetWorkouts:
         assert len(result["workouts"]) == 2
 
     @pytest.mark.asyncio
+    async def test_get_workouts_exposes_planned_and_actual_tss(self, mock_api_responses):
+        """tss_planned and tss_actual are exposed alongside the coalesced tss.
+
+        Downstream tools (e.g. compliance dashboards that compare planned vs. actual
+        on the same row) need both values; the coalesced `tss` loses the planned
+        intensity once a workout is completed.
+        """
+        workouts_response = APIResponse(success=True, data=mock_api_responses["workouts"])
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=workouts_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_get_workouts("2025-01-08", "2025-01-09")
+
+        # First fixture workout is completed with both planned+actual TSS.
+        completed = next(w for w in result["workouts"] if w["type"] == "completed")
+        assert completed["tss_planned"] == 80
+        assert completed["tss_actual"] == 75
+        assert completed["tss"] == 75  # backward-compatible coalesced value unchanged
+
+        # Second fixture workout is planned-only (no actual yet).
+        planned = next(w for w in result["workouts"] if w["type"] == "planned")
+        assert planned["tss_planned"] == 40
+        assert planned["tss_actual"] is None
+        assert planned["tss"] == 40
+
+    @pytest.mark.asyncio
     async def test_get_workouts_filter_completed(self, mock_api_responses):
         """Test filtering for completed workouts only."""
         workouts_response = APIResponse(success=True, data=mock_api_responses["workouts"])


### PR DESCRIPTION
## Motivation

`tp_get_workouts` coalesces `tssPlanned` and `tssActual` into a single `tss` field (`w.tss_actual or w.tss_planned`). Once a planned workout is completed, TrainingPeaks pairs the two values onto the same row — but the coalesced field returns only the actual, dropping planned intensity on the floor.

This matters for any downstream tool comparing planned vs. actual on the same row: compliance dashboards, adherence reports, week-over-week coaching summaries. The current workaround is to call `tp_get_workout` per row to recover `tssPlanned`, which is N extra API calls per week.

## Change

Add `tss_planned` and `tss_actual` to the normalized response alongside the existing `tss`. Purely additive — the coalesced `tss` stays identical for backward compatibility.

## Tests

Added one test covering both the paired (completed) and planned-only cases. Full suite green (48/48).