### PR TITLE
Fix libraryName mapping and schedule_library_workout endpoint

### DIFF
--- a/src/tp_mcp/client/http.py
+++ b/src/tp_mcp/client/http.py
@@ -293,6 +293,7 @@ class TPClient:
         endpoint: str,
         json: dict[str, Any] | list[Any] | None = None,
         params: dict[str, Any] | None = None,
+        base_url: str | None = None,
         _retry_on_401: bool = True,
     ) -> APIResponse:
         """Make an authenticated API request.
@@ -302,6 +303,7 @@ class TPClient:
             endpoint: API endpoint (e.g., "/users/v3/user").
             json: JSON body for POST/PUT requests.
             params: Query parameters.
+            base_url: Optional base URL override for endpoints not on the default host.
             _retry_on_401: Internal flag to prevent infinite retry loops.
 
         Returns:
@@ -317,7 +319,7 @@ class TPClient:
 
         await self._throttle()
 
-        url = f"{self.base_url}{endpoint}"
+        url = f"{base_url or self.base_url}{endpoint}"
         headers = self._get_headers()
 
         try:
@@ -333,7 +335,9 @@ class TPClient:
             if response.status_code == 401 and _retry_on_401:
                 # Token might have expired mid-request, clear and retry once
                 self._token_cache.clear()
-                return await self._request(method, endpoint, json=json, params=params, _retry_on_401=False)
+                return await self._request(
+                    method, endpoint, json=json, params=params, base_url=base_url, _retry_on_401=False
+                )
 
             return self._handle_response(response)
 
@@ -424,17 +428,23 @@ class TPClient:
         """
         return await self._request("GET", endpoint, params=params)
 
-    async def post(self, endpoint: str, json: dict[str, Any] | list[Any] | None = None) -> APIResponse:
+    async def post(
+        self,
+        endpoint: str,
+        json: dict[str, Any] | list[Any] | None = None,
+        base_url: str | None = None,
+    ) -> APIResponse:
         """Make a POST request.
 
         Args:
             endpoint: API endpoint.
             json: JSON body.
+            base_url: Optional base URL override for endpoints not on the default host.
 
         Returns:
             APIResponse.
         """
