### PR TITLE
fix(workouts): populate sport (was always null) from workoutTypeValueId

### DIFF
--- a/src/tp_mcp/client/models.py
+++ b/src/tp_mcp/client/models.py
@@ -21,6 +21,48 @@ def _strip_datetime_to_date(v: Any) -> Any:
 DateOnly = Annotated[date_type, BeforeValidator(_strip_datetime_to_date)]
 
 
+# Maps a TrainingPeaks base-sport id (``workoutTypeValueId``) to a sport name.
+#
+# The v6 workouts endpoints (list and single detail) do NOT return the legacy
+# ``workoutTypeFamilyId`` field; they carry the base sport in
+# ``workoutTypeValueId`` (the specific subtype, if any, lives in the separate
+# ``workoutSubTypeId`` field). The ids below match the families returned by
+# ``GET /fitness/v6/workouttypes`` and the values in ``SPORT_TYPE_MAP`` used by
+# the create/update tools, so the resolved name round-trips back into
+# ``tp_create_workout`` / ``tp_update_workout`` unchanged.
+WORKOUT_TYPE_VALUE_TO_SPORT: dict[int, str] = {
+    1: "Swim",
+    2: "Bike",
+    3: "Run",
+    4: "Brick",
+    5: "Crosstrain",
+    6: "Race",
+    7: "DayOff",
+    8: "MtnBike",
+    9: "Strength",
+    10: "Custom",
+    11: "XCSki",
+    12: "Rowing",
+    13: "Walk",
+    29: "Strength",  # newer Strength family (Mobility/Yoga/etc. subtypes)
+    100: "Other",
+}
+
+
+def _sport_from_type_value(value: Any) -> str | None:
+    """Resolve a TrainingPeaks base-sport name from a ``workoutTypeValueId``."""
+    if isinstance(value, bool):  # bool is an int subclass; never a valid id
+        return None
+    if isinstance(value, int):
+        return WORKOUT_TYPE_VALUE_TO_SPORT.get(value)
+    if isinstance(value, str):
+        try:
+            return WORKOUT_TYPE_VALUE_TO_SPORT.get(int(value))
+        except ValueError:
+            return None
+    return None
+
+
 class UserProfile(BaseModel):
     """User profile information."""
 
@@ -49,7 +91,6 @@ class WorkoutSummary(BaseModel):
     workout_date: DateOnly = Field(alias="workoutDay")
     title: str | None = None
     workout_type: str | int | None = Field(default=None, alias="workoutTypeValueId")
-    sport: str | None = Field(default=None, alias="workoutTypeFamilyId")
     duration_planned: int | float | None = Field(default=None, alias="totalTimePlanned")
     duration_actual: int | float | None = Field(default=None, alias="totalTime")
     tss_planned: float | None = Field(default=None, alias="tssPlanned")
@@ -63,6 +104,15 @@ class WorkoutSummary(BaseModel):
     def date(self) -> date_type:
         """Alias for workout_date for backwards compatibility."""
         return self.workout_date
+
+    @property
+    def sport(self) -> str | None:
+        """Base sport name, derived from ``workoutTypeValueId``.
+
+        The v6 list response omits ``workoutTypeFamilyId``, so the sport is
+        resolved from the type value id present on every workout.
+        """
+        return _sport_from_type_value(self.workout_type)
 
     @property
     def is_completed(self) -> bool:
@@ -106,7 +156,6 @@ class WorkoutDetail(BaseModel):
     id: int = Field(alias="workoutId")
     workout_date: DateOnly = Field(alias="workoutDay")
     title: str | None = None
-    sport: str | None = Field(default=None, alias="workoutTypeFamilyId")
     workout_type: str | int | None = Field(default=None, alias="workoutTypeValueId")
     description: str | None = None
     duration_planned: int | float | None = Field(default=None, alias="totalTimePlanned")
@@ -130,6 +179,15 @@ class WorkoutDetail(BaseModel):
     def date(self) -> date_type:
         """Alias for workout_date for backwards compatibility."""
         return self.workout_date
