### PR TITLE
fix(auth): use personId for tp_auth_status athlete_id on coach accounts

### DIFF
--- a/src/tp_mcp/auth/validator.py
+++ b/src/tp_mcp/auth/validator.py
@@ -85,11 +85,11 @@ async def validate_auth(cookie: str) -> AuthResult:
                             user_data = user_resp.json().get("user", {})
                             email = user_data.get("email")
                             user_id = user_data.get("userId")
-                            athletes = user_data.get("athletes", [])
-                            if athletes:
-                                athlete_id = athletes[0].get("athleteId")
-                            if not athlete_id:
-                                athlete_id = user_data.get("personId")
+                            # personId is the authenticated user's own ID.
+                            # Don't read athletes[0]: on a coach account that
+                            # list is the coached roster, so athletes[0] is
+                            # another athlete, not the coach (#75).
+                            athlete_id = user_data.get("personId")
                     except httpx.RequestError:
                         pass  # User info is best-effort; auth is still valid
 

--- a/tests/test_auth/test_validator.py
+++ b/tests/test_auth/test_validator.py
@@ -29,7 +29,7 @@ class TestValidateAuth:
                 "email": "test@example.com",
                 "userId": 456,
                 "personId": 789,
-                "athletes": [{"athleteId": 123}],
+                "athletes": [{"athleteId": 789}],
             }
         }
 
@@ -42,8 +42,43 @@ class TestValidateAuth:
 
             assert result.is_valid is True
             assert result.status == AuthStatus.VALID
-            assert result.athlete_id == 123
+            assert result.athlete_id == 789
             assert result.email == "test@example.com"
+
+    @pytest.mark.asyncio
+    async def test_valid_auth_coach_account(self):
+        """athlete_id is the coach's own personId, not the first coached athlete (#75)."""
+        token_response = MagicMock()
+        token_response.status_code = 200
+        token_response.json.return_value = {
+            "success": True,
+            "token": {"access_token": "test_token", "expires_in": 3600},
+        }
+
+        # On a coach account, "athletes" is the coached roster, not the coach.
+        user_response = MagicMock()
+        user_response.status_code = 200
+        user_response.json.return_value = {
+            "user": {
+                "email": "coach@example.com",
+                "userId": 456,
+                "personId": 1000001,
+                "athletes": [
+                    {"athleteId": 2000001},
+                    {"athleteId": 2000002},
+                ],
+            }
+        }
+
+        with patch("tp_mcp.auth.validator.httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.get.side_effect = [token_response, user_response]
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await validate_auth("valid_cookie")
+
+            assert result.is_valid is True
+            assert result.athlete_id == 1000001
 
     @pytest.mark.asyncio
     async def test_expired_auth(self):


### PR DESCRIPTION
## Problem

On a coach account, `tp_auth_status` returned the `athleteId` of the first athlete in the coach's roster instead of the coach's own ID. `tp_get_profile` on the same session returned the correct ID, so the two disagreed.

## Cause

`validate_auth` in `auth/validator.py` read `athletes[0].athleteId` as the user's `athlete_id`. For a self-coached athlete that entry happens to be the user, so the bug stayed hidden. On a coach account the `athletes` list is the coached roster, so `athletes[0]` is somebody else.

## Fix

Drop the `athletes[0]` lookup and use `personId`, which is the authenticated user's own ID for both account types and matches what `tp_get_profile` returns.

The diagnosis and the suggested fix both came from @igor-batrakov in #75, credited via `Co-authored-by`.

## Tests

- Updated `test_valid_auth` to assert `athlete_id` resolves to `personId`.
- Added `test_valid_auth_coach_account`: a roster of other athletes, `athlete_id` still resolves to the coach's `personId`.
- Full suite green (340 passed).

Closes #75