-        return await self._request("POST", endpoint, json=json)
+        return await self._request("POST", endpoint, json=json, base_url=base_url)
 
     async def put(self, endpoint: str, json: dict[str, Any] | list[Any] | None = None) -> APIResponse:
         """Make a PUT request.

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -27,6 +27,7 @@ from tp_mcp.tools import (
     tp_create_library,
     tp_create_library_item,
     tp_create_note,
+    tp_create_strength_workout,
     tp_create_workout,
     tp_delete_availability,
     tp_delete_equipment,
@@ -971,6 +972,72 @@ TOOLS = [
         },
     ),
     Tool(
+        name="tp_create_strength_workout",
+        description=(
+            "Create a structured strength workout on a calendar date. "
+            "Each block has blockType (SingleExercise/WarmUp/CoolDown/Superset), "
+            "title, optional coachNotes, and a list of exercises. Each exercise "
+            "has exercise_id, exercise_title, and sets (list of {parameter, value})."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "date": {"type": "string", "description": "YYYY-MM-DD"},
+                "title": {"type": "string"},
+                "blocks": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "blockType": {
+                                "type": "string",
+                                "description": (
+                                    "SingleExercise | WarmUp | CoolDown | Superset"
+                                ),
+                            },
+                            "title": {"type": "string"},
+                            "coachNotes": {"type": ["string", "null"]},
+                            "exercises": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "exercise_id": {"type": "string"},
+                                        "exercise_title": {"type": "string"},
+                                        "sets": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "parameter": {"type": "string"},
+                                                    "value": {
+                                                        "type": [
+                                                            "number",
+                                                            "integer",
+                                                            "null",
+                                                        ]
+                                                    },
+                                                },
+                                                "required": ["parameter"],
+                                            },
+                                        },
+                                    },
+                                    "required": [
+                                        "exercise_id",
+                                        "exercise_title",
+                                        "sets",
+                                    ],
+                                },
+                            },
+                        },
+                        "required": ["blockType", "title", "exercises"],
+                    },
+                },
+            },
+            "required": ["date", "title", "blocks"],
+        },
+    ),
+    Tool(
         name="tp_list_athletes",
         description="List athletes available to this account (coach accounts).",
         inputSchema={
@@ -1354,6 +1421,12 @@ async def _h_update_lib_item(args):
 async def _h_schedule_lib(args):
     return await tp_schedule_library_workout(
         library_id=args["library_id"], item_id=args["item_id"], date=args["date"],
+    )
+
+@_handler("tp_create_strength_workout")
+async def _h_create_strength(args):
+    return await tp_create_strength_workout(
+        date=args["date"], title=args["title"], blocks=args["blocks"],
     )
 
 

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -31,6 +31,7 @@ from tp_mcp.tools.fitness import tp_get_fitness
 from tp_mcp.tools.library import (
     tp_create_library,
     tp_create_library_item,
+    tp_create_strength_workout,
     tp_delete_library,
     tp_get_libraries,
     tp_get_library_item,
@@ -86,6 +87,7 @@ __all__ = [
     "tp_create_library",
     "tp_create_library_item",
     "tp_create_note",
+    "tp_create_strength_workout",
     "tp_create_workout",
     "tp_delete_availability",
     "tp_delete_equipment",

--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -523,11 +523,30 @@ async def tp_schedule_library_workout(
 
 # Parameter metadata for the structured strength builder. Unknown parameter
 # names fall back to a Reps-like Integer shape.
+# templateLabel is the suffix used in setSummaryTemplate after "{Param}";
+# an empty string means no suffix (e.g. "{Duration}" rather than "{Duration} Duration").
+
+# TrainingPeaks' default owner ID for library exercises — required by the UI.
+_STRENGTH_DEFAULT_OWNER_ID = 2000301
+
 _STRENGTH_PARAM_DEFS: dict[str, dict[str, Any]] = {
     "Reps": {
         "category": "Reps",
         "unit": {"title": "Reps", "abbreviation": "", "unit": "Reps"},
         "inputFormat": "Integer",
+        "templateLabel": "Reps",
+    },
+    "Duration": {
+        "category": "Duration",
+        "unit": {"title": "Seconds", "abbreviation": "sec", "unit": "Seconds"},
+        "inputFormat": "Time",
+        "templateLabel": "",
+    },
+    "WeightLb": {
+        "category": "WeightLb",
+        "unit": {"title": "Pounds", "abbreviation": "lb", "unit": "Pounds"},
+        "inputFormat": "Decimal",
+        "templateLabel": "lbs",
     },
 }
 
@@ -539,13 +558,25 @@ def _strength_param_def(name: str) -> dict[str, Any]:
             "category": name,
             "unit": {"title": name, "abbreviation": "", "unit": name},
             "inputFormat": "Integer",
+            "templateLabel": name,
         },
     )
+
+
+def _serialize_prescribed_value(value: Any) -> Any:
+    # TP API requires prescribedValue as a string for all parameter types
+    # (e.g. "30" for Duration seconds, "15" for Reps, "135" for WeightLb).
+    # None is preserved (valid for nullable parameters like WeightLb).
+    if value is None:
+        return None
+    return str(value)
 
 
 def _build_strength_prescription(exercise: dict[str, Any]) -> dict[str, Any]:
     exercise_id = str(exercise.get("exercise_id", ""))
     exercise_title = exercise.get("exercise_title", "")
+    video_url = exercise.get("video_url", "") or ""
+    instructions = exercise.get("instructions", "") or ""
     sets_input = exercise.get("sets", []) or []
 
     # Unique parameter names in first-seen order define the exercise columns.
@@ -582,18 +613,37 @@ def _build_strength_prescription(exercise: dict[str, Any]) -> dict[str, Any]:
                         "id": str(uuid.uuid4()),
                         "parameter": p,
                         "inputFormat": defs["inputFormat"],
-                        "prescribedValue": s.get("value"),
+                        "prescribedValue": _serialize_prescribed_value(s.get("value")),
                         "executedValue": None,
                     }
                 ],
             }
         )
 
-    template = " ".join(f"{{{p}}} {p}" for p in param_order)
+    template_parts: list[str] = []
+    for p in param_order:
+        label = _strength_param_def(p).get("templateLabel", p)
+        template_parts.append(f"{{{p}}} {label}".rstrip())
+    template = " ".join(template_parts)
+
+    # TP UI requires the full exercise object — id/title alone causes a crash
+    # when opening the workout. ownerId 2000301 is TP's default for library
+    # exercises; parameters mirrors the prescription-level parameters array.
+    exercise_obj = {
+        "id": exercise_id,
+        "title": exercise_title,
+        "ownerId": _STRENGTH_DEFAULT_OWNER_ID,
+        "videoUrl": video_url,
+        "instructions": instructions,
+        "primaryMuscleGroups": [],
+        "secondaryMuscleGroups": [],
+        "canEdit": False,
+        "parameters": parameters,
+    }
 
     return {
         "id": str(uuid.uuid4()),
-        "exercise": {"id": exercise_id, "title": exercise_title},
+        "exercise": exercise_obj,
         "parameters": parameters,
         "sets": sets,
         "coachNotes": None,
@@ -633,7 +683,9 @@ async def tp_create_strength_workout(
             - title: str
             - coachNotes: str | None (optional)
             - exercises: list of {exercise_id, exercise_title,
-              sets: list of {parameter, value}}
+              sets: list of {parameter, value},
+              video_url: str | None (optional),
+              instructions: str | None (optional)}
 
     Returns:
         Dict with confirmation or error.

--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -1,6 +1,7 @@
 """Workout library tools: templates, scheduling."""
 
 import logging
+import uuid
 from typing import Any
 
 from pydantic import ValidationError
@@ -517,4 +518,192 @@ async def tp_schedule_library_workout(
             "success": True,
             "message": f"Library workout scheduled for {date}.",
             "date": date,
+        }
+
+
+# Parameter metadata for the structured strength builder. Unknown parameter
+# names fall back to a Reps-like Integer shape.
+_STRENGTH_PARAM_DEFS: dict[str, dict[str, Any]] = {
+    "Reps": {
+        "category": "Reps",
+        "unit": {"title": "Reps", "abbreviation": "", "unit": "Reps"},
+        "inputFormat": "Integer",
+    },
+}
+
+
+def _strength_param_def(name: str) -> dict[str, Any]:
+    return _STRENGTH_PARAM_DEFS.get(
+        name,
+        {
+            "category": name,
+            "unit": {"title": name, "abbreviation": "", "unit": name},
+            "inputFormat": "Integer",
+        },
+    )
+
+
+def _build_strength_prescription(exercise: dict[str, Any]) -> dict[str, Any]:
+    exercise_id = str(exercise.get("exercise_id", ""))
+    exercise_title = exercise.get("exercise_title", "")
+    sets_input = exercise.get("sets", []) or []
+
+    # Unique parameter names in first-seen order define the exercise columns.
+    param_order: list[str] = []
+    for s in sets_input:
+        p = s.get("parameter")
+        if p and p not in param_order:
+            param_order.append(p)
+
+    parameters = []
+    for p in param_order:
+        defs = _strength_param_def(p)
+        parameters.append(
+            {
+                "id": str(uuid.uuid4()),
+                "parameter": p,
+                "title": p,
+                "category": defs["category"],
+                "unit": defs["unit"],
+            }
+        )
+
+    sets = []
+    for s in sets_input:
+        p = s.get("parameter", "")
+        defs = _strength_param_def(p)
+        sets.append(
+            {
+                "id": str(uuid.uuid4()),
+                "isComplete": False,
+                "setOrigin": "Prescribed",
+                "parameterValues": [
+                    {
+                        "id": str(uuid.uuid4()),
+                        "parameter": p,
+                        "inputFormat": defs["inputFormat"],
+                        "prescribedValue": s.get("value"),
+                        "executedValue": None,
+                    }
+                ],
+            }
+        )
+
+    template = " ".join(f"{{{p}}} {p}" for p in param_order)
+
+    return {
+        "id": str(uuid.uuid4()),
+        "exercise": {"id": exercise_id, "title": exercise_title},
+        "parameters": parameters,
+        "sets": sets,
+        "coachNotes": None,
+        "compliancePercent": 0,
+        "complianceState": "NoCompletion",
+        "setSummaryTemplate": template,
+    }
+
+
+def _build_strength_block(block: dict[str, Any]) -> dict[str, Any]:
+    exercises = block.get("exercises", []) or []
+    return {
+        "id": str(uuid.uuid4()),
+        "blockType": block.get("blockType", "SingleExercise"),
+        "title": block.get("title", ""),
+        "coachNotes": block.get("coachNotes"),
+        "parameters": [],
+        "isComplete": False,
+        "compliancePercent": 0,
+        "complianceState": "NoCompletion",
+        "prescriptions": [_build_strength_prescription(ex) for ex in exercises],
+    }
+
+
+async def tp_create_strength_workout(
+    date: str,
+    title: str,
+    blocks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Create a structured strength workout via TrainingPeaks' strength builder.
+
+    Args:
+        date: Target date (YYYY-MM-DD).
+        title: Workout title.
+        blocks: List of block dicts. Each block has:
+            - blockType: SingleExercise | WarmUp | CoolDown | Superset
+            - title: str
+            - coachNotes: str | None (optional)
+            - exercises: list of {exercise_id, exercise_title,
+              sets: list of {parameter, value}}
+
+    Returns:
+        Dict with confirmation or error.
+    """
+    from datetime import date as date_type
+
+    try:
+        date_type.fromisoformat(date)
+    except ValueError:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": f"Invalid date: {date}",
+        }
+
+    if not title or not title.strip():
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": "Workout title must not be empty.",
+        }
+
+    if not isinstance(blocks, list) or not blocks:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": "blocks must be a non-empty list.",
+        }
+
+    async with TPClient() as client:
+        athlete_id = await client.ensure_athlete_id()
+        if not athlete_id:
+            return {
+                "isError": True,
+                "error_code": "AUTH_INVALID",
+                "message": "Could not get athlete ID. Re-authenticate.",
+            }
+
+        api_blocks = [_build_strength_block(b) for b in blocks]
+
+        payload: dict[str, Any] = {
+            "workoutType": "StructuredStrength",
+            "calendarId": athlete_id,
+            "title": title.strip(),
+            "prescribedDate": date,
+            "orderOnDay": 1,
+            "isHidden": False,
+            "isLocked": False,
+            "complianceState": "Unplanned",
+            "blocks": api_blocks,
+        }
+
+        endpoint = "/rx/activity/v1/workouts/save"
+        response = await client.post(endpoint, json=payload, base_url=RX_API_BASE)
+
+        if response.is_error:
+            return {
+                "isError": True,
+                "error_code": response.error_code.value if response.error_code else "API_ERROR",
+                "message": response.message,
+            }
+
+        workout_id = None
+        if isinstance(response.data, dict):
+            workout_id = response.data.get("id") or response.data.get("workoutId")
+
+        return {
+            "success": True,
+            "title": title.strip(),
+            "date": date,
+            "block_count": len(api_blocks),
+            "workout_id": workout_id,
         }

