### PR TITLE
fix(library): correct sport field names and broken schedule endpoint

### DIFF
--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -930,8 +930,14 @@ TOOLS = [
             "properties": {
                 "library_id": {"type": "string"},
                 "name": {"type": "string"},
-                "sport_family_id": {"type": "integer"},
-                "sport_type_id": {"type": "integer"},
+                "sport_family_id": {
+                    "type": "integer",
+                    "description": "Sport ID (e.g. 2=Bike; see tp_get_workout_types)",
+                },
+                "sport_type_id": {
+                    "type": "integer",
+                    "description": "Sport subtype ID (e.g. 3=Road Bike)",
+                },
                 "duration_hours": {"type": "number"},
                 "tss": {"type": "number"},
                 "description": {"type": "string"},

--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -1,5 +1,6 @@
 """Workout library tools: templates, scheduling."""
 
+import json
 import logging
 from typing import Any
 
@@ -40,9 +41,9 @@ async def tp_get_libraries() -> dict[str, Any]:
         libraries = [
             {
                 "id": lib.get("exerciseLibraryId", lib.get("id")),
-                "name": lib.get("name", ""),
-                "is_default": lib.get("isDefault", False),
-                "item_count": lib.get("itemCount", 0),
+                "name": lib.get("libraryName", lib.get("name", "")),
+                "is_default": lib.get("isDefaultContent", False),
+                "owner_name": lib.get("ownerName"),
             }
             for lib in data
         ]
@@ -93,7 +94,7 @@ async def tp_get_library_items(library_id: str) -> dict[str, Any]:
             {
                 "id": item.get("exerciseLibraryItemId", item.get("id")),
                 "name": item.get("itemName", item.get("name", "")),
-                "sport": item.get("workoutTypeFamilyId"),
+                "sport": item.get("workoutTypeId"),
                 "duration": item.get("totalTimePlanned"),
                 "tss": item.get("tssPlanned"),
             }
@@ -268,8 +269,8 @@ async def tp_create_library_item(
     Args:
         library_id: Library ID.
         name: Template name.
-        sport_family_id: Sport family ID.
-        sport_type_id: Sport type ID.
+        sport_family_id: Sport ID (e.g. 2 = Bike; see tp_get_workout_types).
+        sport_type_id: Sport subtype ID (e.g. 3 = Road Bike).
         duration_hours: Optional duration in hours.
         tss: Optional planned TSS.
         description: Optional description.
@@ -304,11 +305,15 @@ async def tp_create_library_item(
                 "message": "Could not get athlete ID. Re-authenticate.",
             }
 
+        # Library items use workoutTypeId/workoutSubTypeId (not the
+        # workoutTypeFamilyId/workoutTypeValueId pair of the fitness API).
+        # Sending the wrong field names silently creates items with sport 0
+        # ("unknown"), which render without power targets in the TP UI.
         payload: dict[str, Any] = {
             "exerciseLibraryId": lib_validated.workout_id,
             "itemName": name.strip(),
-            "workoutTypeFamilyId": sport_family_id,
-            "workoutTypeValueId": sport_type_id,
+            "workoutTypeId": sport_family_id,
+            "workoutSubTypeId": sport_type_id,
         }
         if duration_hours is not None:
             payload["totalTimePlanned"] = duration_hours
@@ -450,13 +455,19 @@ async def tp_schedule_library_workout(
 ) -> dict[str, Any]:
     """Schedule a library template to a calendar date.
 
+    Copies the template into a planned workout (title, structure, planned
+    metrics, description). The native ``addworkoutfromlibraryitem`` command
+    endpoint returns HTTP 500 for every payload shape, so this mirrors what
+    the TP web app effectively does when a template is dragged onto the
+    calendar.
+
     Args:
         library_id: Library ID.
         item_id: Library item ID.
         date: Target date (YYYY-MM-DD).
 
     Returns:
-        Dict with confirmation or error.
+        Dict with confirmation (including new workout_id) or error.
     """
     try:
         lib_validated = WorkoutIdInput(workout_id=library_id)
@@ -489,12 +500,61 @@ async def tp_schedule_library_workout(
                 "message": "Could not get athlete ID. Re-authenticate.",
             }
 
-        endpoint = f"/fitness/v6/athletes/{athlete_id}/commands/addworkoutfromlibraryitem"
-        payload = {
-            "exerciseLibraryId": lib_validated.workout_id,
-            "exerciseLibraryItemId": item_validated.workout_id,
-            "date": f"{date}T00:00:00",
+        # Fetch the template to copy
+        items_endpoint = f"/exerciselibrary/v2/libraries/{lib_validated.workout_id}/items"
+        items_response = await client.get(items_endpoint)
+
+        if items_response.is_error:
+            return {
+                "isError": True,
+                "error_code": items_response.error_code.value
+                if items_response.error_code
+                else "API_ERROR",
+                "message": items_response.message,
+            }
+
+        items = items_response.data if isinstance(items_response.data, list) else []
+        item = next(
+            (
+                i
+                for i in items
+                if i.get("exerciseLibraryItemId", i.get("id")) == item_validated.workout_id
+            ),
+            None,
+        )
+        if item is None:
+            return {
+                "isError": True,
+                "error_code": "NOT_FOUND",
+                "message": (
+                    f"Item {item_validated.workout_id} not found in "
+                    f"library {lib_validated.workout_id}."
+                ),
+            }
+
+        sport_id = item.get("workoutTypeId")
+        payload: dict[str, Any] = {
+            "athleteId": athlete_id,
+            "workoutDay": f"{date}T00:00:00",
+            "workoutTypeFamilyId": sport_id,
+            "workoutTypeValueId": sport_id,
+            "title": item.get("itemName"),
+            "totalTimePlanned": item.get("totalTimePlanned"),
+            "tssPlanned": item.get("tssPlanned"),
+            "ifPlanned": item.get("ifPlanned"),
+            "distancePlanned": item.get("distancePlanned"),
+            "elevationGainPlanned": item.get("elevationGainPlanned"),
+            "caloriesPlanned": item.get("caloriesPlanned"),
+            "description": item.get("description"),
+            "coachComments": item.get("coachComments"),
         }
+        if item.get("workoutSubTypeId") is not None:
+            payload["workoutSubTypeId"] = item["workoutSubTypeId"]
+        if item.get("structure"):
+            # Calendar workouts carry structure as a JSON string
+            payload["structure"] = json.dumps(item["structure"])
+
+        endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts"
         response = await client.post(endpoint, json=payload)
 
         if response.is_error:
@@ -504,8 +564,14 @@ async def tp_schedule_library_workout(
                 "message": response.message,
             }
 
+        workout_id = None
+        if isinstance(response.data, dict):
+            workout_id = response.data.get("workoutId")
+
         return {
             "success": True,
             "message": f"Library workout scheduled for {date}.",
             "date": date,
+            "workout_id": workout_id,
+            "title": item.get("itemName"),
         }

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -19,8 +19,8 @@ class TestGetLibraries:
     @pytest.mark.asyncio
     async def test_list_libraries(self):
         data = [
-            {"exerciseLibraryId": 1, "name": "My Workouts", "isDefault": False, "itemCount": 5},
-            {"exerciseLibraryId": 2, "name": "Default", "isDefault": True, "itemCount": 20},
+            {"exerciseLibraryId": 1, "libraryName": "My Workouts", "isDefaultContent": False, "ownerName": "Athlete"},
+            {"exerciseLibraryId": 2, "libraryName": "Default", "isDefaultContent": True, "ownerName": "Joe Friel"},
         ]
         response = APIResponse(success=True, data=data)
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
@@ -33,6 +33,7 @@ class TestGetLibraries:
 
         assert result["count"] == 2
         assert result["libraries"][0]["name"] == "My Workouts"
+        assert result["libraries"][0]["owner_name"] == "Athlete"
         assert result["libraries"][1]["is_default"] is True
 
 
@@ -40,7 +41,13 @@ class TestGetLibraryItems:
     @pytest.mark.asyncio
     async def test_list_items(self):
         data = [
-            {"exerciseLibraryItemId": 10, "itemName": "Sweet Spot", "workoutTypeFamilyId": 2, "totalTimePlanned": 1.5, "tssPlanned": 80},
+            {
+                "exerciseLibraryItemId": 10,
+                "itemName": "Sweet Spot",
+                "workoutTypeId": 2,
+                "totalTimePlanned": 1.5,
+                "tssPlanned": 80,
+            },
         ]
         response = APIResponse(success=True, data=data)
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
@@ -53,6 +60,7 @@ class TestGetLibraryItems:
 
         assert result["count"] == 1
         assert result["items"][0]["name"] == "Sweet Spot"
+        assert result["items"][0]["sport"] == 2
 
 
 class TestCreateLibrary:
@@ -110,22 +118,68 @@ class TestCreateLibraryItem:
         payload = mock_instance.post.call_args[1]["json"]
         # Structure should be nested object, NOT JSON string
         assert isinstance(payload["structure"], dict)
+        # Library API expects workoutTypeId/workoutSubTypeId; the fitness-API
+        # field names silently create items with sport 0 (no power targets)
+        assert payload["workoutTypeId"] == 2
+        assert payload["workoutSubTypeId"] == 3
+        assert "workoutTypeFamilyId" not in payload
+        assert "workoutTypeValueId" not in payload
 
 
 class TestScheduleLibraryWorkout:
+    TEMPLATE = {
+        "exerciseLibraryItemId": 10,
+        "itemName": "Sweet Spot",
+        "workoutTypeId": 2,
+        "workoutSubTypeId": 3,
+        "totalTimePlanned": 1.5,
+        "tssPlanned": 80.0,
+        "ifPlanned": 0.85,
+        "description": "2x15 @ 88-93%",
+        "structure": {"structure": [{"type": "step"}]},
+    }
+
     @pytest.mark.asyncio
-    async def test_schedule_to_date(self):
-        response = APIResponse(success=True, data=None)
+    async def test_schedule_copies_template_to_workout(self):
+        items_response = APIResponse(success=True, data=[self.TEMPLATE])
+        create_response = APIResponse(success=True, data={"workoutId": 999})
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
-            mock_instance.post = AsyncMock(return_value=response)
+            mock_instance.get = AsyncMock(return_value=items_response)
+            mock_instance.post = AsyncMock(return_value=create_response)
             mock_client.return_value.__aenter__.return_value = mock_instance
 
             result = await tp_schedule_library_workout("1", "10", "2026-04-01")
 
         assert result["success"] is True
+        assert result["workout_id"] == 999
+        # Copies the template into a planned workout (the native
+        # addworkoutfromlibraryitem command endpoint returns HTTP 500)
+        endpoint = mock_instance.post.call_args[0][0]
+        assert endpoint == "/fitness/v6/athletes/123/workouts"
         payload = mock_instance.post.call_args[1]["json"]
-        assert payload["exerciseLibraryId"] == 1
-        assert payload["exerciseLibraryItemId"] == 10
-        assert payload["date"] == "2026-04-01T00:00:00"
+        assert payload["workoutDay"] == "2026-04-01T00:00:00"
+        assert payload["title"] == "Sweet Spot"
+        assert payload["workoutTypeFamilyId"] == 2
+        assert payload["workoutTypeValueId"] == 2
+        assert payload["workoutSubTypeId"] == 3
+        assert payload["tssPlanned"] == 80.0
+        # Calendar workouts carry structure as a JSON string
+        assert isinstance(payload["structure"], str)
+
+    @pytest.mark.asyncio
+    async def test_schedule_unknown_item_returns_not_found(self):
+        items_response = APIResponse(success=True, data=[self.TEMPLATE])
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=items_response)
+            mock_instance.post = AsyncMock()
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_schedule_library_workout("1", "404", "2026-04-01")
+
+        assert result.get("isError") is True
+        assert result["error_code"] == "NOT_FOUND"
+        mock_instance.post.assert_not_called()


### PR DESCRIPTION
## Problem

Found while building a training plan from library templates — four related bugs in the exercise-library tools:

1. **`tp_create_library_item` creates items with sport 0 ("unknown")** — it posts `workoutTypeFamilyId`/`workoutTypeValueId`, but the library API expects `workoutTypeId`/`workoutSubTypeId`. The wrong fields are silently ignored, so every created template lands with `workoutTypeId: 0` and **renders without power targets** in the TP UI, even when the structure is valid.
2. **`tp_get_libraries` returns empty names** — the API returns `libraryName`/`isDefaultContent`, not `name`/`isDefault`. There is also no `itemCount` field, so `item_count` was always 0.
3. **`tp_get_library_items` always returns `sport: null`** — items carry `workoutTypeId`, not `workoutTypeFamilyId`.
4. **`tp_schedule_library_workout` always fails with HTTP 500** — the `commands/addworkoutfromlibraryitem` endpoint 500s for every payload shape I could construct (string/int ids, `date` vs `workoutDay`, with/without `athleteId`).

## Fix

- Create payload now sends `workoutTypeId` (sport, e.g. 2=Bike) and `workoutSubTypeId` (e.g. 3=Road Bike); schema descriptions in `server.py` clarify the two params.
- `tp_get_libraries` maps `libraryName`/`isDefaultContent` and returns `owner_name` instead of the nonexistent `item_count`.
- `tp_get_library_items` maps sport from `workoutTypeId`.
- `tp_schedule_library_workout` now fetches the template and copies it into a planned workout via `POST /fitness/v6/athletes/{id}/workouts` (title, planned duration/TSS/IF, description, structure serialized as a JSON string) — mirroring what the TP web app effectively does when you drag a template onto the calendar — and returns the new `workout_id`.

## Testing

- `uv run pytest tests/` — 383 passed (updated library tests assert the corrected payloads/mappings; added a NOT_FOUND case for scheduling an unknown item)
- `ruff` clean on changed files, `mypy src` clean
- **Verified against the live TrainingPeaks API**: created item stores `workoutTypeId: 2` / `workoutSubTypeId: 3` and renders power targets; scheduled copy carries title, TSS/IF, and full structure; library names/sports now populate. (Used these fixes for real to rebuild a 49-workout training block from library templates.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)