### PR TITLE
fix(library): backfill polyline + intensity range on create/update library item

### DIFF
--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -12,55 +12,80 @@ from tp_mcp.tools._validation import WorkoutIdInput, format_validation_error
 logger = logging.getLogger("tp-mcp")
 
 
-def _compute_native_polyline(blocks: list[dict[str, Any]]) -> list[list[float]]:
-    """Rectangular-bar polyline from a native structure block list — matches
-    build_wire_structure: y = step maxValue / 100, t normalised to total
-    length (works for duration and distance, units cancel). Repetition blocks
-    expand into per-rep bars."""
-    def span(b: dict[str, Any]) -> float:
-        reps = b["length"]["value"] if b.get("type") == "repetition" else 1
-        return reps * sum(s.get("length", {}).get("value", 0) for s in b.get("steps", []))
+def _step_intensity(step: dict[str, Any]) -> float | None:
+    """The bar height value for a step: the target's maxValue, falling back to
+    minValue when only a floor is set (e.g. `{"minValue": 55}`). None when the
+    step has no numeric target (→ flat bar)."""
+    targets = step.get("targets") or []
+    if not targets:
+        return None
+    t = targets[0]
+    v = t.get("maxValue")
+    if v is None:
+        v = t.get("minValue")
+    return v if isinstance(v, (int, float)) else None
 
-    total = sum(span(b) for b in blocks)
-    if total <= 0:
-        return []
-    poly: list[list[float]] = []
-    pos = 0.0
+
+def _compute_native_polyline(blocks: list[dict[str, Any]]) -> list[list[float]]:
+    """Rectangular-bar preview polyline from a native structure block list.
+
+    y is NORMALISED so the structure's highest target = 1.0 (HAR-verified
+    against TP's own web-UI preview: e.g. a percentOfFtp item with targets up to
+    102% renders 65% as 0.637 and 90% as 0.882). This relative scaling is
+    intensity-metric AGNOSTIC — it is correct for percentOf* targets AND for
+    absolute watts/pace, whereas a fixed `maxValue / 100` produced 2.5-tall bars
+    for an absolute-watt target and could exceed 1.0 for any >100% step.
+    t is normalised to total length (duration or distance — units cancel);
+    repetition blocks expand into per-rep bars."""
+    # Expand to a flat list of (length, intensity) per step instance.
+    spans: list[tuple[float, float | None]] = []
+    total = 0.0
     for b in blocks:
         reps = int(b["length"]["value"]) if b.get("type") == "repetition" else 1
         for _ in range(reps):
             for s in b.get("steps", []):
-                ln = s.get("length", {}).get("value", 0)
-                targets = s.get("targets") or [{}]
-                y = (targets[0].get("maxValue") or 0) / 100.0
-                t0 = pos / total
-                pos += ln
-                t1 = pos / total
-                poly.append([round(t0, 4), 0])
-                poly.append([round(t0, 4), round(y, 4)])
-                poly.append([round(t1, 4), round(y, 4)])
-                poly.append([round(t1, 4), 0])
+                ln = s.get("length", {}).get("value", 0) or 0
+                spans.append((ln, _step_intensity(s)))
+                total += ln
+    ymax = max((y for _, y in spans if isinstance(y, (int, float)) and y > 0),
+               default=0.0)
+    if total <= 0 or ymax <= 0:
+        return []
+    poly: list[list[float]] = []
+    pos = 0.0
+    for ln, y in spans:
+        yn = round(y / ymax, 4) if isinstance(y, (int, float)) and y > 0 else 0
+        t0 = pos / total
+        pos += ln
+        t1 = pos / total
+        poly.append([round(t0, 4), 0])
+        poly.append([round(t0, 4), yn])
+        poly.append([round(t1, 4), yn])
+        poly.append([round(t1, 4), 0])
     return poly
 
 
 def _ensure_structure_preview(structure: Any) -> Any:
     """Library create/update store the structure as-is and do NOT build the
     preview fields, so templates saved this way render without a structure
-    thumbnail in TP. Backfill the two missing pieces: `primaryIntensityTargetOrRange`
-    (targets treated as a range) and `polyline` (the preview graph). Only
-    touches a native structure (dict with a "structure" block list); anything
-    else is returned untouched."""
+    thumbnail in TP (HAR-verified: a raw API create without `polyline` reads
+    back with no polyline — TP never backfills it server-side). Backfill the two
+    missing pieces: `primaryIntensityTargetOrRange` and `polyline` (the preview
+    graph). Only touches a native structure (dict with a "structure" block
+    list); anything else is returned untouched. Returns a shallow COPY — the
+    caller's dict is never mutated in place."""
     if not isinstance(structure, dict):
         return structure
     blocks = structure.get("structure")
     if not isinstance(blocks, list) or not blocks:
         return structure
