### PR TITLE
fix(library): allow setting workout type on tp_update_library_item

### DIFF
--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -953,6 +953,11 @@ TOOLS = [
                 "tss": {"type": "number"},
                 "description": {"type": "string"},
                 "structure": {"type": "object"},
+                "workout_type_id": {
+                    "type": "integer",
+                    "description": "Sport/workout type: 1=swim, 2=bike, 3=run, etc. Sets the sport on templates saved without one.",
+                },
+                "workout_sub_type_id": {"type": "integer"},
             },
             "required": ["library_id", "item_id"],
         },
@@ -1348,6 +1353,8 @@ async def _h_update_lib_item(args):
         name=args.get("name"), duration_hours=args.get("duration_hours"),
         tss=args.get("tss"), description=args.get("description"),
         structure=args.get("structure"),
+        workout_type_id=args.get("workout_type_id"),
+        workout_sub_type_id=args.get("workout_sub_type_id"),
     )
 
 @_handler("tp_schedule_library_workout")

--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -350,6 +350,8 @@ async def tp_update_library_item(
     tss: float | None = None,
     description: str | None = None,
     structure: dict[str, Any] | None = None,
+    workout_type_id: int | None = None,
+    workout_sub_type_id: int | None = None,
 ) -> dict[str, Any]:
     """Edit a workout template.
 
@@ -361,6 +363,9 @@ async def tp_update_library_item(
         tss: Optional planned TSS.
         description: Optional description.
         structure: Optional structure (nested object).
+        workout_type_id: Optional sport/workout type (1=swim, 2=bike, 3=run, ...).
+            Use to set the sport on templates that were saved without one.
+        workout_sub_type_id: Optional workout subtype id (e.g. 6=Indoor Bike).
 
     Returns:
         Dict with confirmation or error.
@@ -423,6 +428,10 @@ async def tp_update_library_item(
             existing["description"] = description
         if structure is not None:
             existing["structure"] = structure
+        if workout_type_id is not None:
+            existing["workoutTypeId"] = workout_type_id
+        if workout_sub_type_id is not None:
+            existing["workoutSubTypeId"] = workout_sub_type_id
 
         put_endpoint = (
             f"/exerciselibrary/v1/libraries/{lib_validated.workout_id}"


### PR DESCRIPTION
## Problem
`tp_update_library_item` could edit name/duration/tss/description/structure, but had **no way to set the sport**. Templates saved with `workoutTypeId=0` (no sport) were stuck: update silently ignored any sport field, and there is no per-item delete to recreate them.

## Change
- `tp_update_library_item`: add optional `workout_type_id` (1=swim, 2=bike, 3=run, …) and `workout_sub_type_id`; they are merged into the item before the existing GET→PUT round-trip.
- Register both in the `server.py` Tool `inputSchema` and pass them through the handler.
- Additive — existing callers are unaffected.

## Testing
Applied to 16 real coach library templates (7 bike → Bike, 9 run → Run): `workoutTypeId` now persists and structure / TSS / description are preserved (verified by re-read, including from a separate session). Import check passes; rebased cleanly on latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)