### PR TITLE
fix(events): use singular /event/{id} endpoint for tp_delete_event

### DIFF
--- a/src/tp_mcp/tools/events.py
+++ b/src/tp_mcp/tools/events.py
@@ -427,7 +427,7 @@ async def tp_delete_event(event_id: str) -> dict[str, Any]:
                 "message": "Could not get athlete ID. Re-authenticate.",
             }
 
-        endpoint = f"/fitness/v6/athletes/{athlete_id}/events/{validated.workout_id}"
+        endpoint = f"/fitness/v6/athletes/{athlete_id}/event/{validated.workout_id}"
         response = await client.delete(endpoint)
 
         if response.is_error:

--- a/tests/test_tools/test_events.py
+++ b/tests/test_tools/test_events.py
@@ -125,6 +125,10 @@ class TestDeleteEvent:
             result = await tp_delete_event("501")
 
         assert result["success"] is True
+        # v6 uses singular /event/{id}; the plural form returns NOT_FOUND.
+        mock_instance.delete.assert_awaited_once_with(
+            "/fitness/v6/athletes/123/event/501"
+        )
 
 
 class TestCreateNote:


### PR DESCRIPTION
## Summary

`tp_delete_event` was hitting `DELETE /fitness/v6/athletes/{id}/events/{event_id}` (plural), which the v6 API rejects with NOT_FOUND. The correct endpoint is the singular `/event/{event_id}`, matching the singular form already used for create (after #57) and update.

Result: every call to `tp_delete_event` silently failed and the event stayed on the user's profile.

## Verification

Confirmed against the live TrainingPeaks API while smoke-testing #57:

```
DELETE /fitness/v6/athletes/{aid}/event/{eid}   → 200 OK, event removed
DELETE /fitness/v6/athletes/{aid}/events/{eid}  → NOT_FOUND
```

The existing unit test passed only because it mocked `client.delete` to always return success without asserting the URL — same mock-confirms-itself pattern caught in #54. Test now asserts the exact endpoint.

## Test plan

- [x] `pytest tests/test_tools/test_events.py` — 9 passed
- [x] Full suite — 339 passed
- [x] `ruff check` clean
- [x] Live API: deleted leftover smoke-test event via singular endpoint

## Related

- Builds on #57 which switched create+update to the singular `/event` form.