### PR TITLE
fix(library): correct create payload and library listing fields

### DIFF
--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -40,9 +40,13 @@ async def tp_get_libraries() -> dict[str, Any]:
         libraries = [
             {
                 "id": lib.get("exerciseLibraryId", lib.get("id")),
-                "name": lib.get("name", ""),
-                "is_default": lib.get("isDefault", False),
+                # The v2 libraries endpoint returns "libraryName"/"isDefaultContent";
+                # keep the old keys as fallbacks for safety.
+                "name": lib.get("libraryName", lib.get("name", "")),
+                "is_default": lib.get("isDefaultContent", lib.get("isDefault", False)),
+                # NOTE: the v2 libraries endpoint does not return an item count.
                 "item_count": lib.get("itemCount", 0),
+                "owner_id": lib.get("ownerId"),
             }
             for lib in data
         ]
@@ -187,8 +191,16 @@ async def tp_create_library(name: str) -> dict[str, Any]:
                 "message": "Could not get athlete ID. Re-authenticate.",
             }
 
+        # TP expects "libraryName" and the owner's personId, not "name".
+        owner_id = None
+        user_data = await client._get_user_data()
+        if user_data:
+            owner_id = user_data.get("personId")
+
         endpoint = "/exerciselibrary/v1/libraries"
-        payload = {"name": name.strip()}
+        payload: dict[str, Any] = {"libraryName": name.strip()}
+        if owner_id is not None:
+            payload["ownerId"] = owner_id
         response = await client.post(endpoint, json=payload)
 
         if response.is_error:

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -19,8 +19,8 @@ class TestGetLibraries:
     @pytest.mark.asyncio
     async def test_list_libraries(self):
         data = [
-            {"exerciseLibraryId": 1, "name": "My Workouts", "isDefault": False, "itemCount": 5},
-            {"exerciseLibraryId": 2, "name": "Default", "isDefault": True, "itemCount": 20},
+            {"exerciseLibraryId": 1, "libraryName": "My Workouts", "isDefaultContent": False, "ownerId": 7},
+            {"exerciseLibraryId": 2, "libraryName": "Default", "isDefaultContent": True, "ownerId": 7},
         ]
         response = APIResponse(success=True, data=data)
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
@@ -62,6 +62,7 @@ class TestCreateLibrary:
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance._get_user_data = AsyncMock(return_value={"personId": 999})
             mock_instance.post = AsyncMock(return_value=response)
             mock_client.return_value.__aenter__.return_value = mock_instance
 
@@ -70,7 +71,8 @@ class TestCreateLibrary:
         assert result["success"] is True
         assert result["library_id"] == 3
         payload = mock_instance.post.call_args[1]["json"]
-        assert payload["name"] == "Race Prep"
+        assert payload["libraryName"] == "Race Prep"
+        assert payload["ownerId"] == 999
 
 
 class TestDeleteLibrary:


### PR DESCRIPTION
## Problem
Two bugs in the workout-library tools, both from field-name mismatches with the TrainingPeaks API:

1. **`tp_create_library` always failed (HTTP 400).** It POSTed `{"name": ...}` to `/exerciselibrary/v1/libraries`, but TP expects `libraryName` plus the owner's `personId`.
2. **`tp_get_libraries` returned empty names.** It read `name`/`isDefault`, but the v2 libraries payload uses `libraryName` and `isDefaultContent`. Every folder came back with `name: ""`.

Raw v2 library object for reference:
```json
{"exerciseLibraryId": 1102358, "libraryName": "Калинин - вело", "ownerId": 1135463, "ownerName": "Temp Training", "imageUrl": "...", "isDefaultContent": false}
```

## Change
- `tp_create_library`: send `{"libraryName": <name>, "ownerId": <personId>}` (personId resolved from the authenticated user).
- `tp_get_libraries`: read `libraryName`/`isDefaultContent` (old keys kept as fallbacks), and expose `owner_id`. The v2 endpoint returns no item count, so `item_count` stays `0` (documented in a comment).
- Tests updated to the real field names + create payload assertions.

## Testing
Live: creating a library now succeeds, and the listing returns real names for all folders (e.g. `1102358 → "Калинин - вело"`) instead of empty strings. Import check passes; rebased on latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)