### PR TITLE
fix(workouts): make tp_add_workout_comment return v6 comment shape

### DIFF
--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -1014,7 +1014,8 @@ async def tp_add_workout_comment(workout_id: str, comment: str) -> dict[str, Any
         comment: The comment text.
 
     Returns:
-        Dict with confirmation or error.
+        Dict with confirmation and current workoutComments from a follow-up v6 GET.
+        If the follow-up GET fails, comments is [] and comments_fetch_failed is True.
     """
     try:
         validated = WorkoutIdInput(workout_id=workout_id)
@@ -1056,7 +1057,7 @@ async def tp_add_workout_comment(workout_id: str, comment: str) -> dict[str, Any
         get_endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{validated.workout_id}"
         get_response = await client.get(get_endpoint)
         if get_response.is_error:
-            return {"success": True, "message": "Comment added.", "comments": [], "count": 0}
+            return {"success": True, "message": "Comment added.", "comments": [], "count": 0, "comments_fetch_failed": True}
 
         comments = (get_response.data or {}).get("workoutComments") or []
         return {

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -1057,7 +1057,13 @@ async def tp_add_workout_comment(workout_id: str, comment: str) -> dict[str, Any
         get_endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{validated.workout_id}"
         get_response = await client.get(get_endpoint)
         if get_response.is_error:
-            return {"success": True, "message": "Comment added.", "comments": [], "count": 0, "comments_fetch_failed": True}
+            return {
+                "success": True,
+                "message": "Comment added.",
+                "comments": [],
+                "count": 0,
+                "comments_fetch_failed": True,
+            }
 
         comments = (get_response.data or {}).get("workoutComments") or []
         return {

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -1053,8 +1053,12 @@ async def tp_add_workout_comment(workout_id: str, comment: str) -> dict[str, Any
                 "message": response.message,
             }
 
-        # v2 POST returns a flat list; v6 GET returns {workoutComments: [...]} — shapes differ
-        comments = response.data if isinstance(response.data, list) else []
+        get_endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts/{validated.workout_id}"
+        get_response = await client.get(get_endpoint)
+        if get_response.is_error:
+            return {"success": True, "message": "Comment added.", "comments": [], "count": 0}
+
+        comments = (get_response.data or {}).get("workoutComments") or []
         return {
             "success": True,
             "message": "Comment added.",

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -816,19 +816,27 @@ class TestWorkoutComments:
 
     @pytest.mark.asyncio
     async def test_add_comment_success(self):
-        response = APIResponse(success=True, data=None)
+        post_response = APIResponse(success=True, data=None)
+        comments_data = [{"id": 1, "comment": "Nice ride!", "isCoach": False}]
+        get_response = APIResponse(
+            success=True, data={"workoutId": 1001, "workoutComments": comments_data}
+        )
 
         with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
-            mock_instance.post = AsyncMock(return_value=response)
+            mock_instance.post = AsyncMock(return_value=post_response)
+            mock_instance.get = AsyncMock(return_value=get_response)
             mock_client.return_value.__aenter__.return_value = mock_instance
 
             result = await tp_add_workout_comment("1001", "Nice ride!")
 
         assert result["success"] is True
+        assert result["count"] == 1
+        assert result["comments"] == comments_data
         payload = mock_instance.post.call_args[1]["json"]
         assert payload["value"] == "Nice ride!"
+        mock_instance.get.assert_called_once_with("/fitness/v6/athletes/123/workouts/1001")
 
     @pytest.mark.asyncio
     async def test_add_empty_comment_rejected(self):

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -839,6 +839,25 @@ class TestWorkoutComments:
         mock_instance.get.assert_called_once_with("/fitness/v6/athletes/123/workouts/1001")
 
     @pytest.mark.asyncio
+    async def test_add_comment_get_fails_gracefully(self):
+        post_response = APIResponse(success=True, data=None)
+        get_response = APIResponse(success=False, error_code=ErrorCode.API_ERROR, message="timeout")
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=post_response)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_add_workout_comment("1001", "Nice ride!")
+
+        assert result["success"] is True
+        assert result["comments"] == []
+        assert result["count"] == 0
+        assert result["comments_fetch_failed"] is True
+
+    @pytest.mark.asyncio
     async def test_add_empty_comment_rejected(self):
         result = await tp_add_workout_comment("1001", "")
         assert result["isError"] is True


### PR DESCRIPTION
Closes #77.

## Summary

- `tp_add_workout_comment` now does a v6 GET after a successful POST and returns `workoutComments` from the workout detail response — the same source used by `tp_get_workout_comments`
- Both tools now always return comments with the same shape: `{ id, comment, dateCreated, isCoach, ... }`
- The misleading code comment claiming the shapes differ (from PR #74) is removed; HAR captures confirm v2 POST and v6 GET return identical comment objects

## Notes

The v2 POST endpoint is still used for writing (no v6 write endpoint exists in HAR captures), but the response is discarded in favour of a fresh v6 read to guarantee shape consistency.

## Test plan

- [ ] `TestWorkoutComments::test_add_comment_success` updated to mock the follow-up GET and assert the returned `comments` list matches the v6 response
- [ ] All 353 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)