--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -10,6 +10,9 @@ from tp_mcp.tools._validation import WorkoutIdInput, format_validation_error
 
 logger = logging.getLogger("tp-mcp")
 
+# Calendar scheduling lives on a separate host from the default tpapi base.
+RX_API_BASE = "https://api.peakswaresb.com"
+
 
 async def tp_get_libraries() -> dict[str, Any]:
     """List all workout library folders.
@@ -40,7 +43,7 @@ async def tp_get_libraries() -> dict[str, Any]:
         libraries = [
             {
                 "id": lib.get("exerciseLibraryId", lib.get("id")),
-                "name": lib.get("name", ""),
+                "name": lib.get("libraryName", lib.get("name", "")),
                 "is_default": lib.get("isDefault", False),
                 "item_count": lib.get("itemCount", 0),
             }
@@ -489,13 +492,19 @@ async def tp_schedule_library_workout(
                 "message": "Could not get athlete ID. Re-authenticate.",
             }
 
-        endpoint = f"/fitness/v6/athletes/{athlete_id}/commands/addworkoutfromlibraryitem"
-        payload = {
-            "exerciseLibraryId": lib_validated.workout_id,
-            "exerciseLibraryItemId": item_validated.workout_id,
-            "date": f"{date}T00:00:00",
+        # library_id is accepted for caller convenience but not part of the
+        # new applyToCalendar payload — the item ID alone identifies the source.
+        _ = lib_validated
+
+        endpoint = "/rx/activity/v1/libraryContent/workoutLibrary/applyToCalendar"
+        payload: dict[str, Any] = {
+            "calendarId": athlete_id,
+            "workoutLibraryItemId": int(item_validated.workout_id),
+            "prescribedDate": date,
+            "prescribedStartTime": None,
+            "orderOnDay": 1,
         }
-        response = await client.post(endpoint, json=payload)
+        response = await client.post(endpoint, json=payload, base_url=RX_API_BASE)
 
         if response.is_error:
             return {

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -95,6 +95,7 @@ class TestListTools:
             "tp_create_library_item",
             "tp_update_library_item",
             "tp_schedule_library_workout",
+            "tp_create_strength_workout",
             "tp_list_athletes",
             "tp_upload_workout_file",
             "tp_download_workout_file",

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -19,8 +19,8 @@ class TestGetLibraries:
     @pytest.mark.asyncio
     async def test_list_libraries(self):
         data = [
-            {"exerciseLibraryId": 1, "name": "My Workouts", "isDefault": False, "itemCount": 5},
-            {"exerciseLibraryId": 2, "name": "Default", "isDefault": True, "itemCount": 20},
+            {"exerciseLibraryId": 1, "libraryName": "My Workouts", "isDefault": False, "itemCount": 5},
+            {"exerciseLibraryId": 2, "libraryName": "Default", "isDefault": True, "itemCount": 20},
         ]
         response = APIResponse(success=True, data=data)
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
@@ -125,7 +125,18 @@ class TestScheduleLibraryWorkout:
             result = await tp_schedule_library_workout("1", "10", "2026-04-01")
 
         assert result["success"] is True
-        payload = mock_instance.post.call_args[1]["json"]
-        assert payload["exerciseLibraryId"] == 1
-        assert payload["exerciseLibraryItemId"] == 10
-        assert payload["date"] == "2026-04-01T00:00:00"
+
+        call_args = mock_instance.post.call_args
+        endpoint = call_args[0][0]
+        payload = call_args[1]["json"]
+        base_url = call_args[1]["base_url"]
+
+        assert endpoint == "/rx/activity/v1/libraryContent/workoutLibrary/applyToCalendar"
+        assert base_url == "https://api.peakswaresb.com"
+        assert payload == {
+            "calendarId": 123,
+            "workoutLibraryItemId": 10,
+            "prescribedDate": "2026-04-01",
+            "prescribedStartTime": None,
+            "orderOnDay": 1,
+        }

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -250,7 +250,17 @@ class TestCreateStrengthWorkout:
         assert isinstance(warmup["id"], str) and len(warmup["id"]) == 36
 
         prescription = warmup["prescriptions"][0]
-        assert prescription["exercise"] == {"id": "100", "title": "Air Squat"}
+        ex = prescription["exercise"]
+        assert ex["id"] == "100"
+        assert ex["title"] == "Air Squat"
+        assert ex["ownerId"] == 2000301
+        assert ex["videoUrl"] == ""
+        assert ex["instructions"] == ""
+        assert ex["primaryMuscleGroups"] == []
+        assert ex["secondaryMuscleGroups"] == []
+        assert ex["canEdit"] is False
+        # Exercise parameters must mirror the prescription-level parameters array
+        assert ex["parameters"] == prescription["parameters"]
         assert prescription["coachNotes"] is None
         assert prescription["complianceState"] == "NoCompletion"
         assert prescription["setSummaryTemplate"] == "{Reps} Reps"
@@ -272,7 +282,7 @@ class TestCreateStrengthWorkout:
             pv = s["parameterValues"][0]
             assert pv["parameter"] == "Reps"
             assert pv["inputFormat"] == "Integer"
-            assert pv["prescribedValue"] == 10
+            assert pv["prescribedValue"] == "10"
             assert pv["executedValue"] is None
 
         # Back Squat: 3 sets of 5 reps
@@ -281,7 +291,7 @@ class TestCreateStrengthWorkout:
         assert squat["coachNotes"] is None
         assert len(squat["prescriptions"][0]["sets"]) == 3
         assert all(
-            s["parameterValues"][0]["prescribedValue"] == 5
+            s["parameterValues"][0]["prescribedValue"] == "5"
             for s in squat["prescriptions"][0]["sets"]
         )
 
@@ -351,3 +361,132 @@ class TestCreateStrengthWorkout:
 
         assert result["isError"] is True
         assert result["error_code"] == "AUTH_INVALID"
+
+    @pytest.mark.asyncio
+    async def test_duration_parameter_serialization(self):
+        """Duration parameters use inputFormat='Time', string prescribedValue, and bare template."""
+        response = APIResponse(success=True, data={"id": 1})
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            blocks = [
+                {
+                    "blockType": "SingleExercise",
+                    "title": "Plank",
+                    "exercises": [
+                        {
+                            "exercise_id": "400",
+                            "exercise_title": "Plank",
+                            "sets": [
+                                {"parameter": "Duration", "value": 30},
+                                {"parameter": "Duration", "value": 45},
+                            ],
+                        },
+                    ],
+                },
+            ]
+            await tp_create_strength_workout(
+                date="2026-04-01", title="Core", blocks=blocks,
+            )
+
+        payload = mock_instance.post.call_args[1]["json"]
+        prescription = payload["blocks"][0]["prescriptions"][0]
+
+        assert prescription["setSummaryTemplate"] == "{Duration}"
+        assert prescription["parameters"][0]["parameter"] == "Duration"
+        assert prescription["parameters"][0]["category"] == "Duration"
+        assert prescription["parameters"][0]["unit"] == {
+            "title": "Seconds",
+            "abbreviation": "sec",
+            "unit": "Seconds",
+        }
+
+        pv0 = prescription["sets"][0]["parameterValues"][0]
+        pv1 = prescription["sets"][1]["parameterValues"][0]
+        assert pv0["inputFormat"] == "Time"
+        assert pv0["prescribedValue"] == "30"
+        assert pv1["inputFormat"] == "Time"
+        assert pv1["prescribedValue"] == "45"
+
+    @pytest.mark.asyncio
+    async def test_weightlb_parameter_serialization(self):
+        """WeightLb parameters use inputFormat='Decimal', string-or-None prescribedValue."""
+        response = APIResponse(success=True, data={"id": 1})
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            blocks = [
+                {
+                    "blockType": "SingleExercise",
+                    "title": "Bench",
+                    "exercises": [
+                        {
+                            "exercise_id": "500",
+                            "exercise_title": "Bench Press",
+                            "sets": [
+                                {"parameter": "WeightLb", "value": 135},
+                                {"parameter": "WeightLb", "value": None},
+                            ],
+                        },
+                    ],
+                },
+            ]
+            await tp_create_strength_workout(
+                date="2026-04-01", title="Bench Day", blocks=blocks,
+            )
+
+        payload = mock_instance.post.call_args[1]["json"]
+        prescription = payload["blocks"][0]["prescriptions"][0]
+
+        assert prescription["setSummaryTemplate"] == "{WeightLb} lbs"
+        assert prescription["parameters"][0]["unit"] == {
+            "title": "Pounds",
+            "abbreviation": "lb",
+            "unit": "Pounds",
+        }
+        pv0 = prescription["sets"][0]["parameterValues"][0]
+        pv1 = prescription["sets"][1]["parameterValues"][0]
+        assert pv0["inputFormat"] == "Decimal"
+        assert pv0["prescribedValue"] == "135"
+        assert pv1["inputFormat"] == "Decimal"
+        assert pv1["prescribedValue"] is None
+
+    @pytest.mark.asyncio
+    async def test_exercise_video_url_and_instructions_passthrough(self):
+        """Optional video_url and instructions on the exercise are passed through."""
+        response = APIResponse(success=True, data={"id": 1})
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            blocks = [
+                {
+                    "blockType": "SingleExercise",
+                    "title": "Custom",
+                    "exercises": [
+                        {
+                            "exercise_id": "600",
+                            "exercise_title": "Custom Lift",
+                            "video_url": "https://example.com/v.mp4",
+                            "instructions": "Lift with form.",
+                            "sets": [{"parameter": "Reps", "value": 8}],
+                        },
+                    ],
+                },
+            ]
+            await tp_create_strength_workout(
+                date="2026-04-01", title="Custom Day", blocks=blocks,
+            )
+
+        payload = mock_instance.post.call_args[1]["json"]
+        ex = payload["blocks"][0]["prescriptions"][0]["exercise"]
+        assert ex["videoUrl"] == "https://example.com/v.mp4"
+        assert ex["instructions"] == "Lift with form."

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -8,6 +8,7 @@ from tp_mcp.client.http import APIResponse
 from tp_mcp.tools.library import (
     tp_create_library,
     tp_create_library_item,
+    tp_create_strength_workout,
     tp_delete_library,
     tp_get_libraries,
     tp_get_library_items,
@@ -140,3 +141,213 @@ class TestScheduleLibraryWorkout:
             "prescribedStartTime": None,
             "orderOnDay": 1,
         }
+
+
+class TestCreateStrengthWorkout:
+    @pytest.mark.asyncio
+    async def test_invalid_date(self):
+        result = await tp_create_strength_workout(
+            date="not-a-date", title="Strength", blocks=[{"blockType": "SingleExercise", "title": "X", "exercises": []}],
+        )
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_empty_title(self):
+        result = await tp_create_strength_workout(
+            date="2026-04-01", title="   ", blocks=[{"blockType": "SingleExercise", "title": "X", "exercises": []}],
+        )
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_empty_blocks(self):
+        result = await tp_create_strength_workout(
+            date="2026-04-01", title="Strength", blocks=[],
+        )
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_creates_with_correct_payload(self):
+        response = APIResponse(success=True, data={"id": 999})
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            blocks = [
+                {
+                    "blockType": "WarmUp",
+                    "title": "Warm-up",
+                    "coachNotes": "Easy",
+                    "exercises": [
+                        {
+                            "exercise_id": "100",
+                            "exercise_title": "Air Squat",
+                            "sets": [
+                                {"parameter": "Reps", "value": 10},
+                                {"parameter": "Reps", "value": 10},
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "blockType": "SingleExercise",
+                    "title": "Back Squat",
+                    "exercises": [
+                        {
+                            "exercise_id": "200",
+                            "exercise_title": "Back Squat",
+                            "sets": [
+                                {"parameter": "Reps", "value": 5},
+                                {"parameter": "Reps", "value": 5},
+                                {"parameter": "Reps", "value": 5},
+                            ],
+                        },
+                    ],
+                },
+            ]
+
+            result = await tp_create_strength_workout(
+                date="2026-04-01", title="Strength A", blocks=blocks,
+            )
+
+        assert result["success"] is True
+        assert result["title"] == "Strength A"
+        assert result["date"] == "2026-04-01"
+        assert result["block_count"] == 2
+        assert result["workout_id"] == 999
+
+        call_args = mock_instance.post.call_args
+        endpoint = call_args[0][0]
+        payload = call_args[1]["json"]
+        base_url = call_args[1]["base_url"]
+
+        assert endpoint == "/rx/activity/v1/workouts/save"
+        assert base_url == "https://api.peakswaresb.com"
+
+        assert payload["workoutType"] == "StructuredStrength"
+        assert payload["calendarId"] == 123
+        assert payload["title"] == "Strength A"
+        assert payload["prescribedDate"] == "2026-04-01"
+        assert payload["orderOnDay"] == 1
+        assert payload["isHidden"] is False
+        assert payload["isLocked"] is False
+        assert payload["complianceState"] == "Unplanned"
+
+        assert len(payload["blocks"]) == 2
+        warmup = payload["blocks"][0]
+        assert warmup["blockType"] == "WarmUp"
+        assert warmup["title"] == "Warm-up"
+        assert warmup["coachNotes"] == "Easy"
+        assert warmup["parameters"] == []
+        assert warmup["isComplete"] is False
+        assert warmup["compliancePercent"] == 0
+        assert warmup["complianceState"] == "NoCompletion"
+        # UUIDs are string-typed
+        assert isinstance(warmup["id"], str) and len(warmup["id"]) == 36
+
+        prescription = warmup["prescriptions"][0]
+        assert prescription["exercise"] == {"id": "100", "title": "Air Squat"}
+        assert prescription["coachNotes"] is None
+        assert prescription["complianceState"] == "NoCompletion"
+        assert prescription["setSummaryTemplate"] == "{Reps} Reps"
+
+        # Single shared parameter column
+        assert len(prescription["parameters"]) == 1
+        param = prescription["parameters"][0]
+        assert param["parameter"] == "Reps"
+        assert param["title"] == "Reps"
+        assert param["category"] == "Reps"
+        assert param["unit"] == {"title": "Reps", "abbreviation": "", "unit": "Reps"}
+
+        # Two sets, each with one parameterValue
+        assert len(prescription["sets"]) == 2
+        for s in prescription["sets"]:
+            assert s["isComplete"] is False
+            assert s["setOrigin"] == "Prescribed"
+            assert len(s["parameterValues"]) == 1
+            pv = s["parameterValues"][0]
+            assert pv["parameter"] == "Reps"
+            assert pv["inputFormat"] == "Integer"
+            assert pv["prescribedValue"] == 10
+            assert pv["executedValue"] is None
+
+        # Back Squat: 3 sets of 5 reps
+        squat = payload["blocks"][1]
+        assert squat["blockType"] == "SingleExercise"
+        assert squat["coachNotes"] is None
+        assert len(squat["prescriptions"][0]["sets"]) == 3
+        assert all(
+            s["parameterValues"][0]["prescribedValue"] == 5
+            for s in squat["prescriptions"][0]["sets"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_unique_uuids_per_field(self):
+        response = APIResponse(success=True, data={})
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            blocks = [
+                {
+                    "blockType": "SingleExercise",
+                    "title": "Bench",
+                    "exercises": [
+                        {
+                            "exercise_id": "300",
+                            "exercise_title": "Bench Press",
+                            "sets": [
+                                {"parameter": "Reps", "value": 8},
+                                {"parameter": "Reps", "value": 8},
+                            ],
+                        },
+                    ],
+                },
+            ]
+            await tp_create_strength_workout(
+                date="2026-04-01", title="W", blocks=blocks,
+            )
+
+        payload = mock_instance.post.call_args[1]["json"]
+        block = payload["blocks"][0]
+        prescription = block["prescriptions"][0]
+
+        ids = [
+            block["id"],
+            prescription["id"],
+            prescription["parameters"][0]["id"],
+            prescription["sets"][0]["id"],
+            prescription["sets"][1]["id"],
+            prescription["sets"][0]["parameterValues"][0]["id"],
+            prescription["sets"][1]["parameterValues"][0]["id"],
+        ]
+        # All UUIDs distinct
+        assert len(set(ids)) == len(ids)
+
+    @pytest.mark.asyncio
+    async def test_auth_failure(self):
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=None)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_create_strength_workout(
+                date="2026-04-01",
+                title="Strength",
+                blocks=[
+                    {
+                        "blockType": "SingleExercise",
+                        "title": "X",
+                        "exercises": [],
+                    }
+                ],
+            )
+
+        assert result["isError"] is True
+        assert result["error_code"] == "AUTH_INVALID"


### PR DESCRIPTION
Fix tp_get_libraries dropping libraryName and tp_schedule_library_workout AUTH_INVALID

Two bug fixes:

1. tp_get_libraries was mapping "name" instead of "libraryName" from the API
   response, causing all library folder names to return as empty strings.

2. tp_schedule_library_workout was hitting the wrong endpoint and sending the
   wrong payload shape, causing AUTH_INVALID for coach-athlete scheduling.
   Fixed to use the correct applyToCalendar endpoint with calendarId,
   workoutLibraryItemId, and prescribedDate. Also added per-call base_url
   override to http.py to support the api.peakswaresb.com host.

Both fixes tested against a live TrainingPeaks coach account.