### PR TITLE
fix(workouts): use correct userTags field for workout tags

### DIFF
--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -503,7 +503,7 @@ async def tp_create_workout(
         elif raw_structure_payload is not None:
             payload["structure"] = raw_structure_payload
         if params.tags is not None:
-            payload["tags"] = params.tags
+            payload["userTags"] = params.tags
         if params.feeling is not None:
             payload["feeling"] = params.feeling
         if params.rpe is not None:
@@ -675,7 +675,7 @@ async def tp_update_workout(
         if effective_tss is not None:
             existing["tssPlanned"] = effective_tss
         if params.tags is not None:
-            existing["tags"] = params.tags
+            existing["userTags"] = params.tags
         if params.athlete_comment is not None:
             existing["athleteComments"] = params.athlete_comment
         if params.coach_comment is not None:
@@ -840,10 +840,13 @@ async def tp_copy_workout(
             "ifPlanned",
             "description",
             "coachComments",
-            "tags",
         ]:
             if source.get(field) is not None:
                 payload[field] = source[field]
+
+        # Copy user tags (API uses userTags, not tags)
+        if source.get("userTags") is not None:
+            payload["userTags"] = source["userTags"]
 
         # Shift startTimePlanned to target date, preserving time-of-day.
         # If the value can't be parsed (unexpected format), fall back to the

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -136,7 +136,8 @@ class TestCreateWorkoutWithStructure:
 
         assert result["success"] is True
         payload = mock_instance.post.call_args[1]["json"]
-        assert payload["tags"] == "intervals,hard"
+        assert payload["userTags"] == "intervals,hard"
+        assert "tags" not in payload
 
     @pytest.mark.asyncio
     async def test_create_with_feeling_and_rpe(self):


### PR DESCRIPTION
## Summary

The TrainingPeaks workout API expects `userTags` not `tags` for persisting workout tags. Using `tags` silently succeeds (no API error) but tags are never stored on the server.

## Changes

- **tp_create_workout**: Send `userTags` instead of `tags` in POST payload
- **tp_update_workout**: Write `userTags` instead of `tags` in PUT payload  
- **tp_copy_workout**: Read and write `userTags` instead of `tags` when copying workouts
- **Tests**: Updated assertion to verify `userTags` is sent, and `tags` is not present

## Verification

- All 338 existing tests pass
- Ruff linting clean
- Fix matches live TrainingPeaks API behavior confirmed by @lucahelps in #60

Closes #60