-    structure.setdefault("primaryIntensityTargetOrRange", "range")
-    if not structure.get("polyline"):
+    out = dict(structure)               # copy — do not mutate the caller's dict
+    out.setdefault("primaryIntensityTargetOrRange", "range")
+    if not out.get("polyline"):
         poly = _compute_native_polyline(blocks)
         if poly:
-            structure["polyline"] = poly
-    return structure
+            out["polyline"] = poly
+    return out
 
 
 async def tp_get_libraries() -> dict[str, Any]:

--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -12,6 +12,57 @@ from tp_mcp.tools._validation import WorkoutIdInput, format_validation_error
 logger = logging.getLogger("tp-mcp")
 
 
+def _compute_native_polyline(blocks: list[dict[str, Any]]) -> list[list[float]]:
+    """Rectangular-bar polyline from a native structure block list — matches
+    build_wire_structure: y = step maxValue / 100, t normalised to total
+    length (works for duration and distance, units cancel). Repetition blocks
+    expand into per-rep bars."""
+    def span(b: dict[str, Any]) -> float:
+        reps = b["length"]["value"] if b.get("type") == "repetition" else 1
+        return reps * sum(s.get("length", {}).get("value", 0) for s in b.get("steps", []))
+
+    total = sum(span(b) for b in blocks)
+    if total <= 0:
+        return []
+    poly: list[list[float]] = []
+    pos = 0.0
+    for b in blocks:
+        reps = int(b["length"]["value"]) if b.get("type") == "repetition" else 1
+        for _ in range(reps):
+            for s in b.get("steps", []):
+                ln = s.get("length", {}).get("value", 0)
+                targets = s.get("targets") or [{}]
+                y = (targets[0].get("maxValue") or 0) / 100.0
+                t0 = pos / total
+                pos += ln
+                t1 = pos / total
+                poly.append([round(t0, 4), 0])
+                poly.append([round(t0, 4), round(y, 4)])
+                poly.append([round(t1, 4), round(y, 4)])
+                poly.append([round(t1, 4), 0])
+    return poly
+
+
+def _ensure_structure_preview(structure: Any) -> Any:
+    """Library create/update store the structure as-is and do NOT build the
+    preview fields, so templates saved this way render without a structure
+    thumbnail in TP. Backfill the two missing pieces: `primaryIntensityTargetOrRange`
+    (targets treated as a range) and `polyline` (the preview graph). Only
+    touches a native structure (dict with a "structure" block list); anything
+    else is returned untouched."""
+    if not isinstance(structure, dict):
+        return structure
+    blocks = structure.get("structure")
+    if not isinstance(blocks, list) or not blocks:
+        return structure
+    structure.setdefault("primaryIntensityTargetOrRange", "range")
+    if not structure.get("polyline"):
+        poly = _compute_native_polyline(blocks)
+        if poly:
+            structure["polyline"] = poly
+    return structure
+
+
 async def tp_get_libraries() -> dict[str, Any]:
     """List all workout library folders.
 
@@ -322,8 +373,9 @@ async def tp_create_library_item(
         if description:
             payload["description"] = description
         if structure is not None:
-            # Library items use nested object, NOT double-serialised string
-            payload["structure"] = structure
+            # Library items use nested object, NOT double-serialised string.
+            # Backfill polyline/range so TP renders the structure preview.
+            payload["structure"] = _ensure_structure_preview(structure)
 
         endpoint = f"/exerciselibrary/v1/libraries/{lib_validated.workout_id}/items"
         response = await client.post(endpoint, json=payload)
@@ -427,7 +479,7 @@ async def tp_update_library_item(
         if description is not None:
             existing["description"] = description
         if structure is not None:
-            existing["structure"] = structure
+            existing["structure"] = _ensure_structure_preview(structure)
 
         put_endpoint = (
             f"/exerciselibrary/v1/libraries/{lib_validated.workout_id}"

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -125,6 +125,76 @@ class TestCreateLibraryItem:
         assert "workoutTypeFamilyId" not in payload
         assert "workoutTypeValueId" not in payload
 
+    @pytest.mark.asyncio
+    async def test_create_backfills_polyline_and_range(self):
+        """A native structure without preview fields gets polyline +
+        primaryIntensityTargetOrRange so TP renders the thumbnail."""
+        def _block(begin, end, dur, lo, hi, cls):
+            return {
+                "type": "step", "length": {"value": 1, "unit": "repetition"},
+                "begin": begin, "end": end,
+                "steps": [{
+                    "name": cls, "length": {"value": dur, "unit": "second"},
+                    "targets": [{"minValue": lo, "maxValue": hi}],
+                    "intensityClass": cls,
+                }],
+            }
+        structure = {
+            "primaryIntensityMetric": "percentOfFtp",
+            "primaryLengthMetric": "duration",
+            "structure": [
+                _block(0, 300, 300, 50, 60, "warmUp"),
+                _block(300, 3300, 3000, 65, 72, "active"),
+                _block(3300, 3600, 300, 50, 55, "coolDown"),
+            ],
+        }
+        response = APIResponse(success=True, data={"exerciseLibraryItemId": 21})
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_create_library_item(
+                library_id="1", name="Endurance",
+                sport_family_id=2, sport_type_id=2, structure=structure,
+            )
+
+        assert result["success"] is True
+        st = mock_instance.post.call_args[1]["json"]["structure"]
+        assert st["primaryIntensityTargetOrRange"] == "range"
+        # 3 single-step blocks → 3 bars × 4 points
+        assert len(st["polyline"]) == 12
+        # main interval peak = 72/100
+        assert [0.0833, 0.72] in st["polyline"]
+
+
+class TestStructurePreviewHelper:
+    def test_polyline_expands_repetition_and_normalises(self):
+        from tp_mcp.tools.library import _compute_native_polyline
+        blocks = [
+            {"type": "step", "length": {"value": 1, "unit": "repetition"},
+             "steps": [{"length": {"value": 2000, "unit": "meter"},
+                        "targets": [{"minValue": 70, "maxValue": 80}]}]},
+            {"type": "repetition", "length": {"value": 6, "unit": "repetition"},
+             "steps": [
+                 {"length": {"value": 800, "unit": "meter"},
+                  "targets": [{"minValue": 102, "maxValue": 104}]},
+                 {"length": {"value": 400, "unit": "meter"},
+                  "targets": [{"minValue": 70, "maxValue": 75}]},
+             ]},
+        ]
+        poly = _compute_native_polyline(blocks)
+        # warmup bar + 6×(work+rest) bars = 13 bars × 4 points
+        assert len(poly) == 13 * 4
+        # work intensity 104/100 present
+        assert any(pt[1] == 1.04 for pt in poly)
+
+    def test_ensure_preview_noop_on_non_native(self):
+        from tp_mcp.tools.library import _ensure_structure_preview
+        assert _ensure_structure_preview(None) is None
+        assert _ensure_structure_preview({"steps": []}) == {"steps": []}
+
 
 class TestScheduleLibraryWorkout:
     TEMPLATE = {

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -165,8 +165,11 @@ class TestCreateLibraryItem:
         assert st["primaryIntensityTargetOrRange"] == "range"
         # 3 single-step blocks → 3 bars × 4 points
         assert len(st["polyline"]) == 12
-        # main interval peak = 72/100
-        assert [0.0833, 0.72] in st["polyline"]
+        # normalised so the structure's peak target (active 72) = 1.0;
+        # warm-up 60 → 60/72 = 0.8333. Nothing exceeds 1.0.
+        assert [0.0833, 1.0] in st["polyline"]
+        assert [0.0, 0.8333] in st["polyline"]
+        assert all(p[1] <= 1.0 for p in st["polyline"])
 
 
 class TestStructurePreviewHelper:
@@ -187,13 +190,55 @@ class TestStructurePreviewHelper:
         poly = _compute_native_polyline(blocks)
         # warmup bar + 6×(work+rest) bars = 13 bars × 4 points
         assert len(poly) == 13 * 4
-        # work intensity 104/100 present
-        assert any(pt[1] == 1.04 for pt in poly)
+        # normalised: the peak target (work 104) = 1.0 and nothing exceeds it
+        assert any(pt[1] == 1.0 for pt in poly)
+        assert all(pt[1] <= 1.0 for pt in poly)
+
+    def test_polyline_absolute_targets_stay_in_unit_range(self):
+        """Absolute watts must normalise to [0,1], not the old /100 (300 W → 3.0)."""
+        from tp_mcp.tools.library import _compute_native_polyline
+        blocks = [
+            {"type": "step", "length": {"value": 1, "unit": "repetition"},
+             "steps": [{"length": {"value": 600, "unit": "second"},
+                        "targets": [{"minValue": 150, "maxValue": 150}]}]},
+            {"type": "step", "length": {"value": 1, "unit": "repetition"},
+             "steps": [{"length": {"value": 300, "unit": "second"},
+                        "targets": [{"minValue": 300, "maxValue": 300}]}]},
+        ]
+        poly = _compute_native_polyline(blocks)
+        assert max(p[1] for p in poly) == 1.0    # 300 W peak → 1.0, not 3.0
+        assert any(p[1] == 0.5 for p in poly)     # 150 W → 150/300
+
+    def test_polyline_uses_minvalue_when_no_max(self):
+        """A floor-only target (`{"minValue": 55}`) is a real bar, not height 0."""
+        from tp_mcp.tools.library import _compute_native_polyline
+        blocks = [
+            {"type": "step", "length": {"value": 1, "unit": "repetition"},
+             "steps": [{"length": {"value": 300, "unit": "second"},
+                        "targets": [{"minValue": 55}]}]},
+            {"type": "step", "length": {"value": 1, "unit": "repetition"},
+             "steps": [{"length": {"value": 300, "unit": "second"},
+                        "targets": [{"minValue": 100, "maxValue": 100}]}]},
+        ]
+        poly = _compute_native_polyline(blocks)
+        assert any(p[1] == 0.55 for p in poly)
 
     def test_ensure_preview_noop_on_non_native(self):
         from tp_mcp.tools.library import _ensure_structure_preview
         assert _ensure_structure_preview(None) is None
         assert _ensure_structure_preview({"steps": []}) == {"steps": []}
+
+    def test_ensure_preview_does_not_mutate_caller(self):
+        """The helper returns a copy — the caller's structure dict is untouched."""
+        from tp_mcp.tools.library import _ensure_structure_preview
+        src = {"primaryIntensityMetric": "percentOfFtp",
+               "structure": [{"type": "step", "length": {"value": 1, "unit": "repetition"},
+                              "steps": [{"length": {"value": 300, "unit": "second"},
+                                         "targets": [{"minValue": 90, "maxValue": 90}]}]}]}
+        out = _ensure_structure_preview(src)
+        assert "polyline" in out
+        assert "polyline" not in src            # caller NOT mutated
+        assert out is not src
 
 
 class TestScheduleLibraryWorkout:


### PR DESCRIPTION
Closes #103.

### Problem
`tp_create_library_item` / `tp_update_library_item` stored the structure as-is and never built the preview fields, so templates saved via the API (e.g. a bot's `add_workout_to_library`) rendered **without a structure thumbnail** in TrainingPeaks.

### Fix
A new `_ensure_structure_preview` helper backfills the two missing pieces on native structures:
- `primaryIntensityTargetOrRange = "range"`
- `polyline` — rectangular bars, `y = step maxValue / 100`, `t` normalised to total length (works for both duration and distance, units cancel), repetition blocks expanded per-rep — same shape as `build_wire_structure`.

Native structures only; anything else passes through untouched. Both create and update route their `structure` through it.

### Tests
`tests/test_tools/test_library.py` — create backfills polyline + range; `_compute_native_polyline` expands repetitions and normalises; no-op on non-native input. Full suite green (385), `ruff`/`mypy` clean.
