### PR TITLE
feat(groups): expose TP athlete groups (tags) — read side (tp_list_groups + tp_list_athletes_in_group)

### DIFF
--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -62,6 +62,8 @@ from tp_mcp.tools import (
     tp_get_workout_types,
     tp_get_workouts,
     tp_list_athletes,
+    tp_list_athletes_in_group,
+    tp_list_groups,
     tp_list_notes,
     tp_log_metrics,
     tp_pair_workout,
@@ -994,6 +996,30 @@ TOOLS = [
             "properties": {},
         },
     ),
+    Tool(
+        name="tp_list_groups",
+        description="List the coach's athlete groups (TP exposes these as tags). "
+                    "Returns id, name, athlete_count, is_default.",
+        inputSchema={
+            "type": "object",
+            "properties": {},
+        },
+    ),
+    Tool(
+        name="tp_list_athletes_in_group",
+        description="List the athletes in one athlete group, with names resolved "
+                    "from the coach's roster. Use tp_list_groups to get group_id.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "group_id": {
+                    "type": "string",
+                    "description": "Group (tag) ID from tp_list_groups.",
+                },
+            },
+            "required": ["group_id"],
+        },
+    ),
 ]
 
 # ---------------------------------------------------------------------------
@@ -1002,6 +1028,8 @@ TOOLS = [
 _ATHLETE_EXEMPT_TOOLS = {
     "tp_auth_status", "tp_refresh_auth", "tp_validate_structure",
     "tp_list_athletes", "tp_get_workout_types",
+    # Coach-scoped (groups belong to the coach, not a targeted athlete).
+    "tp_list_groups", "tp_list_athletes_in_group",
 }
 
 _ATHLETE_PARAM = {
@@ -1045,6 +1073,12 @@ async def _h_get_profile(args): return await tp_get_profile()
 
 @_handler("tp_list_athletes")
 async def _h_list_athletes(args): return await tp_list_athletes()
+
+@_handler("tp_list_groups")
+async def _h_list_groups(args): return await tp_list_groups()
+
+@_handler("tp_list_athletes_in_group")
+async def _h_list_athletes_in_group(args): return await tp_list_athletes_in_group(group_id=args["group_id"])
 
 @_handler("tp_refresh_auth")
 async def _h_refresh_auth(args): return await tp_refresh_auth(browser=args.get("browser", "auto"))

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -28,6 +28,7 @@ from tp_mcp.tools.events import (
     tp_update_note,
 )
 from tp_mcp.tools.fitness import tp_get_fitness
+from tp_mcp.tools.groups import tp_list_athletes_in_group, tp_list_groups
 from tp_mcp.tools.library import (
     tp_create_library,
     tp_create_library_item,
@@ -121,6 +122,8 @@ __all__ = [
     "tp_get_workout_prs",
     "tp_get_workout_types",
     "tp_list_athletes",
+    "tp_list_groups",
+    "tp_list_athletes_in_group",
     "tp_get_workouts",
     "tp_log_metrics",
     "tp_pair_workout",

--- a/src/tp_mcp/tools/groups.py
+++ b/src/tp_mcp/tools/groups.py
@@ -1,0 +1,145 @@
+"""Athlete group tools — read-only (issue #69).
+
+TrainingPeaks exposes a coach's "Athlete Groups" as TAGS in the API:
+
+    GET /coaches/v2/coaches/{coachId}/tags
+
+where ``coachId`` is the personId of the token owner. These are *coach-scoped*
+endpoints — they describe how the coach has grouped their roster, so they do
+NOT take an ``athlete`` target. Each tag looks like::
+
+    {"id": 123, "coachId": 1135463, "name": "Group A",
+     "athleteIds": [201, 202], "isDefault": false}
+
+This module exposes listing only. Creating / updating / deleting groups is a
+separate (write) effort: the POST/PUT/DELETE signatures must first be verified
+against the live API, because TP write bodies are easy to get wrong (the
+library endpoints, for instance, needed ``libraryName`` rather than ``name``
+and an explicit ``ownerId``).
+"""
+
+import logging
+from typing import Any
+
+from tp_mcp.client import TPClient
+
+logger = logging.getLogger("tp-mcp")
+
+_TAGS_ENDPOINT = "/coaches/v2/coaches/{coach_id}/tags"
+
+
+async def _coach_id(client: TPClient) -> int | None:
+    """personId of the token owner — the ``coachId`` for group endpoints.
+
+    Groups are coach-scoped, so this deliberately ignores any athlete override
+    (unlike ``ensure_athlete_id``): the grouping belongs to the coach, not to a
+    targeted athlete.
+    """
+    user_data = await client._get_user_data()
+    if not user_data:
+        return None
+    return user_data.get("personId")
+
+
+def _slim_group(tag: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": tag.get("id"),
+        "name": tag.get("name", ""),
+        "athlete_count": len(tag.get("athleteIds") or []),
+        "is_default": tag.get("isDefault", False),
+    }
+
+
+async def tp_list_groups() -> dict[str, Any]:
+    """List the coach's athlete groups (TP tags).
+
+    Returns:
+        Dict with a ``groups`` list of ``{id, name, athlete_count, is_default}``.
+    """
+    async with TPClient() as client:
+        coach_id = await _coach_id(client)
+        if not coach_id:
+            return {
+                "isError": True,
+                "error_code": "AUTH_INVALID",
+                "message": "Could not resolve the coach account. Re-authenticate.",
+            }
+
+        response = await client.get(_TAGS_ENDPOINT.format(coach_id=coach_id))
+        if response.is_error:
+            return {
+                "isError": True,
+                "error_code": response.error_code.value if response.error_code else "API_ERROR",
+                "message": response.message,
+            }
+
+        data = response.data if isinstance(response.data, list) else []
+        groups = [_slim_group(t) for t in data if isinstance(t, dict)]
+        return {"groups": groups, "count": len(groups)}
+
+
+async def tp_list_athletes_in_group(group_id: str) -> dict[str, Any]:
+    """List the athletes in one group, resolving athleteIds to names.
+
+    Args:
+        group_id: The group (tag) ID from tp_list_groups.
+
+    Returns:
+        Dict with the group name and an ``athletes`` list of
+        ``{athlete_id, name}`` (names joined from the coach's roster).
+    """
+    try:
+        gid = int(group_id)
+    except (TypeError, ValueError):
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": f"group_id must be a numeric ID, got {group_id!r}.",
+        }
+
+    async with TPClient() as client:
+        user_data = await client._get_user_data()
+        if not user_data or not user_data.get("personId"):
+            return {
+                "isError": True,
+                "error_code": "AUTH_INVALID",
+                "message": "Could not resolve the coach account. Re-authenticate.",
+            }
+        coach_id = user_data.get("personId")
+
+        response = await client.get(_TAGS_ENDPOINT.format(coach_id=coach_id))
+        if response.is_error:
+            return {
+                "isError": True,
+                "error_code": response.error_code.value if response.error_code else "API_ERROR",
+                "message": response.message,
+            }
+
+        data = response.data if isinstance(response.data, list) else []
+        tag = next((t for t in data
+                    if isinstance(t, dict) and t.get("id") == gid), None)
+        if tag is None:
+            return {
+                "isError": True,
+                "error_code": "NOT_FOUND",
+                "message": f"No athlete group with id {gid}. Use tp_list_groups.",
+            }
+
+        # Join athleteIds against the coach's roster (from /users/v3/user, the
+        # same source tp_list_athletes uses) to attach names.
+        roster = {a.get("athleteId"): a for a in user_data.get("athletes", [])}
+        athletes = []
+        for aid in (tag.get("athleteIds") or []):
+            a = roster.get(aid)
+            # name is None when the athlete is in the group but not in this
+            # account's roster
+            name = f"{a.get('firstName', '')} {a.get('lastName', '')}".strip() if a is not None else None
+            athletes.append({"athlete_id": aid, "name": name})
+        athletes.sort(key=lambda x: (x["name"] or "").lower())
+
+        return {
+            "group_id": gid,
+            "name": tag.get("name", ""),
+            "athletes": athletes,
+            "count": len(athletes),
+        }

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -96,6 +96,8 @@ class TestListTools:
             "tp_update_library_item",
             "tp_schedule_library_workout",
             "tp_list_athletes",
+            "tp_list_groups",
+            "tp_list_athletes_in_group",
             "tp_upload_workout_file",
             "tp_download_workout_file",
             "tp_delete_workout_file",

--- a/tests/test_tools/test_groups.py
+++ b/tests/test_tools/test_groups.py
@@ -1,0 +1,136 @@
+"""Tests for athlete group (tag) read tools — issue #69."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tp_mcp.client.http import APIResponse
+from tp_mcp.tools.groups import tp_list_athletes_in_group, tp_list_groups
+
+USER = {
+    "personId": 1135463,
+    "athletes": [
+        {"athleteId": 201, "firstName": "Charlotte", "lastName": "Horton"},
+        {"athleteId": 202, "firstName": "Ivan", "lastName": "Petrov"},
+        {"athleteId": 203, "firstName": "Anna", "lastName": "Sun"},
+    ],
+}
+
+TAGS = [
+    {"id": 11, "coachId": 1135463, "name": "Group A",
+     "athleteIds": [202, 201], "isDefault": False},
+    {"id": 12, "coachId": 1135463, "name": "My Athletes",
+     "athleteIds": [201, 202, 203], "isDefault": True},
+]
+
+
+def _client(**methods):
+    inst = AsyncMock()
+    for name, value in methods.items():
+        setattr(inst, name, AsyncMock(return_value=value))
+    return inst
+
+
+def _patch(monkeypatch_target, instance):
+    p = patch(monkeypatch_target)
+    mock = p.start()
+    mock.return_value.__aenter__.return_value = instance
+    return p
+
+
+# ── tp_list_groups ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_list_groups_ok():
+    inst = _client(
+        _get_user_data=USER,
+        get=APIResponse(success=True, data=TAGS),
+    )
+    with patch("tp_mcp.tools.groups.TPClient") as mc:
+        mc.return_value.__aenter__.return_value = inst
+        out = await tp_list_groups()
+    assert out["count"] == 2
+    a = next(g for g in out["groups"] if g["id"] == 11)
+    assert a == {"id": 11, "name": "Group A", "athlete_count": 2, "is_default": False}
+    default = next(g for g in out["groups"] if g["id"] == 12)
+    assert default["is_default"] is True
+    # coach-scoped endpoint built from personId
+    inst.get.assert_awaited_once_with("/coaches/v2/coaches/1135463/tags")
+
+
+@pytest.mark.asyncio
+async def test_list_groups_auth_failure():
+    inst = _client(_get_user_data=None)
+    with patch("tp_mcp.tools.groups.TPClient") as mc:
+        mc.return_value.__aenter__.return_value = inst
+        out = await tp_list_groups()
+    assert out["isError"] is True
+    assert out["error_code"] == "AUTH_INVALID"
+
+
+@pytest.mark.asyncio
+async def test_list_groups_api_error():
+    inst = _client(
+        _get_user_data=USER,
+        get=APIResponse(success=False, message="boom"),
+    )
+    with patch("tp_mcp.tools.groups.TPClient") as mc:
+        mc.return_value.__aenter__.return_value = inst
+        out = await tp_list_groups()
+    assert out["isError"] is True
+
+
+# ── tp_list_athletes_in_group ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_list_athletes_in_group_joins_names_sorted():
+    inst = _client(
+        _get_user_data=USER,
+        get=APIResponse(success=True, data=TAGS),
+    )
+    with patch("tp_mcp.tools.groups.TPClient") as mc:
+        mc.return_value.__aenter__.return_value = inst
+        out = await tp_list_athletes_in_group("11")
+    assert out["group_id"] == 11
+    assert out["name"] == "Group A"
+    # sorted by name: Charlotte Horton, Ivan Petrov
+    assert out["athletes"] == [
+        {"athlete_id": 201, "name": "Charlotte Horton"},
+        {"athlete_id": 202, "name": "Ivan Petrov"},
+    ]
+    assert out["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_list_athletes_in_group_unknown_id():
+    inst = _client(
+        _get_user_data=USER,
+        get=APIResponse(success=True, data=TAGS),
+    )
+    with patch("tp_mcp.tools.groups.TPClient") as mc:
+        mc.return_value.__aenter__.return_value = inst
+        out = await tp_list_athletes_in_group("999")
+    assert out["isError"] is True
+    assert out["error_code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_list_athletes_in_group_non_numeric():
+    out = await tp_list_athletes_in_group("abc")
+    assert out["isError"] is True
+    assert out["error_code"] == "VALIDATION_ERROR"
+
+
+@pytest.mark.asyncio
+async def test_list_athletes_in_group_athlete_not_in_roster():
+    user = {"personId": 1135463, "athletes": []}   # roster doesn't have the ids
+    inst = _client(
+        _get_user_data=user,
+        get=APIResponse(success=True, data=TAGS),
+    )
+    with patch("tp_mcp.tools.groups.TPClient") as mc:
+        mc.return_value.__aenter__.return_value = inst
+        out = await tp_list_athletes_in_group("11")
+    # ids preserved, names None (still useful to the caller)
+    assert {a["athlete_id"] for a in out["athletes"]} == {201, 202}
+    assert all(a["name"] is None for a in out["athletes"])


### PR DESCRIPTION
As requested in #101 / #69 — the **read side** first.

Adds two tools backed by the TP coach tags API (`/coaches/v2/coaches/{coachId}/tags`, verified live; `coachId` = the token owner's `personId`):

- **`tp_list_groups`** — the coach's groups with `id` / `name` / `athleteIds` / `isDefault`
- **`tp_list_athletes_in_group`** — a group's membership

Covers #69's core read need. Write-side CRUD (create / rename / delete + add / remove members) is implemented and tested on our side too — happy to send it as a follow-up PR once this lands, per your note.

Tests: `tests/test_tools/test_groups.py` (7). Full suite green (398).

Addresses #69 and #101.