### PR TITLE
feat(isHidden): Add isHidden option to create/update a workout and hide it for athlete (coach mode)

### DIFF
--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -229,7 +229,7 @@ TOOLS = [
                 "tags": {"type": "string", "description": "Optional comma-separated tags"},
                 "feeling": {"type": "integer", "description": WORKOUT_FEELING_DESCRIPTION},
                 "rpe": {"type": "integer", "description": WORKOUT_RPE_DESCRIPTION},
-                "isHidden": {
+                "is_hidden": {
                     "type": "boolean",
                     "description": "Whether to hide the workout",
                     "default": False,

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -260,17 +260,12 @@ TOOLS = [
                 "tags": {"type": "string"},
                 "athlete_comment": {"type": "string"},
                 "coach_comment": {"type": "string"},
-<<<<<<< HEAD
                 "feeling": {"type": "integer", "description": WORKOUT_FEELING_DESCRIPTION},
                 "rpe": {"type": "integer", "description": WORKOUT_RPE_DESCRIPTION},
-=======
-                "feeling": {"type": "integer", "description": "0-10"},
-                "rpe": {"type": "integer", "description": "1-10"},
                 "is_hidden": {
                     "type": "boolean",
                     "description": "Whether to hide the workout"
                 },
->>>>>>> 7b44dca (feat: Add isHidden option to create/update a workout and hide it for athlete (coach mode))
                 "structure": {
                     "type": ["object", "string"],
                     "description": STRUCTURE_DESCRIPTION,

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -266,7 +266,7 @@ TOOLS = [
 =======
                 "feeling": {"type": "integer", "description": "0-10"},
                 "rpe": {"type": "integer", "description": "1-10"},
-                "isHidden": {
+                "is_hidden": {
                     "type": "boolean",
                     "description": "Whether to hide the workout",
                     "default": False,
@@ -1085,7 +1085,7 @@ async def _h_create_workout(args):
         structured_workout=args.get("structured_workout"),
         subtype_id=args.get("subtype_id"), tags=args.get("tags"),
         feeling=args.get("feeling"), rpe=args.get("rpe"),
-        is_hidden=args.get("isHidden", False),
+        is_hidden=args.get("is_hidden", False),
     )
 
 @_handler("tp_update_workout")
@@ -1100,7 +1100,7 @@ async def _h_update_workout(args):
         coach_comment=args.get("coach_comment"), feeling=args.get("feeling"),
         rpe=args.get("rpe"), structure=args.get("structure"),
         structured_workout=args.get("structured_workout"),
-        is_hidden=args.get("isHidden", False),
+        is_hidden=args.get("is_hidden", False),
     )
 
 @_handler("tp_delete_workout")

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -229,6 +229,11 @@ TOOLS = [
                 "tags": {"type": "string", "description": "Optional comma-separated tags"},
                 "feeling": {"type": "integer", "description": WORKOUT_FEELING_DESCRIPTION},
                 "rpe": {"type": "integer", "description": WORKOUT_RPE_DESCRIPTION},
+                "isHidden": {
+                    "type": "boolean",
+                    "description": "Whether to hide the workout",
+                    "default": False,
+                },
             },
             "required": ["date", "sport", "title"],
         },
@@ -255,8 +260,18 @@ TOOLS = [
                 "tags": {"type": "string"},
                 "athlete_comment": {"type": "string"},
                 "coach_comment": {"type": "string"},
+<<<<<<< HEAD
                 "feeling": {"type": "integer", "description": WORKOUT_FEELING_DESCRIPTION},
                 "rpe": {"type": "integer", "description": WORKOUT_RPE_DESCRIPTION},
+=======
+                "feeling": {"type": "integer", "description": "0-10"},
+                "rpe": {"type": "integer", "description": "1-10"},
+                "isHidden": {
+                    "type": "boolean",
+                    "description": "Whether to hide the workout",
+                    "default": False,
+                },
+>>>>>>> 7b44dca (feat: Add isHidden option to create/update a workout and hide it for athlete (coach mode))
                 "structure": {
                     "type": ["object", "string"],
                     "description": STRUCTURE_DESCRIPTION,
@@ -1070,6 +1085,7 @@ async def _h_create_workout(args):
         structured_workout=args.get("structured_workout"),
         subtype_id=args.get("subtype_id"), tags=args.get("tags"),
         feeling=args.get("feeling"), rpe=args.get("rpe"),
+        is_hidden=args.get("isHidden", False),
     )
 
 @_handler("tp_update_workout")
@@ -1084,6 +1100,7 @@ async def _h_update_workout(args):
         coach_comment=args.get("coach_comment"), feeling=args.get("feeling"),
         rpe=args.get("rpe"), structure=args.get("structure"),
         structured_workout=args.get("structured_workout"),
+        is_hidden=args.get("isHidden", False),
     )
 
 @_handler("tp_delete_workout")

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -268,8 +268,7 @@ TOOLS = [
                 "rpe": {"type": "integer", "description": "1-10"},
                 "is_hidden": {
                     "type": "boolean",
-                    "description": "Whether to hide the workout",
-                    "default": False,
+                    "description": "Whether to hide the workout"
                 },
 >>>>>>> 7b44dca (feat: Add isHidden option to create/update a workout and hide it for athlete (coach mode))
                 "structure": {
@@ -1100,7 +1099,7 @@ async def _h_update_workout(args):
         coach_comment=args.get("coach_comment"), feeling=args.get("feeling"),
         rpe=args.get("rpe"), structure=args.get("structure"),
         structured_workout=args.get("structured_workout"),
-        is_hidden=args.get("is_hidden", False),
+        is_hidden=args.get("is_hidden"),
     )
 
 @_handler("tp_delete_workout")

--- a/src/tp_mcp/tools/_validation.py
+++ b/src/tp_mcp/tools/_validation.py
@@ -67,7 +67,7 @@ class CreateWorkoutInput(BaseModel):
     tags: str | None = Field(default=None, max_length=500)
     feeling: int | None = Field(default=None, ge=0, le=10)
     rpe: int | None = Field(default=None, ge=0, le=10)
-    is_hidden: bool = False
+    is_hidden: bool | None = None
 
     @field_validator("date", mode="before")
     @classmethod
@@ -120,7 +120,7 @@ class UpdateWorkoutInput(BaseModel):
     coach_comment: str | None = None
     feeling: int | None = Field(default=None, ge=0, le=10)
     rpe: int | None = Field(default=None, ge=0, le=10)
-    is_hidden: bool = False
+    is_hidden: bool | None = None
     structure: Any = None
     structured_workout: Any = None
 

--- a/src/tp_mcp/tools/_validation.py
+++ b/src/tp_mcp/tools/_validation.py
@@ -67,6 +67,7 @@ class CreateWorkoutInput(BaseModel):
     tags: str | None = Field(default=None, max_length=500)
     feeling: int | None = Field(default=None, ge=0, le=10)
     rpe: int | None = Field(default=None, ge=0, le=10)
+    is_hidden: bool = False
 
     @field_validator("date", mode="before")
     @classmethod
@@ -119,6 +120,7 @@ class UpdateWorkoutInput(BaseModel):
     coach_comment: str | None = None
     feeling: int | None = Field(default=None, ge=0, le=10)
     rpe: int | None = Field(default=None, ge=0, le=10)
+    is_hidden: bool = False
     structure: Any = None
     structured_workout: Any = None
 

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -410,7 +410,7 @@ async def tp_create_workout(
         structured_workout: Optional native TP structured workout payload.
         subtype_id: Optional workout subtype ID (e.g. Road Bike=3).
         tags: Optional comma-separated tags string.
-        feeling: Optional feeling score (0-10).
+        feeling: Optional TrainingPeaks feeling value (0-10).
         rpe: Optional RPE score (1-10).
         is_hidden: Optional to hide the workout to the athlete.
 

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -394,7 +394,7 @@ async def tp_create_workout(
     tags: str | None = None,
     feeling: int | None = None,
     rpe: int | None = None,
-    is_hidden: bool = False,
+    is_hidden: bool | None = None,
 ) -> dict[str, Any]:
     """Create a planned workout.
 
@@ -410,9 +410,9 @@ async def tp_create_workout(
         structured_workout: Optional native TP structured workout payload.
         subtype_id: Optional workout subtype ID (e.g. Road Bike=3).
         tags: Optional comma-separated tags string.
-        feeling: Optional TrainingPeaks feeling value (0-10).
-        rpe: Optional RPE score (0-10).
-        is_hidden: Whether to hide the workout. Defaults to False.
+        feeling: Optional feeling score (0-10).
+        rpe: Optional RPE score (1-10).
+        is_hidden: Optional to hide the workout to the athlete.
 
     Returns:
         Dict with created workout details or error.
@@ -491,7 +491,7 @@ async def tp_create_workout(
             "workoutTypeFamilyId": family_id,
             "workoutTypeValueId": type_id,
             "title": params.title,
-            "isHidden": params.is_hidden,
+            "isHidden": params.is_hidden if params.is_hidden is not None else False,
         }
         if isinstance(params.date, datetime_type):
             payload["startTimePlanned"] = _format_start_time_planned(params.date)
@@ -562,7 +562,7 @@ async def tp_update_workout(
     coach_comment: str | None = None,
     feeling: int | None = None,
     rpe: int | None = None,
-    is_hidden: bool = False,
+    is_hidden: bool | None = None,
     structure: dict[str, Any] | str | None = None,
     structured_workout: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -697,7 +697,8 @@ async def tp_update_workout(
             existing["feeling"] = params.feeling
         if params.rpe is not None:
             existing["rpe"] = params.rpe
-        existing["isHidden"] = params.is_hidden
+        if params.is_hidden is not None:
+            existing["isHidden"] = params.is_hidden
         if params.structure is not None:
             existing["structure"] = json.dumps(structure_payload.wire_structure)
             if effective_if is not None:

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -394,6 +394,7 @@ async def tp_create_workout(
     tags: str | None = None,
     feeling: int | None = None,
     rpe: int | None = None,
+    is_hidden: bool = False,
 ) -> dict[str, Any]:
     """Create a planned workout.
 
@@ -411,6 +412,7 @@ async def tp_create_workout(
         tags: Optional comma-separated tags string.
         feeling: Optional TrainingPeaks feeling value (0-10).
         rpe: Optional RPE score (0-10).
+        is_hidden: Whether to hide the workout. Defaults to False.
 
     Returns:
         Dict with created workout details or error.
@@ -430,6 +432,7 @@ async def tp_create_workout(
             tags=tags,
             feeling=feeling,
             rpe=rpe,
+            is_hidden=is_hidden,
         )
     except (ValidationError, ValueError) as e:
         msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
@@ -488,6 +491,7 @@ async def tp_create_workout(
             "workoutTypeFamilyId": family_id,
             "workoutTypeValueId": type_id,
             "title": params.title,
+            "isHidden": params.is_hidden,
         }
         if isinstance(params.date, datetime_type):
             payload["startTimePlanned"] = _format_start_time_planned(params.date)
@@ -558,6 +562,7 @@ async def tp_update_workout(
     coach_comment: str | None = None,
     feeling: int | None = None,
     rpe: int | None = None,
+    is_hidden: bool = False,
     structure: dict[str, Any] | str | None = None,
     structured_workout: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -587,6 +592,7 @@ async def tp_update_workout(
             coach_comment=coach_comment,
             feeling=feeling,
             rpe=rpe,
+            is_hidden=is_hidden,
             structure=structure,
             structured_workout=structured_workout,
         )
@@ -691,6 +697,7 @@ async def tp_update_workout(
             existing["feeling"] = params.feeling
         if params.rpe is not None:
             existing["rpe"] = params.rpe
+        existing["isHidden"] = params.is_hidden
         if params.structure is not None:
             existing["structure"] = json.dumps(structure_payload.wire_structure)
             if effective_if is not None:

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -116,12 +116,12 @@ class TestListTools:
         assert "distance_km" in props
         assert "tss_planned" in props
         assert "structured_workout" in props
-        assert "is_hidden" in props
+        assert "isHidden" in props
         assert "distance_km" not in cw.inputSchema["required"]
         assert "tss_planned" not in cw.inputSchema["required"]
         assert "structured_workout" not in cw.inputSchema["required"]
-        assert "is_hidden" not in cw.inputSchema["required"]
-        assert props["is_hidden"]["default"] is False
+        assert "isHidden" not in cw.inputSchema["required"]
+        assert props["isHidden"]["default"] is False
 
     @pytest.mark.asyncio
     async def test_update_workout_schema_includes_structured_workout(self):

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -116,12 +116,12 @@ class TestListTools:
         assert "distance_km" in props
         assert "tss_planned" in props
         assert "structured_workout" in props
-        assert "isHidden" in props
+        assert "is_hidden" in props
         assert "distance_km" not in cw.inputSchema["required"]
         assert "tss_planned" not in cw.inputSchema["required"]
         assert "structured_workout" not in cw.inputSchema["required"]
-        assert "isHidden" not in cw.inputSchema["required"]
-        assert props["isHidden"]["default"] is False
+        assert "is_hidden" not in cw.inputSchema["required"]
+        assert props["is_hidden"]["default"] is False
 
     @pytest.mark.asyncio
     async def test_update_workout_schema_includes_structured_workout(self):
@@ -402,6 +402,37 @@ class TestCreateWorkoutDispatch:
         payload = mock_instance.post.call_args[1]["json"]
         assert "distancePlanned" not in payload
         assert "tssPlanned" not in payload
+
+    @pytest.mark.asyncio
+    async def test_hidden_reaches_api_payload(self):
+        """The public is_hidden argument should map to TrainingPeaks isHidden."""
+        create_response = APIResponse(
+            success=True,
+            data={"workoutId": 9004, "title": "Hidden Run", "workoutDay": "2026-01-10T00:00:00"},
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=create_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = _parse_result(
+                await call_tool(
+                    "tp_create_workout",
+                    {
+                        "date": "2026-01-10",
+                        "sport": "Run",
+                        "title": "Hidden Run",
+                        "duration_minutes": 45,
+                        "is_hidden": True,
+                    },
+                )
+            )
+
+        assert result["success"] is True
+        payload = mock_instance.post.call_args[1]["json"]
+        assert payload["isHidden"] is True
 
     @pytest.mark.asyncio
     async def test_datetime_date_reaches_api_payload(self):

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -116,9 +116,12 @@ class TestListTools:
         assert "distance_km" in props
         assert "tss_planned" in props
         assert "structured_workout" in props
+        assert "isHidden" in props
         assert "distance_km" not in cw.inputSchema["required"]
         assert "tss_planned" not in cw.inputSchema["required"]
         assert "structured_workout" not in cw.inputSchema["required"]
+        assert "isHidden" not in cw.inputSchema["required"]
+        assert props["isHidden"]["default"] is False
 
     @pytest.mark.asyncio
     async def test_update_workout_schema_includes_structured_workout(self):
@@ -127,6 +130,8 @@ class TestListTools:
         props = uw.inputSchema["properties"]
         assert "structure" in props
         assert "structured_workout" in props
+        assert "isHidden" in props
+        assert props["isHidden"]["default"] is False
 
     @pytest.mark.asyncio
     async def test_workout_tools_schema_advertises_datetime_dates(self):

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -116,12 +116,12 @@ class TestListTools:
         assert "distance_km" in props
         assert "tss_planned" in props
         assert "structured_workout" in props
-        assert "isHidden" in props
+        assert "is_hidden" in props
         assert "distance_km" not in cw.inputSchema["required"]
         assert "tss_planned" not in cw.inputSchema["required"]
         assert "structured_workout" not in cw.inputSchema["required"]
-        assert "isHidden" not in cw.inputSchema["required"]
-        assert props["isHidden"]["default"] is False
+        assert "is_hidden" not in cw.inputSchema["required"]
+        assert props["is_hidden"]["default"] is False
 
     @pytest.mark.asyncio
     async def test_update_workout_schema_includes_structured_workout(self):
@@ -130,8 +130,8 @@ class TestListTools:
         props = uw.inputSchema["properties"]
         assert "structure" in props
         assert "structured_workout" in props
-        assert "isHidden" in props
-        assert props["isHidden"]["default"] is False
+        assert "is_hidden" in props
+        assert props["is_hidden"]["default"] is False
 
     @pytest.mark.asyncio
     async def test_workout_tools_schema_advertises_datetime_dates(self):

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -131,7 +131,6 @@ class TestListTools:
         assert "structure" in props
         assert "structured_workout" in props
         assert "is_hidden" in props
-        assert props["is_hidden"]["default"] is False
 
     @pytest.mark.asyncio
     async def test_workout_tools_schema_advertises_datetime_dates(self):

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -303,9 +303,37 @@ class TestUpdateWorkout:
         assert result["success"] is True
         put_payload = mock_instance.put.call_args[1]["json"]
         assert put_payload["title"] == "Updated Title"
-        assert put_payload["isHidden"] is False
         # Original fields preserved
         assert put_payload["workoutTypeFamilyId"] == 3
+
+    @pytest.mark.asyncio
+    async def test_update_keeps_hidden(self):
+        """The TrainingPeaks isHidden field should be preserved if not explicitly updated."""
+        existing = {
+            "workoutId": 1001,
+            "title": "Original",
+            "workoutDay": "2026-03-01T00:00:00",
+            "workoutTypeFamilyId": 3,
+            "workoutTypeValueId": 3,
+            "isHidden": False,
+        }
+        get_response = APIResponse(success=True, data=existing)
+        put_response = APIResponse(success=True, data=None)
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(workout_id="1001", sport="Bike")
+
+        assert result["success"] is True
+        put_payload = mock_instance.put.call_args[1]["json"]
+        assert put_payload["workoutTypeFamilyId"] == 2
+        assert put_payload["workoutTypeValueId"] == 2
+        assert put_payload["isHidden"] is False
 
     @pytest.mark.asyncio
     async def test_update_hidden(self):

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -303,8 +303,36 @@ class TestUpdateWorkout:
         assert result["success"] is True
         put_payload = mock_instance.put.call_args[1]["json"]
         assert put_payload["title"] == "Updated Title"
+        assert put_payload["isHidden"] is False
         # Original fields preserved
         assert put_payload["workoutTypeFamilyId"] == 3
+
+    @pytest.mark.asyncio
+    async def test_update_hidden(self):
+        """is_hidden should update the TrainingPeaks isHidden field."""
+        existing = {
+            "workoutId": 1001,
+            "title": "Original",
+            "workoutDay": "2026-03-01T00:00:00",
+            "workoutTypeFamilyId": 3,
+            "workoutTypeValueId": 3,
+            "isHidden": False,
+        }
+        get_response = APIResponse(success=True, data=existing)
+        put_response = APIResponse(success=True, data=None)
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(workout_id="1001", is_hidden=True)
+
+        assert result["success"] is True
+        put_payload = mock_instance.put.call_args[1]["json"]
+        assert put_payload["isHidden"] is True
 
     @pytest.mark.asyncio
     async def test_update_sport_changes_ids(self):

--- a/tests/test_tools/test_validation.py
+++ b/tests/test_tools/test_validation.py
@@ -75,7 +75,7 @@ class TestCreateWorkoutInput:
         )
         assert result.sport == "Run"
         assert result.duration_minutes == 60
-        assert result.is_hidden is False
+        assert result.is_hidden is None
 
     def test_accepts_hidden_flag(self):
         result = CreateWorkoutInput(
@@ -200,7 +200,7 @@ class TestUpdateWorkoutInput:
         result = UpdateWorkoutInput(workout_id="123", date="2026-04-14")
         assert result.date is not None
         assert result.date.isoformat() == "2026-04-14"
-        assert result.is_hidden is False
+        assert result.is_hidden is None
 
     def test_accepts_hidden_flag(self):
         result = UpdateWorkoutInput(workout_id="123", is_hidden=True)

--- a/tests/test_tools/test_validation.py
+++ b/tests/test_tools/test_validation.py
@@ -75,6 +75,17 @@ class TestCreateWorkoutInput:
         )
         assert result.sport == "Run"
         assert result.duration_minutes == 60
+        assert result.is_hidden is False
+
+    def test_accepts_hidden_flag(self):
+        result = CreateWorkoutInput(
+            date="2025-06-01",
+            sport="Run",
+            title="Morning Run",
+            duration_minutes=60,
+            is_hidden=True,
+        )
+        assert result.is_hidden is True
 
     def test_valid_datetime(self):
         result = CreateWorkoutInput(
@@ -189,6 +200,11 @@ class TestUpdateWorkoutInput:
         result = UpdateWorkoutInput(workout_id="123", date="2026-04-14")
         assert result.date is not None
         assert result.date.isoformat() == "2026-04-14"
+        assert result.is_hidden is False
+
+    def test_accepts_hidden_flag(self):
+        result = UpdateWorkoutInput(workout_id="123", is_hidden=True)
+        assert result.is_hidden is True
 
     def test_accepts_datetime(self):
         result = UpdateWorkoutInput(workout_id="123", date="2026-04-14T16:45:00")

--- a/tests/test_tools/test_workouts.py
+++ b/tests/test_tools/test_workouts.py
@@ -304,6 +304,37 @@ class TestTpCreateWorkout:
         assert payload["workoutTypeValueId"] == 3
         assert payload["title"] == "Morning Run"
         assert payload["totalTimePlanned"] == 1.0  # 60 min -> 1.0 hours
+        assert payload["isHidden"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_workout_hidden(self):
+        """is_hidden should map to the TrainingPeaks isHidden payload field."""
+        create_response = APIResponse(
+            success=True,
+            data={
+                "workoutId": 5004,
+                "title": "Hidden Run",
+                "workoutDay": "2026-01-10T00:00:00",
+            },
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=create_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_create_workout(
+                date_str="2026-01-10",
+                sport="Run",
+                title="Hidden Run",
+                duration_minutes=60,
+                is_hidden=True,
+            )
+
+        assert result["success"] is True
+        payload = mock_instance.post.call_args[1]["json"]
+        assert payload["isHidden"] is True
 
     @pytest.mark.asyncio
     async def test_create_workout_datetime_preserves_time(self):


### PR DESCRIPTION
Added an option to create/update a workout as hidden for an athlete (when creating a workout as a coach).

I added proper tests, ran:

```
pytest tests/ -v
mypy src/
ruff check src/
```

Also manually tested with MCP Inspector (`npx @modelcontextprotocol/inspector tp-mcp serve`) to create/update a workout as hidden.