### PR TITLE
fix(library): read sport from workoutTypeId in tp_get_library_items

### DIFF
--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -93,7 +93,7 @@ async def tp_get_library_items(library_id: str) -> dict[str, Any]:
             {
                 "id": item.get("exerciseLibraryItemId", item.get("id")),
                 "name": item.get("itemName", item.get("name", "")),
-                "sport": item.get("workoutTypeFamilyId"),
+                "sport": item.get("workoutTypeId"),
                 "duration": item.get("totalTimePlanned"),
                 "tss": item.get("tssPlanned"),
             }

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -40,7 +40,7 @@ class TestGetLibraryItems:
     @pytest.mark.asyncio
     async def test_list_items(self):
         data = [
-            {"exerciseLibraryItemId": 10, "itemName": "Sweet Spot", "workoutTypeFamilyId": 2, "totalTimePlanned": 1.5, "tssPlanned": 80},
+            {"exerciseLibraryItemId": 10, "itemName": "Sweet Spot", "workoutTypeId": 2, "totalTimePlanned": 1.5, "tssPlanned": 80},
         ]
         response = APIResponse(success=True, data=data)
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
@@ -53,6 +53,7 @@ class TestGetLibraryItems:
 
         assert result["count"] == 1
         assert result["items"][0]["name"] == "Sweet Spot"
+        assert result["items"][0]["sport"] == 2
 
 
 class TestCreateLibrary:


### PR DESCRIPTION
Closes #99.

### Problem
`tp_get_library_items` mapped `sport` from `workoutTypeFamilyId`, an alias TP does **not** return on the `exerciselibrary/v2/.../items` payload, so every item came back as `sport: null`.

### Fix
Read `sport` from `workoutTypeId` (the field TP actually returns), matching the sibling fix on the workout endpoints (#83 root cause).

### Tests
`tests/test_tools/test_library.py::TestGetLibraryItems::test_list_items` updated to assert the sport is surfaced. Full suite green (382), `ruff check src/` and `mypy src/` clean.
