### PR TITLE
fix(library): read sport from workoutTypeId in tp_get_library_items

### DIFF
--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -93,7 +93,7 @@ async def tp_get_library_items(library_id: str) -> dict[str, Any]:
             {
                 "id": item.get("exerciseLibraryItemId", item.get("id")),
                 "name": item.get("itemName", item.get("name", "")),
-                "sport": item.get("workoutTypeFamilyId"),
+                "sport": item.get("workoutTypeId"),
                 "duration": item.get("totalTimePlanned"),
                 "tss": item.get("tssPlanned"),
             }

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -40,7 +40,7 @@ class TestGetLibraryItems:
     @pytest.mark.asyncio
     async def test_list_items(self):
         data = [
-            {"exerciseLibraryItemId": 10, "itemName": "Sweet Spot", "workoutTypeFamilyId": 2, "totalTimePlanned": 1.5, "tssPlanned": 80},
+            {"exerciseLibraryItemId": 10, "itemName": "Sweet Spot", "workoutTypeId": 2, "totalTimePlanned": 1.5, "tssPlanned": 80},
         ]
         response = APIResponse(success=True, data=data)
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
@@ -53,6 +53,7 @@ class TestGetLibraryItems:
 
         assert result["count"] == 1
         assert result["items"][0]["name"] == "Sweet Spot"
+        assert result["items"][0]["sport"] == 2
 
 
 class TestCreateLibrary:


### PR DESCRIPTION
## Problem
`tp_get_library_items` mapped each item's `sport` from `workoutTypeFamilyId`, but the TrainingPeaks v2 library-items payload never contains that key — so `sport` came back `null` for every template. The actual sport is in `workoutTypeId` (1=swim, 2=bike, 3=run, …).

## Change
- Map `sport` from `item.get("workoutTypeId")`.
- Update the `TestGetLibraryItems` mock to the real field name and assert `sport == 2`.

## Testing
Live run against a real library now returns `sport` for all items (28/28 → 2) instead of null. Import check passes.

Note: complements #95 (which adds the ability to *set* `workout_type_id` via `tp_update_library_item`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)