+
+    @property
+    def sport(self) -> str | None:
+        """Base sport name, derived from ``workoutTypeValueId``.
+
+        The v6 detail response omits ``workoutTypeFamilyId``, so the sport is
+        resolved from the type value id present on every workout.
+        """
+        return _sport_from_type_value(self.workout_type)
 
 
 class AnalysisTotal(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def mock_api_responses():
                 "workoutId": 1001,
                 "workoutDay": "2025-01-08",
                 "title": "Test Workout",
-                "workoutTypeFamilyId": "bike",
+                "workoutTypeValueId": 2,  # Bike
                 "totalTimePlanned": 3600,
                 "totalTime": 3500,
                 "tssPlanned": 80,
@@ -112,7 +112,7 @@ def mock_api_responses():
                 "workoutId": 1002,
                 "workoutDay": "2025-01-09",
                 "title": "Planned Workout",
-                "workoutTypeFamilyId": "run",
+                "workoutTypeValueId": 3,  # Run
                 "totalTimePlanned": 1800,
                 "tssPlanned": 40,
                 "completed": False,
@@ -122,7 +122,7 @@ def mock_api_responses():
             "workoutId": 1001,
             "workoutDay": "2025-01-08",
             "title": "Test Workout",
-            "workoutTypeFamilyId": "bike",
+            "workoutTypeValueId": 2,  # Bike
             "description": "Test description",
             "totalTimePlanned": 3600,
             "totalTime": 3500,

--- a/tests/test_client/test_models.py
+++ b/tests/test_client/test_models.py
@@ -54,7 +54,7 @@ class TestWorkoutSummary:
             "workoutId": 1001,
             "workoutDay": "2025-01-08",
             "title": "Test Workout",
-            "workoutTypeFamilyId": "bike",
+            "workoutTypeValueId": 2,  # Bike
             "totalTimePlanned": 3600,
             "totalTime": 3500,
             "tssPlanned": 80,
@@ -69,6 +69,7 @@ class TestWorkoutSummary:
         assert workout.title == "Test Workout"
         assert workout.is_completed is True
         assert workout.workout_status == "completed"
+        assert workout.sport == "Bike"  # resolved from workoutTypeValueId
 
     def test_parse_planned_workout(self):
         """Test parsing planned workout summary."""
@@ -84,6 +85,7 @@ class TestWorkoutSummary:
         assert workout.id == 1002
         assert workout.is_completed is False
         assert workout.workout_status == "planned"
+        assert workout.sport is None  # no type id present
 
 
 class TestWorkoutDetail:
@@ -147,6 +149,64 @@ class TestWorkoutDetail:
         assert workout.elevation_gain == 80.0
         assert workout.calories == 570
         assert workout.distance_actual == 30000.0
+        assert workout.sport == "Bike"  # resolved from workoutTypeValueId
+
+
+class TestSportResolution:
+    """sport is derived from workoutTypeValueId (v6 omits workoutTypeFamilyId)."""
+
+    def test_summary_resolves_each_base_sport(self):
+        """Every base-sport id maps to its SPORT_TYPE_MAP name."""
+        cases = {
+            1: "Swim",
+            2: "Bike",
+            3: "Run",
+            4: "Brick",
+            5: "Crosstrain",
+            6: "Race",
+            7: "DayOff",
+            8: "MtnBike",
+            9: "Strength",
+            10: "Custom",
+            11: "XCSki",
+            12: "Rowing",
+            13: "Walk",
+            29: "Strength",
+            100: "Other",
+        }
+        for type_id, expected in cases.items():
+            workout = WorkoutSummary.model_validate({
+                "workoutId": 1,
+                "workoutDay": "2025-01-08",
+                "workoutTypeValueId": type_id,
+            })
+            assert workout.sport == expected, f"id {type_id}"
+
+    def test_detail_resolves_sport(self):
+        """WorkoutDetail resolves sport the same way as WorkoutSummary."""
+        detail = WorkoutDetail.model_validate({
+            "workoutId": 1,
+            "workoutDay": "2025-01-08",
+            "workoutTypeValueId": 3,
+        })
+        assert detail.sport == "Run"
+
+    def test_unknown_type_id_is_none(self):
+        """An unrecognised type id resolves to None rather than raising."""
+        workout = WorkoutSummary.model_validate({
+            "workoutId": 1,
+            "workoutDay": "2025-01-08",
+            "workoutTypeValueId": 9999,
+        })
+        assert workout.sport is None
+
+    def test_missing_type_id_is_none(self):
+        """A workout with no type id resolves to None."""
+        workout = WorkoutSummary.model_validate({
+            "workoutId": 1,
+            "workoutDay": "2025-01-08",
+        })
+        assert workout.sport is None
 
 
 class TestParseWorkoutList:

--- a/tests/test_tools/test_workouts.py
+++ b/tests/test_tools/test_workouts.py
@@ -28,6 +28,9 @@ class TestTpGetWorkouts:
         assert "isError" not in result or not result.get("isError")
         assert result["count"] == 2
         assert len(result["workouts"]) == 2
+        # sport is resolved from workoutTypeValueId (Bike=2, Run=3)
+        assert result["workouts"][0]["sport"] == "Bike"
+        assert result["workouts"][1]["sport"] == "Run"
 
     @pytest.mark.asyncio
     async def test_get_workouts_exposes_planned_and_actual_tss(self, mock_api_responses):


### PR DESCRIPTION
Fixes #111

## Problem

`tp_get_workouts` and `tp_get_workout` always return `"sport": null`.

## Root cause

`WorkoutSummary.sport` / `WorkoutDetail.sport` were aliased to `workoutTypeFamilyId`:

```python
sport: str | None = Field(default=None, alias="workoutTypeFamilyId")
```

The v6 workouts endpoints don't return `workoutTypeFamilyId`. They carry the base sport in `workoutTypeValueId` (an int; the subtype, if any, is in `workoutSubTypeId`). With the aliased field missing from the response, `sport` silently defaults to `None`. The previous fixtures hid this with a fake `"workoutTypeFamilyId": "bike"` string the API never sends.

## Fix

Resolve `sport` from `workoutTypeValueId` via a reverse map of the base-sport ids. The names match `SPORT_TYPE_MAP`, so the value round-trips back into `tp_create_workout` / `tp_update_workout`. `sport` becomes a computed property, consistent with the models' existing `date` / `is_completed` / `workout_status` properties.

## Verification

Against a live account, all 26 workouts in an 11-day range now resolve correctly (Bike / Run / Swim / Brick / DayOff / Other) — 0 nulls. Single-workout detail resolves too.

## Tests

- Updated fixtures to the real `workoutTypeValueId` shape.
- Added coverage for every base-sport id, an unknown id (→ `None`), and a missing id (→ `None`).
- Full suite: 386 passed. `ruff check src/` and `mypy src/` clean.
