### PR TITLE
feat(events): attach workouts to an event as legs via tp_update_event(workout_ids=…)

### DIFF
--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -740,6 +740,14 @@ TOOLS = [
                 "distance_km": {"type": "number"},
                 "ctl_target": {"type": "number"},
                 "description": {"type": "string"},
+                "workout_ids": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": (
+                        "Workout IDs to attach to the event as its legs, in order "
+                        "(e.g. swim, T1, bike, T2, run). Replaces the existing list."
+                    ),
+                },
             },
             "required": ["event_id"],
         },
@@ -1258,7 +1266,7 @@ async def _h_update_event(args):
         event_id=args["event_id"], name=args.get("name"), date=args.get("date"),
         event_type=args.get("event_type"), priority=args.get("priority"),
         distance_km=args.get("distance_km"), ctl_target=args.get("ctl_target"),
-        description=args.get("description"),
+        description=args.get("description"), workout_ids=args.get("workout_ids"),
     )
 
 @_handler("tp_delete_event")

--- a/src/tp_mcp/tools/events.py
+++ b/src/tp_mcp/tools/events.py
@@ -301,6 +301,7 @@ async def tp_update_event(
     distance_km: float | None = None,
     ctl_target: float | None = None,
     description: str | None = None,
+    workout_ids: list[int] | None = None,
 ) -> dict[str, Any]:
     """Update an event (GET then PUT merge).
 
@@ -313,6 +314,10 @@ async def tp_update_event(
         distance_km: Optional distance in km.
         ctl_target: Optional CTL target.
         description: Optional description.
+        workout_ids: Optional list of workout IDs to attach to the event as its
+            legs. TrainingPeaks links workouts via the event's ``workouts`` array
+            (the ``legs`` structure is derived server-side); pass the ordered
+            swim/T1/bike/T2/run workout IDs. Replaces the existing list.
 
     Returns:
         Dict with confirmation or error.
@@ -384,6 +389,11 @@ async def tp_update_event(
             existing["ctlTarget"] = ctl_target
         if description is not None:
             existing["description"] = description
+        if workout_ids is not None:
+            # TP attaches workouts to an event via the `workouts` id array (HAR-
+            # verified: PUT /event with workouts=[…], legs stays [] and is derived
+            # server-side). Replace the list with the provided ordered leg ids.
+            existing["workouts"] = [int(w) for w in workout_ids]
 
         endpoint = f"/fitness/v6/athletes/{athlete_id}/event"
         response = await client.put(endpoint, json=existing)

--- a/tests/test_tools/test_events.py
+++ b/tests/test_tools/test_events.py
@@ -18,6 +18,7 @@ from tp_mcp.tools.events import (
     tp_get_note,
     tp_get_note_comments,
     tp_list_notes,
+    tp_update_event,
     tp_update_note,
 )
 
@@ -552,3 +553,68 @@ class TestListNotes:
             result = await tp_list_notes(start_date="2026-05-01", end_date="2026-05-31")
 
         assert result["notes"][0]["date"] is None
+
+
+class TestUpdateEventAttachLegs:
+    """tp_update_event(workout_ids=...) attaches workouts to an event as its legs.
+    TP links them via the event's `workouts` id array (HAR-verified: PUT /event
+    with workouts=[…]; `legs` stays [] and is derived server-side)."""
+
+    @pytest.mark.asyncio
+    async def test_workout_ids_sets_workouts_array(self):
+        existing = {
+            "id": 37493307,
+            "name": "Ironstar Гром олимпийка",
+            "eventDate": "2026-05-30T00:00:00",
+            "eventType": "MultisportTriathlon",
+            "personId": 1680841,
+            "legs": [],
+            "workouts": [3753121100],  # one leg already attached
+        }
+        get_response = APIResponse(success=True, data=[existing])
+        put_response = APIResponse(success=True, data={})
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=1680841)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_event(
+                event_id="37493307",
+                workout_ids=[3753121100, 3763855286, 3753121299, 3753122444],
+            )
+
+        assert result["success"] is True
+        payload = mock_instance.put.call_args.kwargs["json"]
+        assert payload["workouts"] == [3753121100, 3763855286, 3753121299, 3753122444]
+        assert payload["legs"] == []          # legs untouched — TP derives them
+
+    @pytest.mark.asyncio
+    async def test_string_workout_ids_are_coerced_to_int(self):
+        existing = {"id": 1, "personId": 9, "legs": [], "workouts": []}
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=9)
+            mock_instance.get = AsyncMock(return_value=APIResponse(success=True, data=[existing]))
+            mock_instance.put = AsyncMock(return_value=APIResponse(success=True, data={}))
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_event(event_id="1", workout_ids=["10", "20"])
+
+        assert result["success"] is True
+        assert mock_instance.put.call_args.kwargs["json"]["workouts"] == [10, 20]
+
+    @pytest.mark.asyncio
+    async def test_workout_ids_omitted_leaves_workouts_untouched(self):
+        existing = {"id": 1, "personId": 9, "legs": [], "workouts": [55]}
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=9)
+            mock_instance.get = AsyncMock(return_value=APIResponse(success=True, data=[existing]))
+            mock_instance.put = AsyncMock(return_value=APIResponse(success=True, data={}))
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            await tp_update_event(event_id="1", description="just a note")
+
+        assert mock_instance.put.call_args.kwargs["json"]["workouts"] == [55]


### PR DESCRIPTION
Closes #104.

### Problem
There was no way to attach workouts to a race/event as its legs through the connector. For a multisport event the GET always returns `legs: []` / `workouts: []`, so swim/T1/bike/T2/run legs couldn't be linked.

### Fix
TrainingPeaks links workouts to an event through the event's `workouts` id array — HAR-verified: `PUT /fitness/v6/athletes/{id}/event` with `workouts=[…]`; `legs` stays `[]` and is derived server-side.

`tp_update_event` gains an optional `workout_ids: list[int]` that sets `existing["workouts"]` before the PUT (ids coerced to int). Omitted → the existing array is left untouched (back-compat). The new parameter is wired through the MCP layer (`server.py` inputSchema + handler) so it's actually reachable by clients.

> Note: the `workouts`-array behaviour is HAR-derived from the web app — happy to adjust if you'd prefer a different shape or a dedicated `legs` payload.

### Tests
`tests/test_tools/test_events.py::TestUpdateEventAttachLegs` (3) — sets the workouts array; coerces ids to int; leaves it untouched when omitted. Full suite green (385), `ruff`/`mypy` clean.
