### PR TITLE
feat(notes): add tp_list_notes to list calendar notes by date range

### DIFF
--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -62,6 +62,7 @@ from tp_mcp.tools import (
     tp_get_workout_types,
     tp_get_workouts,
     tp_list_athletes,
+    tp_list_notes,
     tp_log_metrics,
     tp_pair_workout,
     tp_refresh_auth,
@@ -825,6 +826,18 @@ TOOLS = [
         },
     ),
     Tool(
+        name="tp_list_notes",
+        description="List calendar notes for a date range.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "start_date": {"type": "string", "description": "Start date (YYYY-MM-DD)"},
+                "end_date": {"type": "string", "description": "End date (YYYY-MM-DD)"},
+            },
+            "required": ["start_date", "end_date"],
+        },
+    ),
+    Tool(
         name="tp_get_availability",
         description="Get availability entries for a date range.",
         inputSchema={
@@ -1284,6 +1297,10 @@ async def _h_get_note_comments(args): return await tp_get_note_comments(note_id=
 @_handler("tp_add_note_comment")
 async def _h_add_note_comment(args):
     return await tp_add_note_comment(note_id=args["note_id"], comment=args["comment"])
+
+@_handler("tp_list_notes")
+async def _h_list_notes(args):
+    return await tp_list_notes(start_date=args["start_date"], end_date=args["end_date"])
 
 @_handler("tp_get_availability")
 async def _h_get_avail(args):

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -23,6 +23,7 @@ from tp_mcp.tools.events import (
     tp_get_next_event,
     tp_get_note,
     tp_get_note_comments,
+    tp_list_notes,
     tp_update_event,
     tp_update_note,
 )
@@ -108,6 +109,7 @@ __all__ = [
     "tp_get_next_event",
     "tp_get_note",
     "tp_get_note_comments",
+    "tp_list_notes",
     "tp_get_nutrition",
     "tp_get_peaks",
     "tp_get_pool_length_settings",

--- a/src/tp_mcp/tools/events.py
+++ b/src/tp_mcp/tools/events.py
@@ -649,14 +649,14 @@ async def tp_list_notes(start_date: str, end_date: str) -> dict[str, Any]:
         for d in raw_notes:
             if not isinstance(d, dict):
                 continue
-            note_date_str = d.get("noteDate", "")
-            if note_date_str and "T" in note_date_str:
-                note_date_str = note_date_str.split("T", 1)[0]
+            raw_date = d.get("noteDate")
+            if isinstance(raw_date, str) and "T" in raw_date:
+                raw_date = raw_date.split("T", 1)[0]
             notes.append({
                 "id": d.get("id") or d.get("calendarNoteId"),
                 "title": d.get("title"),
                 "description": d.get("description"),
-                "date": note_date_str,
+                "date": raw_date or None,
                 "is_hidden": d.get("isHidden", False),
                 "comment_count": d.get("commentCount", 0),
                 "created_date": d.get("createdDate"),
@@ -665,7 +665,11 @@ async def tp_list_notes(start_date: str, end_date: str) -> dict[str, Any]:
                 "attachments": d.get("attachments") or [],
             })
 
-        return {"notes": notes, "count": len(notes), "date_range": {"start": start_date, "end": end_date}}
+        return {
+            "notes": notes,
+            "count": len(notes),
+            "date_range": {"start": validated.start_date.isoformat(), "end": validated.end_date.isoformat()},
+        }
 
 
 async def tp_update_note(

--- a/src/tp_mcp/tools/events.py
+++ b/src/tp_mcp/tools/events.py
@@ -630,11 +630,10 @@ async def tp_list_notes(start_date: str, end_date: str) -> dict[str, Any]:
             return {"isError": True, "error_code": "AUTH_INVALID",
                     "message": "Could not get athlete ID. Re-authenticate."}
 
+        start_str = validated.start_date.isoformat()
+        end_str = validated.end_date.isoformat()
         # v1 only supports POST/DELETE by ID; range listing requires v2.
-        endpoint = (
-            f"/fitness/v2/athletes/{athlete_id}/calendarNote"
-            f"/{validated.start_date}/{validated.end_date}"
-        )
+        endpoint = f"/fitness/v2/athletes/{athlete_id}/calendarNote/{start_str}/{end_str}"
         response = await client.get(endpoint)
 
         if response.is_error:
@@ -668,7 +667,7 @@ async def tp_list_notes(start_date: str, end_date: str) -> dict[str, Any]:
         return {
             "notes": notes,
             "count": len(notes),
-            "date_range": {"start": validated.start_date.isoformat(), "end": validated.end_date.isoformat()},
+            "date_range": {"start": start_str, "end": end_str},
         }
 
 

--- a/src/tp_mcp/tools/events.py
+++ b/src/tp_mcp/tools/events.py
@@ -630,6 +630,7 @@ async def tp_list_notes(start_date: str, end_date: str) -> dict[str, Any]:
             return {"isError": True, "error_code": "AUTH_INVALID",
                     "message": "Could not get athlete ID. Re-authenticate."}
 
+        # v1 only supports POST/DELETE by ID; range listing requires v2.
         endpoint = (
             f"/fitness/v2/athletes/{athlete_id}/calendarNote"
             f"/{validated.start_date}/{validated.end_date}"
@@ -646,11 +647,13 @@ async def tp_list_notes(start_date: str, end_date: str) -> dict[str, Any]:
         raw_notes = response.data if isinstance(response.data, list) else []
         notes = []
         for d in raw_notes:
+            if not isinstance(d, dict):
+                continue
             note_date_str = d.get("noteDate", "")
             if note_date_str and "T" in note_date_str:
-                note_date_str = note_date_str.split("T")[0]
+                note_date_str = note_date_str.split("T", 1)[0]
             notes.append({
-                "id": d.get("id"),
+                "id": d.get("id") or d.get("calendarNoteId"),
                 "title": d.get("title"),
                 "description": d.get("description"),
                 "date": note_date_str,
@@ -658,9 +661,11 @@ async def tp_list_notes(start_date: str, end_date: str) -> dict[str, Any]:
                 "comment_count": d.get("commentCount", 0),
                 "created_date": d.get("createdDate"),
                 "modified_date": d.get("modifiedDate"),
+                "owner_id": d.get("ownerId"),
+                "attachments": d.get("attachments") or [],
             })
 
-        return {"notes": notes, "count": len(notes)}
+        return {"notes": notes, "count": len(notes), "date_range": {"start": start_date, "end": end_date}}
 
 
 async def tp_update_note(

--- a/src/tp_mcp/tools/events.py
+++ b/src/tp_mcp/tools/events.py
@@ -608,6 +608,61 @@ async def tp_get_note(note_id: str) -> dict[str, Any]:
         }
 
 
+async def tp_list_notes(start_date: str, end_date: str) -> dict[str, Any]:
+    """List calendar notes for a date range.
+
+    Args:
+        start_date: Range start (YYYY-MM-DD).
+        end_date: Range end (YYYY-MM-DD).
+
+    Returns:
+        Dict with list of notes or error.
+    """
+    try:
+        validated = DateRangeInput(start_date=start_date, end_date=end_date)
+    except (ValidationError, ValueError) as e:
+        msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
+        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": msg}
+
+    async with TPClient() as client:
+        athlete_id = await client.ensure_athlete_id()
+        if not athlete_id:
+            return {"isError": True, "error_code": "AUTH_INVALID",
+                    "message": "Could not get athlete ID. Re-authenticate."}
+
+        endpoint = (
+            f"/fitness/v2/athletes/{athlete_id}/calendarNote"
+            f"/{validated.start_date}/{validated.end_date}"
+        )
+        response = await client.get(endpoint)
+
+        if response.is_error:
+            return {
+                "isError": True,
+                "error_code": response.error_code.value if response.error_code else "API_ERROR",
+                "message": response.message,
+            }
+
+        raw_notes = response.data if isinstance(response.data, list) else []
+        notes = []
+        for d in raw_notes:
+            note_date_str = d.get("noteDate", "")
+            if note_date_str and "T" in note_date_str:
+                note_date_str = note_date_str.split("T")[0]
+            notes.append({
+                "id": d.get("id"),
+                "title": d.get("title"),
+                "description": d.get("description"),
+                "date": note_date_str,
+                "is_hidden": d.get("isHidden", False),
+                "comment_count": d.get("commentCount", 0),
+                "created_date": d.get("createdDate"),
+                "modified_date": d.get("modifiedDate"),
+            })
+
+        return {"notes": notes, "count": len(notes)}
+
+
 async def tp_update_note(
     note_id: str,
     title: str | None = None,

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -83,6 +83,7 @@ class TestListTools:
             "tp_update_note",
             "tp_get_note_comments",
             "tp_add_note_comment",
+            "tp_list_notes",
             "tp_get_availability",
             "tp_create_availability",
             "tp_delete_availability",

--- a/tests/test_tools/test_events.py
+++ b/tests/test_tools/test_events.py
@@ -467,6 +467,7 @@ class TestListNotes:
 
         assert result["count"] == 0
         assert result["notes"] == []
+        assert result["date_range"] == {"start": "2026-01-01", "end": "2026-01-07"}
 
     @pytest.mark.asyncio
     async def test_list_notes_invalid_date(self):
@@ -523,3 +524,17 @@ class TestListNotes:
             result = await tp_list_notes(start_date="2026-05-01", end_date="2026-05-31")
 
         assert result["notes"][0]["id"] == 999
+
+    @pytest.mark.asyncio
+    async def test_list_notes_missing_note_date(self):
+        data = [{"id": 1, "title": "No date"}]
+        response = APIResponse(success=True, data=data)
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=1463609)
+            mock_instance.get = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_list_notes(start_date="2026-05-01", end_date="2026-05-31")
+
+        assert result["notes"][0]["date"] is None

--- a/tests/test_tools/test_events.py
+++ b/tests/test_tools/test_events.py
@@ -440,12 +440,15 @@ class TestListNotes:
 
         assert result["count"] == 2
         assert len(result["notes"]) == 2
+        assert result["date_range"] == {"start": "2026-05-01", "end": "2026-05-31"}
         first = result["notes"][0]
         assert first["id"] == 83073469
         assert first["title"] == "Zwei Tests"
         assert first["date"] == "2026-05-07"
         assert first["is_hidden"] is False
         assert first["comment_count"] == 0
+        assert first["owner_id"] == 1463609
+        assert first["attachments"] == []
         second = result["notes"][1]
         assert second["id"] == 87921017
         assert second["is_hidden"] is True
@@ -506,3 +509,17 @@ class TestListNotes:
         assert "/fitness/v2/" in called_endpoint
         assert "2026-05-01" in called_endpoint
         assert "2026-05-31" in called_endpoint
+
+    @pytest.mark.asyncio
+    async def test_list_notes_calendar_note_id_fallback(self):
+        data = [{"calendarNoteId": 999, "title": "Fallback", "noteDate": "2026-05-10T00:00:00"}]
+        response = APIResponse(success=True, data=data)
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=1463609)
+            mock_instance.get = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_list_notes(start_date="2026-05-01", end_date="2026-05-31")
+
+        assert result["notes"][0]["id"] == 999

--- a/tests/test_tools/test_events.py
+++ b/tests/test_tools/test_events.py
@@ -17,6 +17,7 @@ from tp_mcp.tools.events import (
     tp_get_next_event,
     tp_get_note,
     tp_get_note_comments,
+    tp_list_notes,
     tp_update_note,
 )
 
@@ -390,3 +391,118 @@ class TestAddNoteComment:
         result = await tp_add_note_comment(note_id="abc", comment="test")
         assert result["isError"] is True
         assert result["error_code"] == "VALIDATION_ERROR"
+
+
+class TestListNotes:
+    NOTE_DATA = [
+        {
+            "id": 83073469,
+            "title": "Zwei Tests",
+            "description": "Du brauchst nur einen der beiden Tests absolvieren.",
+            "noteDate": "2026-05-07T00:00:00",
+            "createdDate": "2026-03-03T07:21:22",
+            "modifiedDate": "2026-03-03T07:21:22",
+            "athleteId": 1463609,
+            "isHidden": False,
+            "commentCount": 0,
+            "ownerId": 1463609,
+            "appliedPlanId": 1024010,
+            "parentPlanNoteId": 231128,
+            "attachments": [],
+        },
+        {
+            "id": 87921017,
+            "title": "Spitzenwoche",
+            "description": None,
+            "noteDate": "2026-05-14T00:00:00",
+            "createdDate": "2026-05-01T08:00:00",
+            "modifiedDate": "2026-05-01T08:00:00",
+            "athleteId": 1463609,
+            "isHidden": True,
+            "commentCount": 2,
+            "ownerId": 1463609,
+            "appliedPlanId": 0,
+            "parentPlanNoteId": 0,
+            "attachments": [],
+        },
+    ]
+
+    @pytest.mark.asyncio
+    async def test_list_notes_success(self):
+        response = APIResponse(success=True, data=self.NOTE_DATA)
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=1463609)
+            mock_instance.get = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_list_notes(start_date="2026-05-01", end_date="2026-05-31")
+
+        assert result["count"] == 2
+        assert len(result["notes"]) == 2
+        first = result["notes"][0]
+        assert first["id"] == 83073469
+        assert first["title"] == "Zwei Tests"
+        assert first["date"] == "2026-05-07"
+        assert first["is_hidden"] is False
+        assert first["comment_count"] == 0
+        second = result["notes"][1]
+        assert second["id"] == 87921017
+        assert second["is_hidden"] is True
+        assert second["comment_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_list_notes_empty(self):
+        response = APIResponse(success=True, data=[])
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=1463609)
+            mock_instance.get = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_list_notes(start_date="2026-01-01", end_date="2026-01-07")
+
+        assert result["count"] == 0
+        assert result["notes"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_notes_invalid_date(self):
+        result = await tp_list_notes(start_date="not-a-date", end_date="2026-05-31")
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_list_notes_end_before_start(self):
+        result = await tp_list_notes(start_date="2026-05-31", end_date="2026-05-01")
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_list_notes_api_error(self):
+        response = APIResponse(success=False, error_code=ErrorCode.NOT_FOUND, message="Not found")
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=1463609)
+            mock_instance.get = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_list_notes(start_date="2026-05-01", end_date="2026-05-31")
+
+        assert result["isError"] is True
+        assert result["error_code"] == "NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_list_notes_uses_v2_endpoint(self):
+        response = APIResponse(success=True, data=[])
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=1463609)
+            mock_instance.get = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            await tp_list_notes(start_date="2026-05-01", end_date="2026-05-31")
+
+        called_endpoint = mock_instance.get.call_args[0][0]
+        assert "/fitness/v2/" in called_endpoint
+        assert "2026-05-01" in called_endpoint
+        assert "2026-05-31" in called_endpoint


### PR DESCRIPTION
## Summary

- Adds `tp_list_notes(start_date, end_date)` tool to list calendar notes for a date range
- Uses the v2 API endpoint: `GET /fitness/v2/athletes/{id}/calendarNote/{start}/{end}` (previously only v1 endpoints were used for notes)
- Returns `{ notes: [...], count: N }` with fields: `id`, `title`, `description`, `date`, `is_hidden`, `comment_count`, `created_date`, `modified_date`

## Test plan

- [x] 6 unit tests in `TestListNotes`: success with multiple notes, empty result, invalid date, end before start, API error, explicit v2 endpoint check
- [x] Tool registered in `test_server_functional.py` tool count assertion
- [x] 375 tests passing, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)