### PR TITLE
fix(profile): honour the athlete override in tp_get_profile

### DIFF
--- a/src/tp_mcp/tools/profile.py
+++ b/src/tp_mcp/tools/profile.py
@@ -4,17 +4,62 @@ import logging
 from typing import Any
 
 from tp_mcp.client import TPClient
+from tp_mcp.client.context import athlete_override
 
 logger = logging.getLogger("tp-mcp")
+
+
+async def _targeted_athlete_profile(client: TPClient) -> dict[str, Any]:
+    """Build a profile for a coach's targeted roster athlete.
+
+    /users/v3/user only ever describes the logged-in user, so a targeted
+    athlete's profile is assembled from their entry in the coach's roster.
+    """
+    athlete_id = await client.ensure_athlete_id()
+    if not athlete_id:
+        return {
+            "isError": True,
+            "error_code": "NOT_FOUND",
+            "message": "Could not resolve that athlete. Check the name or ID against tp_list_athletes.",
+        }
+
+    user_data = await client._get_user_data()
+    athletes = user_data.get("athletes", []) if user_data else []
+    entry = next((a for a in athletes if a.get("athleteId") == athlete_id), None)
+    if entry is None:
+        return {
+            "isError": True,
+            "error_code": "NOT_FOUND",
+            "message": "That athlete is not in your roster.",
+        }
+
+    first = entry.get("firstName", "")
+    last = entry.get("lastName", "")
+    return {
+        "athlete_id": athlete_id,
+        "name": f"{first} {last}".strip(),
+        "email": entry.get("email"),
+        # Premium status belongs to the logged-in account, not a coached
+        # athlete, so it is not available when targeting one.
+        "account_type": None,
+    }
 
 
 async def tp_get_profile() -> dict[str, Any]:
     """Get TrainingPeaks athlete profile.
 
+    On a coach account, pass `athlete` to get a roster athlete's profile
+    instead of your own.
+
     Returns:
-        Dict with athlete_id, name, email, and account_type.
+        Dict with athlete_id, name, email, and account_type. account_type
+        is null when targeting a coached athlete.
     """
     async with TPClient() as client:
+        # Coach targeting a specific athlete: resolve via the roster (#68).
+        if athlete_override.get() is not None:
+            return await _targeted_athlete_profile(client)
+
         response = await client.get("/users/v3/user")
 
         if response.is_error:

--- a/tests/test_tools/test_profile.py
+++ b/tests/test_tools/test_profile.py
@@ -1,0 +1,122 @@
+"""Tests for tp_get_profile, including coach athlete targeting (#68)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tp_mcp.client.context import athlete_override
+from tp_mcp.client.http import APIResponse
+from tp_mcp.tools.profile import tp_get_profile
+
+OWN_USER_RESPONSE = {
+    "user": {
+        "personId": 100,
+        "firstName": "Stevan",
+        "lastName": "Coach",
+        "email": "stevan@example.com",
+        "settings": {"account": {"isPremium": True}},
+    }
+}
+
+ROSTER = [
+    {
+        "athleteId": 100,
+        "firstName": "Stevan",
+        "lastName": "Coach",
+        "email": "stevan@example.com",
+        "coachedBy": 100,
+    },
+    {
+        "athleteId": 201,
+        "firstName": "Charlotte",
+        "lastName": "Horton",
+        "email": "charlotte@example.com",
+        "coachedBy": 100,
+    },
+]
+
+
+def _mock_client(**methods):
+    """Patch profile.TPClient and return the mocked client instance."""
+    mock_instance = AsyncMock()
+    for name, value in methods.items():
+        setattr(mock_instance, name, AsyncMock(return_value=value))
+    return mock_instance
+
+
+class TestGetProfileSelf:
+    @pytest.mark.asyncio
+    async def test_no_override_returns_own_profile(self):
+        """With no athlete override, the logged-in user's profile is returned."""
+        instance = _mock_client(get=APIResponse(success=True, data=OWN_USER_RESPONSE))
+
+        with patch("tp_mcp.tools.profile.TPClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value = instance
+            result = await tp_get_profile()
+
+        assert result["athlete_id"] == 100
+        assert result["name"] == "Stevan Coach"
+        assert result["email"] == "stevan@example.com"
+        assert result["account_type"] == "premium"
+        instance.get.assert_awaited_once_with("/users/v3/user")
+
+
+class TestGetProfileTargetedAthlete:
+    @pytest.mark.asyncio
+    async def test_override_returns_targeted_athlete(self):
+        """With an athlete override, the targeted roster athlete is returned (#68)."""
+        instance = _mock_client(
+            ensure_athlete_id=201,
+            _get_user_data={"athletes": ROSTER},
+        )
+
+        with patch("tp_mcp.tools.profile.TPClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value = instance
+            token = athlete_override.set("Charlotte Horton")
+            try:
+                result = await tp_get_profile()
+            finally:
+                athlete_override.reset(token)
+
+        assert result["athlete_id"] == 201
+        assert result["name"] == "Charlotte Horton"
+        assert result["email"] == "charlotte@example.com"
+        # Premium status is not knowable for a coached athlete.
+        assert result["account_type"] is None
+        # The logged-in user's profile endpoint must not be the source here.
+        instance.get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unresolved_athlete_returns_not_found(self):
+        """An override that resolves to nothing returns NOT_FOUND, not the coach."""
+        instance = _mock_client(ensure_athlete_id=None)
+
+        with patch("tp_mcp.tools.profile.TPClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value = instance
+            token = athlete_override.set("Nobody")
+            try:
+                result = await tp_get_profile()
+            finally:
+                athlete_override.reset(token)
+
+        assert result["isError"] is True
+        assert result["error_code"] == "NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_athlete_not_in_roster_returns_not_found(self):
+        """A resolved ID absent from the roster returns NOT_FOUND."""
+        instance = _mock_client(
+            ensure_athlete_id=999,
+            _get_user_data={"athletes": ROSTER},
+        )
+
+        with patch("tp_mcp.tools.profile.TPClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value = instance
+            token = athlete_override.set("999")
+            try:
+                result = await tp_get_profile()
+            finally:
+                athlete_override.reset(token)
+
+        assert result["isError"] is True
+        assert result["error_code"] == "NOT_FOUND"


### PR DESCRIPTION
## Problem

On a coach account, `tp_get_profile(athlete=...)` returned the coach's own profile instead of the targeted athlete's. `tp_get_athlete_settings` honours the same parameter, so the two disagreed.

## Cause

`tp_get_profile` calls `/users/v3/user` directly. That endpoint always describes the logged-in user. The `athlete` parameter is injected into the schema and `call_tool` sets the `athlete_override` context var from it, but `tp_get_profile` never read it or went through `ensure_athlete_id()`.

## Fix

`/users/v3/user` has no per-athlete variant, so this isn't a drop-in endpoint swap. When an override is active, the profile is now built from the targeted athlete's entry in the coach's roster (`athletes[]`), the same data `tp_list_athletes` uses: `athlete_id`, `name`, `email`. `account_type` is `null` for a targeted athlete, since premium status belongs to the logged-in account. With no override, behaviour is unchanged.

Reported by @nateetongsiri in #68, credited via `Co-authored-by`.

## Tests

New `tests/test_tools/test_profile.py`:
- no override returns the logged-in user's profile, unchanged
- override returns the targeted roster athlete, and does not hit `/users/v3/user`
- an unresolved athlete returns `NOT_FOUND` rather than silently falling back to the coach
- a resolved ID absent from the roster returns `NOT_FOUND`

Full suite green (369 passed).

Closes #68