### PR TITLE
feat(strength): structured strength/gym workouts via Peaksware API (#17)

### DIFF
--- a/src/tp_mcp/data/exercises.json
+++ b/src/tp_mcp/data/exercises.json
@@ -1,0 +1,20356 @@
+{
+ "1": {
+  "id": "1",
+  "title": "Air Squat",
+  "videoUrl": "https://youtu.be/xPtIxrUwnxg",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "63"
+   }
+  ]
+ },
+ "6": {
+  "id": "6",
+  "title": "Band Face Pull",
+  "videoUrl": "https://youtu.be/9MiPot3jB3I",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "68"
+   }
+  ]
+ },
+ "7": {
+  "id": "7",
+  "title": "Band Pull Apart",
+  "videoUrl": "https://youtu.be/2Tf_E4cYmD4",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Chest"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "69"
+   }
+  ]
+ },
+ "8": {
+  "id": "8",
+  "title": "Band Rotation Stretch",
+  "videoUrl": "https://youtu.be/6Y-dNMZQSf0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "70"
+   }
+  ]
+ },
+ "9": {
+  "id": "9",
+  "title": "Barbell Bicep Curl",
+  "videoUrl": "https://youtu.be/yL5iINtD874",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "71"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "194"
+   }
+  ]
+ },
+ "10": {
+  "id": "10",
+  "title": "Barbell Reverse Lunge",
+  "videoUrl": "https://youtu.be/Iw2OtbzZw4M",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "72"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "195"
+   }
+  ]
+ },
+ "11": {
+  "id": "11",
+  "title": "Barbell Overhead Press",
+  "videoUrl": "https://youtu.be/hQj_qpVpGOQ",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "73"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "196"
+   }
+  ]
+ },
+ "12": {
+  "id": "12",
+  "title": "Barbell Rollout",
+  "videoUrl": "https://youtu.be/qABKbx4cp4I",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "74"
+   }
+  ]
+ },
+ "13": {
+  "id": "13",
+  "title": "Barbell Shrug",
+  "videoUrl": "https://youtu.be/V1efRmNbCC8",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "75"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "197"
+   }
+  ]
+ },
+ "14": {
+  "id": "14",
+  "title": "Barbell Thruster",
+  "videoUrl": "https://youtu.be/_F25zs42hsQ",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "76"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "198"
+   }
+  ]
+ },
+ "16": {
+  "id": "16",
+  "title": "Bench Press",
+  "videoUrl": "https://youtu.be/O8PCB1Rwz-U",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "78"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "199"
+   }
+  ]
+ },
+ "21": {
+  "id": "21",
+  "title": "Box Jump",
+  "videoUrl": "https://youtu.be/8tO-FC0l720",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "83"
+   },
+   {
+    "parameter": "HeightIn",
+    "category": "Height",
+    "unit": "Inches",
+    "id": "203"
+   }
+  ]
+ },
+ "22": {
+  "id": "22",
+  "title": "Box Squat",
+  "videoUrl": "https://youtu.be/5rjEknKQcIU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "84"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "204"
+   }
+  ]
+ },
+ "23": {
+  "id": "23",
+  "title": "Broad Jump",
+  "videoUrl": "https://youtu.be/QbQVZdJ7XfI",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "85"
+   }
+  ]
+ },
+ "24": {
+  "id": "24",
+  "title": "Barbell Bulgarian Split Squat",
+  "videoUrl": "https://youtu.be/s_xmy9gt37U",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "86"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "205"
+   }
+  ]
+ },
+ "25": {
+  "id": "25",
+  "title": "Burpee",
+  "videoUrl": "https://youtu.be/5oak3C2g24g",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "87"
+   }
+  ]
+ },
+ "26": {
+  "id": "26",
+  "title": "Single Leg Calf Raise",
+  "videoUrl": "https://youtu.be/jRB58gIRAyU",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "88"
+   }
+  ]
+ },
+ "27": {
+  "id": "27",
+  "title": "Chin Up",
+  "videoUrl": "https://youtu.be/1xUIzwniBbk",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "89"
+   }
+  ]
+ },
+ "29": {
+  "id": "29",
+  "title": "Close Grip Push Up",
+  "videoUrl": "https://youtu.be/W_jcsoo-mKM",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "91"
+   }
+  ]
+ },
+ "30": {
+  "id": "30",
+  "title": "DB Bench Press",
+  "videoUrl": "https://youtu.be/S3XkISkekPA",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "92"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "207"
+   }
+  ]
+ },
+ "32": {
+  "id": "32",
+  "title": "DB Deadlift",
+  "videoUrl": "https://youtu.be/zjyvtMvVrUc",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "94"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "209"
+   }
+  ]
+ },
+ "33": {
+  "id": "33",
+  "title": "DB Farmer's Walk",
+  "videoUrl": "https://youtu.be/mRXBP20Ej9k",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Forearms"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceYd",
+    "category": "Distance",
+    "unit": "Yards",
+    "id": "95"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "210"
+   }
+  ]
+ },
+ "34": {
+  "id": "34",
+  "title": "DB Fly",
+  "videoUrl": "https://youtu.be/MgnvKUapygU",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "96"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "211"
+   }
+  ]
+ },
+ "35": {
+  "id": "35",
+  "title": "DB Front Squat",
+  "videoUrl": "https://youtu.be/ixeg3s04xlw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "97"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "212"
+   }
+  ]
+ },
+ "36": {
+  "id": "36",
+  "title": "DB Jump Lunge",
+  "videoUrl": "https://youtu.be/Z8q8X6XxGdk",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "98"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "213"
+   }
+  ]
+ },
+ "37": {
+  "id": "37",
+  "title": "DB Lateral Raise",
+  "videoUrl": "https://youtu.be/whusm2iuktU",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "99"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "214"
+   }
+  ]
+ },
+ "38": {
+  "id": "38",
+  "title": "DB Military Press",
+  "videoUrl": "https://youtu.be/6gxB7TTf0k0",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "100"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "215"
+   }
+  ]
+ },
+ "39": {
+  "id": "39",
+  "title": "DB Pullover",
+  "videoUrl": "https://youtu.be/vKL5L6L6Aeo",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "101"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "216"
+   }
+  ]
+ },
+ "40": {
+  "id": "40",
+  "title": "DB Push Press",
+  "videoUrl": "https://youtu.be/51B9XyliDrE",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "102"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "217"
+   }
+  ]
+ },
+ "42": {
+  "id": "42",
+  "title": "DB Side Bend",
+  "videoUrl": "https://youtu.be/7EUEzyf8hXo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "104"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "219"
+   }
+  ]
+ },
+ "43": {
+  "id": "43",
+  "title": "DB Skull Crusher",
+  "videoUrl": "https://youtu.be/DqG6ZkWZMPs",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "105"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "220"
+   }
+  ]
+ },
+ "45": {
+  "id": "45",
+  "title": "DB Swing",
+  "videoUrl": "https://youtu.be/fJwijelSyVw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "107"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "222"
+   }
+  ]
+ },
+ "46": {
+  "id": "46",
+  "title": "DB Thruster",
+  "videoUrl": "https://youtu.be/R5bzKfrS0xQ",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "108"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "223"
+   }
+  ]
+ },
+ "47": {
+  "id": "47",
+  "title": "DB Walking Lunge",
+  "videoUrl": "https://youtu.be/OQCwQO_Z4NU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "109"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "224"
+   }
+  ]
+ },
+ "49": {
+  "id": "49",
+  "title": "Diamond Push Up",
+  "videoUrl": "https://youtu.be/GaeesyLE27c",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "111"
+   }
+  ]
+ },
+ "50": {
+  "id": "50",
+  "title": "Double KB Clean & Jerk",
+  "videoUrl": "https://youtu.be/U7Ono7LT_zk",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "112"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "226"
+   }
+  ]
+ },
+ "51": {
+  "id": "51",
+  "title": "Double KB Front Squat",
+  "videoUrl": "https://youtu.be/_R5Sb6ii0yo",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "113"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "227"
+   }
+  ]
+ },
+ "52": {
+  "id": "52",
+  "title": "Double KB Push Press",
+  "videoUrl": "https://youtu.be/aAHVq-vZFME",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "114"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "228"
+   }
+  ]
+ },
+ "53": {
+  "id": "53",
+  "title": "Feet Elevated Push Up",
+  "videoUrl": "https://youtu.be/3teh2HApA7Y",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "115"
+   }
+  ]
+ },
+ "60": {
+  "id": "60",
+  "title": "One Arm KB Reverse Lunge",
+  "videoUrl": "https://youtu.be/_OoQ5yDnbS0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "122"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "234"
+   }
+  ]
+ },
+ "61": {
+  "id": "61",
+  "title": "KB Snatch",
+  "videoUrl": "https://youtu.be/W6q6-tWsmDs",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "123"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "235"
+   }
+  ]
+ },
+ "63": {
+  "id": "63",
+  "title": "Body Weight Lateral Lunge",
+  "videoUrl": "https://youtu.be/WFJjREH6AsU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "125"
+   }
+  ]
+ },
+ "64": {
+  "id": "64",
+  "title": "Medicine Ball Slam",
+  "videoUrl": "https://youtu.be/itvAc4dL_40",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "126"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "236"
+   }
+  ]
+ },
+ "65": {
+  "id": "65",
+  "title": "Mountain Climber",
+  "videoUrl": "https://youtu.be/nhUskkE96EI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "127"
+   }
+  ]
+ },
+ "69": {
+  "id": "69",
+  "title": "Overhead Walking Lunge",
+  "videoUrl": "https://youtu.be/PaUAM1Wh4nM",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "131"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "240"
+   }
+  ]
+ },
+ "71": {
+  "id": "71",
+  "title": "Plank",
+  "videoUrl": "https://youtu.be/l8EaE5zMENQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "133"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "242"
+   }
+  ]
+ },
+ "73": {
+  "id": "73",
+  "title": "Pull Up",
+  "videoUrl": "https://youtu.be/d3IlZYzLeaI",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "135"
+   }
+  ]
+ },
+ "75": {
+  "id": "75",
+  "title": "Renegade Row",
+  "videoUrl": "https://youtu.be/swWMhWTMBns",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "137"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "245"
+   }
+  ]
+ },
+ "76": {
+  "id": "76",
+  "title": "Reverse Lunge",
+  "videoUrl": "https://youtu.be/74-s0YAyEn4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "138"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "246"
+   }
+  ]
+ },
+ "77": {
+  "id": "77",
+  "title": "Russian KB swing",
+  "videoUrl": "https://youtu.be/PvdVVJ--DH8",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "139"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "247"
+   }
+  ]
+ },
+ "79": {
+  "id": "79",
+  "title": "Side Plank",
+  "videoUrl": "https://youtu.be/rrrxDvyfYN0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "141"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "249"
+   }
+  ]
+ },
+ "80": {
+  "id": "80",
+  "title": "Side Plank on Hand",
+  "videoUrl": "https://youtu.be/4IfpCPRjP_w",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "142"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "250"
+   }
+  ]
+ },
+ "81": {
+  "id": "81",
+  "title": "Single Leg Glute Bridge",
+  "videoUrl": "https://youtu.be/ZUtrQ8EU5t0",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "143"
+   }
+  ]
+ },
+ "83": {
+  "id": "83",
+  "title": "Sit-Up",
+  "videoUrl": "https://youtu.be/6CfzNazWmQQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "145"
+   }
+  ]
+ },
+ "84": {
+  "id": "84",
+  "title": "Skull Crusher",
+  "videoUrl": "https://youtu.be/zWbMG0zpPVE",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "146"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "252"
+   }
+  ]
+ },
+ "88": {
+  "id": "88",
+  "title": "Standing DB Press",
+  "videoUrl": "https://youtu.be/lEQLtx2dGnE",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "150"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "255"
+   }
+  ]
+ },
+ "89": {
+  "id": "89",
+  "title": "Standing KB Press",
+  "videoUrl": "https://youtu.be/EZTfG_9Q5LM",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "151"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "256"
+   }
+  ]
+ },
+ "90": {
+  "id": "90",
+  "title": "Superman",
+  "videoUrl": "https://youtu.be/zp7gJ4P8gpk",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "152"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "257"
+   }
+  ]
+ },
+ "92": {
+  "id": "92",
+  "title": "TRX Body Saw",
+  "videoUrl": "https://youtu.be/QFfOLSxjp-o",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "154"
+   }
+  ]
+ },
+ "93": {
+  "id": "93",
+  "title": "TRX Bulgarian Split Squat",
+  "videoUrl": "https://youtu.be/D2jAPPqwK4s",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "155"
+   }
+  ]
+ },
+ "94": {
+  "id": "94",
+  "title": "TRX Chest Fly",
+  "videoUrl": "https://youtu.be/J-syYiaeKs4",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "156"
+   }
+  ]
+ },
+ "95": {
+  "id": "95",
+  "title": "TRX Chest Press",
+  "videoUrl": "https://youtu.be/YvY61YFcDM0",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "157"
+   }
+  ]
+ },
+ "96": {
+  "id": "96",
+  "title": "TRX Cross Lunge",
+  "videoUrl": "https://youtu.be/3C2Q4bh9NX8",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "158"
+   }
+  ]
+ },
+ "97": {
+  "id": "97",
+  "title": "TRX Hip Hinge Stretch",
+  "videoUrl": "https://youtu.be/qINIOj8qhs4",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "159"
+   }
+  ]
+ },
+ "98": {
+  "id": "98",
+  "title": "TRX Hip Press",
+  "videoUrl": "https://youtu.be/tsugE7WFIrk",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "160"
+   }
+  ]
+ },
+ "99": {
+  "id": "99",
+  "title": "TRX Kneeing Rollout",
+  "videoUrl": "https://youtu.be/6I99J47VCQA",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "161"
+   }
+  ]
+ },
+ "100": {
+  "id": "100",
+  "title": "TRX Knee Tuck",
+  "videoUrl": "https://youtu.be/qWNuXlkiGL0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "162"
+   }
+  ]
+ },
+ "101": {
+  "id": "101",
+  "title": "TRX Lateral Lunge",
+  "videoUrl": "https://youtu.be/FNxCFu_Alx4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "163"
+   }
+  ]
+ },
+ "102": {
+  "id": "102",
+  "title": "TRX Low Back Stretch",
+  "videoUrl": "https://youtu.be/RbF0ZtScr1A",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "164"
+   }
+  ]
+ },
+ "103": {
+  "id": "103",
+  "title": "TRX Lower Deltoid Fly",
+  "videoUrl": "https://youtu.be/OKxHJmpPpTk",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "165"
+   }
+  ]
+ },
+ "105": {
+  "id": "105",
+  "title": "TRX Mid Row",
+  "videoUrl": "https://youtu.be/TyYc5QVT0vA",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "167"
+   }
+  ]
+ },
+ "106": {
+  "id": "106",
+  "title": "TRX Mountain Climber",
+  "videoUrl": "https://youtu.be/npdLry0drp8",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "168"
+   }
+  ]
+ },
+ "107": {
+  "id": "107",
+  "title": "TRX Oblique Crunch",
+  "videoUrl": "https://youtu.be/9tTu929ZMSk",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "169"
+   }
+  ]
+ },
+ "108": {
+  "id": "108",
+  "title": "TRX Overhead Squat",
+  "videoUrl": "https://youtu.be/FZjMjpnWodQ",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "170"
+   }
+  ]
+ },
+ "109": {
+  "id": "109",
+  "title": "TRX Pike",
+  "videoUrl": "https://youtu.be/ZTl-hGXFffc",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "171"
+   }
+  ]
+ },
+ "110": {
+  "id": "110",
+  "title": "TRX Pistol Squat",
+  "videoUrl": "https://youtu.be/3SI_JKta4Qw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "172"
+   }
+  ]
+ },
+ "111": {
+  "id": "111",
+  "title": "TRX Plank",
+  "videoUrl": "https://youtu.be/h_S_TnsKpoQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "173"
+   }
+  ]
+ },
+ "112": {
+  "id": "112",
+  "title": "TRX Power Pull",
+  "videoUrl": "https://youtu.be/X7bd2g62A48",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "174"
+   }
+  ]
+ },
+ "113": {
+  "id": "113",
+  "title": "TRX Push Up",
+  "videoUrl": "https://youtu.be/-AdG6qtcNaM",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "175"
+   }
+  ]
+ },
+ "114": {
+  "id": "114",
+  "title": "TRX Single Arm Mid Row",
+  "videoUrl": "https://youtu.be/oinrdMIZvsw",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "176"
+   }
+  ]
+ },
+ "115": {
+  "id": "115",
+  "title": "TRX Single Leg Plank",
+  "videoUrl": "https://youtu.be/cd1yNgItirU",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "177"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "258"
+   }
+  ]
+ },
+ "116": {
+  "id": "116",
+  "title": "TRX Single Leg Squat Jump",
+  "videoUrl": "https://youtu.be/l8gdg2Gvcms",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "178"
+   }
+  ]
+ },
+ "117": {
+  "id": "117",
+  "title": "TRX Sit-Up",
+  "videoUrl": "https://youtu.be/SvqDazlQQB4",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "179"
+   }
+  ]
+ },
+ "118": {
+  "id": "118",
+  "title": "TRX Split Deltoid Fly",
+  "videoUrl": "https://youtu.be/CFljnbla0AU",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "180"
+   }
+  ]
+ },
+ "120": {
+  "id": "120",
+  "title": "TRX Torso Rotation",
+  "videoUrl": "https://youtu.be/JdbenPBEtJ4",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "182"
+   }
+  ]
+ },
+ "121": {
+  "id": "121",
+  "title": "TRX Tricep Extension",
+  "videoUrl": "https://youtu.be/rj0LeZZuu0Q",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "183"
+   }
+  ]
+ },
+ "122": {
+  "id": "122",
+  "title": "Turkish Get Up",
+  "videoUrl": "https://youtu.be/twKrMcYCsBc",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "184"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "259"
+   }
+  ]
+ },
+ "125": {
+  "id": "125",
+  "title": "Wall Sit",
+  "videoUrl": "https://youtu.be/QHOr7igyiBs",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "187"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "261"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "659"
+   }
+  ]
+ },
+ "128": {
+  "id": "128",
+  "title": "Alternating DB Hammer Curl",
+  "videoUrl": "https://youtu.be/DcavD8oq_lg",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "64"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "190"
+   }
+  ]
+ },
+ "129": {
+  "id": "129",
+  "title": "Alternating Reverse DB Lunge",
+  "videoUrl": "https://youtu.be/o6ceMQMCtyA",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "65"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "191"
+   }
+  ]
+ },
+ "130": {
+  "id": "130",
+  "title": "American KB Swing",
+  "videoUrl": "https://youtu.be/FNZkUY9SrlM",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "66"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "192"
+   }
+  ]
+ },
+ "131": {
+  "id": "131",
+  "title": "Back Squat",
+  "videoUrl": "https://youtu.be/JLy14eUhVYI",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "67"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "193"
+   }
+  ]
+ },
+ "132": {
+  "id": "132",
+  "title": "Bench Dip",
+  "videoUrl": "https://youtu.be/g1O6CX4fn7A",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "77"
+   }
+  ]
+ },
+ "133": {
+  "id": "133",
+  "title": "Single Arm Bent Over DB Row",
+  "videoUrl": "https://youtu.be/7jiqP-2o9h4",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "79"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "200"
+   }
+  ]
+ },
+ "134": {
+  "id": "134",
+  "title": "Bent Over Barbell Row",
+  "videoUrl": "https://youtu.be/MWyeM4wg5cg",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "80"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "201"
+   }
+  ]
+ },
+ "135": {
+  "id": "135",
+  "title": "Bicycle Sit-Up",
+  "videoUrl": "https://youtu.be/JlWZ4V8LUyM",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "81"
+   }
+  ]
+ },
+ "136": {
+  "id": "136",
+  "title": "Single Arm Bottom-Up KB Press",
+  "videoUrl": "https://youtu.be/rPsa7dJCdYY",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "82"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "202"
+   }
+  ]
+ },
+ "137": {
+  "id": "137",
+  "title": "Clean",
+  "videoUrl": "https://youtu.be/O1BQJlhUKeo",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "90"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "206"
+   }
+  ]
+ },
+ "138": {
+  "id": "138",
+  "title": "DB Bicep Curl",
+  "videoUrl": "https://youtu.be/WeR82tVsEVs",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "93"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "208"
+   }
+  ]
+ },
+ "139": {
+  "id": "139",
+  "title": "DB Shrug",
+  "videoUrl": "https://youtu.be/EoGZd_fH9ds",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "103"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "218"
+   }
+  ]
+ },
+ "140": {
+  "id": "140",
+  "title": "Single Arm DB Snatch",
+  "videoUrl": "https://youtu.be/iXyRb5CQfUg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "106"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "221"
+   }
+  ]
+ },
+ "141": {
+  "id": "141",
+  "title": "Deadlift",
+  "videoUrl": "https://youtu.be/vds4MUa0TKs",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "110"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "225"
+   }
+  ]
+ },
+ "142": {
+  "id": "142",
+  "title": "DB Floor Press",
+  "videoUrl": "https://youtu.be/i1yoygDuZlA",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "116"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "229"
+   }
+  ]
+ },
+ "143": {
+  "id": "143",
+  "title": "Front Squat",
+  "videoUrl": "https://youtu.be/8MI1z_Qs9sw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "117"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "230"
+   }
+  ]
+ },
+ "144": {
+  "id": "144",
+  "title": "Goblet Squat",
+  "videoUrl": "https://youtu.be/xQrRzGYsiyo",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "118"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "231"
+   }
+  ]
+ },
+ "145": {
+  "id": "145",
+  "title": "Good Morning",
+  "videoUrl": "https://youtu.be/49rgzdBWWj4",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "119"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "232"
+   }
+  ]
+ },
+ "146": {
+  "id": "146",
+  "title": "Hang Clean",
+  "videoUrl": "https://youtu.be/m3VAxTGz1Tw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "120"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "233"
+   }
+  ]
+ },
+ "147": {
+  "id": "147",
+  "title": "Jumping Jack",
+  "videoUrl": "https://youtu.be/FGXP6aPDsCw",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "121"
+   }
+  ]
+ },
+ "148": {
+  "id": "148",
+  "title": "Knee Raise",
+  "videoUrl": "https://youtu.be/0Zz1af_YjxQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "124"
+   }
+  ]
+ },
+ "149": {
+  "id": "149",
+  "title": "Single Arm Curl + Press",
+  "videoUrl": "https://youtu.be/TIsdnUvnYy8",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "128"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "237"
+   }
+  ]
+ },
+ "150": {
+  "id": "150",
+  "title": "Single Arm DB Bench Press",
+  "videoUrl": "https://youtu.be/dOUlqBOrxYs",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "129"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "238"
+   }
+  ]
+ },
+ "151": {
+  "id": "151",
+  "title": "Single Arm DB Row",
+  "videoUrl": "https://youtu.be/efcUQe-Hhi8",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "130"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "239"
+   }
+  ]
+ },
+ "152": {
+  "id": "152",
+  "title": "Pistol Squat",
+  "videoUrl": "https://youtu.be/1P2gYsBmekQ",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "132"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "241"
+   }
+  ]
+ },
+ "153": {
+  "id": "153",
+  "title": "Power Clean",
+  "videoUrl": "https://youtu.be/t62C94vye9o",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "134"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "243"
+   }
+  ]
+ },
+ "154": {
+  "id": "154",
+  "title": "Romanian Deadlift",
+  "videoUrl": "https://youtu.be/DLidaP2nXf8",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "136"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "244"
+   }
+  ]
+ },
+ "155": {
+  "id": "155",
+  "title": "Medicine Ball Russian Twist",
+  "videoUrl": "https://youtu.be/gsKw6Epvm-o",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "140"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "248"
+   }
+  ]
+ },
+ "156": {
+  "id": "156",
+  "title": "Single Leg Romanian Deadlift",
+  "videoUrl": "https://youtu.be/kq75sF66TZs",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "144"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "251"
+   }
+  ]
+ },
+ "157": {
+  "id": "157",
+  "title": "Snatch",
+  "videoUrl": "https://youtu.be/z0it7UT6Qrw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "147"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "253"
+   }
+  ]
+ },
+ "158": {
+  "id": "158",
+  "title": "Split Squat",
+  "videoUrl": "https://youtu.be/r7vYpLXBasM",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "148"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "254"
+   }
+  ]
+ },
+ "159": {
+  "id": "159",
+  "title": "Squat Jump",
+  "videoUrl": "https://youtu.be/yWTD2Rg2wCE",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "149"
+   }
+  ]
+ },
+ "160": {
+  "id": "160",
+  "title": "TRX Bicep Curl",
+  "videoUrl": "https://youtu.be/KjFyDgJA9DM",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "153"
+   }
+  ]
+ },
+ "161": {
+  "id": "161",
+  "title": "TRX Lunge with Hop",
+  "videoUrl": "https://youtu.be/QRG8u5rBzcY",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "166"
+   }
+  ]
+ },
+ "162": {
+  "id": "162",
+  "title": "TRX Standing Rollout",
+  "videoUrl": "https://youtu.be/gF7yic84xog",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "181"
+   }
+  ]
+ },
+ "163": {
+  "id": "163",
+  "title": "V-Up",
+  "videoUrl": "https://youtu.be/fltnzHwP_jc",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "185"
+   }
+  ]
+ },
+ "164": {
+  "id": "164",
+  "title": "Wall Ball",
+  "videoUrl": "https://youtu.be/HB_C96MmqXM",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "186"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "260"
+   }
+  ]
+ },
+ "165": {
+  "id": "165",
+  "title": "Weighted Step Up",
+  "videoUrl": "https://youtu.be/0pHZ-XgXzIY",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "188"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "262"
+   }
+  ]
+ },
+ "396": {
+  "id": "396",
+  "title": "90 Degree Iso Chin Up Hold",
+  "videoUrl": "https://youtu.be/cUNOhNDgPp4",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "660"
+   }
+  ]
+ },
+ "397": {
+  "id": "397",
+  "title": "Alternating DB Bent Over Row",
+  "videoUrl": "https://youtu.be/7MI7jGzTLZA",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "661"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1683"
+   }
+  ]
+ },
+ "398": {
+  "id": "398",
+  "title": "Alternating DB Floor Press",
+  "videoUrl": "https://youtu.be/y01obtAT1gI",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "662"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1684"
+   }
+  ]
+ },
+ "399": {
+  "id": "399",
+  "title": "Alternating DB Lunge",
+  "videoUrl": "https://youtu.be/OIYYqUY3yx4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "663"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1685"
+   }
+  ]
+ },
+ "400": {
+  "id": "400",
+  "title": "Alternating DB Press",
+  "videoUrl": "https://youtu.be/oGZbB67Ff6Q",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "664"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1686"
+   }
+  ]
+ },
+ "401": {
+  "id": "401",
+  "title": "Alternating Heel Touch",
+  "videoUrl": "https://youtu.be/dqjD4AU4yR0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "665"
+   }
+  ]
+ },
+ "402": {
+  "id": "402",
+  "title": "Alternating Incline DB Curl",
+  "videoUrl": "https://youtu.be/IDRlUKikRzk",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "666"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1687"
+   }
+  ]
+ },
+ "403": {
+  "id": "403",
+  "title": "Alternating KB Hang Clean",
+  "videoUrl": "https://youtu.be/pzyXd0mP9aw",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "667"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1688"
+   }
+  ]
+ },
+ "404": {
+  "id": "404",
+  "title": "Alternating KB Press",
+  "videoUrl": "https://youtu.be/nkQ_ICz4u-g",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "668"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1689"
+   }
+  ]
+ },
+ "405": {
+  "id": "405",
+  "title": "Alternating KB Row",
+  "videoUrl": "https://youtu.be/FzpyIa7vxb8",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "669"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1690"
+   }
+  ]
+ },
+ "406": {
+  "id": "406",
+  "title": "Alternating Leg Swing",
+  "videoUrl": "https://youtu.be/x3TvQvCp7jU",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "670"
+   }
+  ]
+ },
+ "407": {
+  "id": "407",
+  "title": "Alternating Superman",
+  "videoUrl": "https://youtu.be/k9Bwu2mGOis",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "671"
+   }
+  ]
+ },
+ "408": {
+  "id": "408",
+  "title": "Arm Climb",
+  "videoUrl": "https://youtu.be/_NDnYm13Eb0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "672"
+   }
+  ]
+ },
+ "409": {
+  "id": "409",
+  "title": "Arnold Press",
+  "videoUrl": "https://youtu.be/tYdYyScwTcg",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "673"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1691"
+   }
+  ]
+ },
+ "410": {
+  "id": "410",
+  "title": "Bam Bam",
+  "videoUrl": "https://youtu.be/9ZpABRKIVjU",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "674"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1692"
+   }
+  ]
+ },
+ "411": {
+  "id": "411",
+  "title": "Band Abduction",
+  "videoUrl": "https://youtu.be/jvCTCtKg72Q",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "675"
+   }
+  ]
+ },
+ "412": {
+  "id": "412",
+  "title": "Band Assisted Pull Up",
+  "videoUrl": "https://youtu.be/KWPWaMZ4PY4",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "676"
+   }
+  ]
+ },
+ "413": {
+  "id": "413",
+  "title": "Band Assisted Push Up",
+  "videoUrl": "https://youtu.be/XuB8eAfDy4A",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "677"
+   }
+  ]
+ },
+ "414": {
+  "id": "414",
+  "title": "Band Pull Through",
+  "videoUrl": "https://youtu.be/cS8Ftum14Ug",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "678"
+   }
+  ]
+ },
+ "415": {
+  "id": "415",
+  "title": "Band Skull Crusher",
+  "videoUrl": "https://youtu.be/6xTbBHpDcJw",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "679"
+   }
+  ]
+ },
+ "416": {
+  "id": "416",
+  "title": "Band Tricep Push Down",
+  "videoUrl": "https://youtu.be/TZw-AZS-r9M",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "680"
+   }
+  ]
+ },
+ "417": {
+  "id": "417",
+  "title": "Banded Bicep Curl",
+  "videoUrl": "https://youtu.be/L-3ekMCdL-w",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "681"
+   }
+  ]
+ },
+ "418": {
+  "id": "418",
+  "title": "Banded Clam Shell",
+  "videoUrl": "https://youtu.be/EjHNhaIsGdw",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "682"
+   }
+  ]
+ },
+ "419": {
+  "id": "419",
+  "title": "Banded Glute Bridge",
+  "videoUrl": "https://youtu.be/eX6mnUv42CQ",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "683"
+   }
+  ]
+ },
+ "420": {
+  "id": "420",
+  "title": "Banded Good Morning",
+  "videoUrl": "https://youtu.be/4i8nbaRG1LQ",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "684"
+   }
+  ]
+ },
+ "421": {
+  "id": "421",
+  "title": "Banded Low Row",
+  "videoUrl": "https://youtu.be/kril7Oh8wwc",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "685"
+   }
+  ]
+ },
+ "422": {
+  "id": "422",
+  "title": "Banded Monster Walk",
+  "videoUrl": "https://youtu.be/eVIX8dqtqTA",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "686"
+   }
+  ]
+ },
+ "423": {
+  "id": "423",
+  "title": "Banded Plank Jack",
+  "videoUrl": "https://youtu.be/vhqaZ36x2qQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "687"
+   }
+  ]
+ },
+ "424": {
+  "id": "424",
+  "title": "Banded V Adduction",
+  "videoUrl": "https://youtu.be/6fPKHfhQ5K4",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "688"
+   }
+  ]
+ },
+ "425": {
+  "id": "425",
+  "title": "Bar Facing Burpee",
+  "videoUrl": "https://youtu.be/xYsV_YP7qDo",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "689"
+   }
+  ]
+ },
+ "426": {
+  "id": "426",
+  "title": "Barbell Ab Rollout",
+  "videoUrl": "https://youtu.be/NywNlVChxpA",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "690"
+   }
+  ]
+ },
+ "427": {
+  "id": "427",
+  "title": "Barbell Bent Over Row",
+  "videoUrl": "https://youtu.be/SYo7I468Jqo",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "691"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1693"
+   }
+  ]
+ },
+ "428": {
+  "id": "428",
+  "title": "Barbell Front Raise",
+  "videoUrl": "https://youtu.be/UZL3e3fAWK0",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "692"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1694"
+   }
+  ]
+ },
+ "429": {
+  "id": "429",
+  "title": "Barbell Hip Thrust",
+  "videoUrl": "https://youtu.be/S41lrDh2OvY",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "693"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1695"
+   }
+  ]
+ },
+ "430": {
+  "id": "430",
+  "title": "Barbell Shrug Behind the Back",
+  "videoUrl": "https://youtu.be/5wJ7moJ6kHk",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "694"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1696"
+   }
+  ]
+ },
+ "431": {
+  "id": "431",
+  "title": "Barbell Squat Jump",
+  "videoUrl": "https://youtu.be/kjNTI4CbxAI",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "695"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1697"
+   }
+  ]
+ },
+ "432": {
+  "id": "432",
+  "title": "Barbell Step Ups",
+  "videoUrl": "https://youtu.be/VKirxyNcqtk",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "696"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1698"
+   }
+  ]
+ },
+ "433": {
+  "id": "433",
+  "title": "Barbell Upright Row",
+  "videoUrl": "https://youtu.be/OUAn-aQWeqo",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "697"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1699"
+   }
+  ]
+ },
+ "434": {
+  "id": "434",
+  "title": "Behind the Neck Push Press",
+  "videoUrl": "https://youtu.be/t3e8AOfuDZw",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "698"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1700"
+   }
+  ]
+ },
+ "435": {
+  "id": "435",
+  "title": "Bent Arm Barbell Pull Over",
+  "videoUrl": "https://youtu.be/Eyah4s20DZc",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "699"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1701"
+   }
+  ]
+ },
+ "436": {
+  "id": "436",
+  "title": "Bent Knee Hip Raise",
+  "videoUrl": "https://youtu.be/wE7cUsmKX2Y",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "700"
+   }
+  ]
+ },
+ "437": {
+  "id": "437",
+  "title": "Bent Over DB Fly",
+  "videoUrl": "https://youtu.be/JQavx-NNXZs",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "701"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1702"
+   }
+  ]
+ },
+ "438": {
+  "id": "438",
+  "title": "Cable Bent Over Lateral Raise",
+  "videoUrl": "https://youtu.be/emjrs9M--jo",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "702"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1703"
+   }
+  ]
+ },
+ "439": {
+  "id": "439",
+  "title": "Bicep Curl to Shoulder Press",
+  "videoUrl": "https://youtu.be/iuM9r1wGU44",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "703"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1704"
+   }
+  ]
+ },
+ "440": {
+  "id": "440",
+  "title": "Bird Dog",
+  "videoUrl": "https://youtu.be/nI7epId02YA",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "704"
+   }
+  ]
+ },
+ "441": {
+  "id": "441",
+  "title": "Body Saw",
+  "videoUrl": "https://youtu.be/CHjunY2z4cA",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "705"
+   }
+  ]
+ },
+ "442": {
+  "id": "442",
+  "title": "Body Weight Alternating Lunge",
+  "videoUrl": "https://youtu.be/Qall172X0S4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "706"
+   }
+  ]
+ },
+ "443": {
+  "id": "443",
+  "title": "Body Weight Bulgarian Split Squat",
+  "videoUrl": "https://youtu.be/FkkvpGq_Gcc",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "707"
+   }
+  ]
+ },
+ "444": {
+  "id": "444",
+  "title": "Body Weight Lunge",
+  "videoUrl": "https://youtu.be/EcGCeO8gTKU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "708"
+   }
+  ]
+ },
+ "445": {
+  "id": "445",
+  "title": "Body Weight Reverse Alternating Lunge",
+  "videoUrl": "https://youtu.be/MviwTulKJ_E",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "709"
+   }
+  ]
+ },
+ "446": {
+  "id": "446",
+  "title": "Body Weight Reverse Lunge",
+  "videoUrl": "https://youtu.be/iwOaXH-gc6U",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "710"
+   }
+  ]
+ },
+ "447": {
+  "id": "447",
+  "title": "Body Weight Split Squat",
+  "videoUrl": "https://youtu.be/EAwPVEjvZLg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "711"
+   }
+  ]
+ },
+ "448": {
+  "id": "448",
+  "title": "Body Weight Walking Lunge",
+  "videoUrl": "https://youtu.be/wEh_ABwdUQg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "712"
+   }
+  ]
+ },
+ "449": {
+  "id": "449",
+  "title": "Bosu Ball Crunch",
+  "videoUrl": "https://youtu.be/zq2owIFL3NU",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "713"
+   }
+  ]
+ },
+ "450": {
+  "id": "450",
+  "title": "Bosu Ball Plank",
+  "videoUrl": "https://youtu.be/89_3jfAWAkQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "714"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1705"
+   }
+  ]
+ },
+ "451": {
+  "id": "451",
+  "title": "Bosu Ball Plank with Leg Lift",
+  "videoUrl": "https://youtu.be/fPuKSr0MUyo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "715"
+   }
+  ]
+ },
+ "452": {
+  "id": "452",
+  "title": "Bosu Ball Push Up V1",
+  "videoUrl": "https://youtu.be/DhouTXg7dxY",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "716"
+   }
+  ]
+ },
+ "453": {
+  "id": "453",
+  "title": "Bosu Ball Push Up V2",
+  "videoUrl": "https://youtu.be/O38ZoXDJry4",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "717"
+   }
+  ]
+ },
+ "454": {
+  "id": "454",
+  "title": "Bosu Ball Side Plank",
+  "videoUrl": "https://youtu.be/WHN29EAGcKA",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "718"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1706"
+   }
+  ]
+ },
+ "455": {
+  "id": "455",
+  "title": "Bosu Ball Sit Up",
+  "videoUrl": "https://youtu.be/MBD0jWh1s1I",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "719"
+   }
+  ]
+ },
+ "456": {
+  "id": "456",
+  "title": "Box Jump Over",
+  "videoUrl": "https://youtu.be/MQR0GdGw1hE",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "720"
+   }
+  ]
+ },
+ "457": {
+  "id": "457",
+  "title": "Box Toe Tap",
+  "videoUrl": "https://youtu.be/0YruYTojLsE",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "721"
+   }
+  ]
+ },
+ "458": {
+  "id": "458",
+  "title": "Burpee Box Jump",
+  "videoUrl": "https://youtu.be/ma2kAYMoTZo",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "722"
+   }
+  ]
+ },
+ "459": {
+  "id": "459",
+  "title": "Burpee Pull Up",
+  "videoUrl": "https://youtu.be/FoQNNM9LPxw",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "723"
+   }
+  ]
+ },
+ "460": {
+  "id": "460",
+  "title": "Burpee Tuck Jump",
+  "videoUrl": "https://youtu.be/mz_DkxA9D-0",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "724"
+   }
+  ]
+ },
+ "461": {
+  "id": "461",
+  "title": "Butt Kicker",
+  "videoUrl": "https://youtu.be/jpH94dKeHO4",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "725"
+   }
+  ]
+ },
+ "462": {
+  "id": "462",
+  "title": "Butt Up",
+  "videoUrl": "https://youtu.be/ksPEDq5J7jM",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "726"
+   }
+  ]
+ },
+ "463": {
+  "id": "463",
+  "title": "Cable Cross Woodchop",
+  "videoUrl": "https://youtu.be/02ZF6O06fgE",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "727"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1707"
+   }
+  ]
+ },
+ "464": {
+  "id": "464",
+  "title": "Cable Crunch",
+  "videoUrl": "https://youtu.be/L2VEXScLd4c",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "728"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1708"
+   }
+  ]
+ },
+ "465": {
+  "id": "465",
+  "title": "Cable External Rotation",
+  "videoUrl": "https://youtu.be/42UtBfcEtZA",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "729"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1709"
+   }
+  ]
+ },
+ "466": {
+  "id": "466",
+  "title": "Cable Facepull",
+  "videoUrl": "https://youtu.be/oe2jvXLE9GM",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "730"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1710"
+   }
+  ]
+ },
+ "467": {
+  "id": "467",
+  "title": "Cable Hammer Curl",
+  "videoUrl": "https://youtu.be/MkUnz721HRs",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "731"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1711"
+   }
+  ]
+ },
+ "468": {
+  "id": "468",
+  "title": "Cable Incline Triceps Extension",
+  "videoUrl": "https://youtu.be/iWQYiJwBbAQ",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "732"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1712"
+   }
+  ]
+ },
+ "469": {
+  "id": "469",
+  "title": "Cable Internal Rotation",
+  "videoUrl": "https://youtu.be/MydEohX-p5E",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "733"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1713"
+   }
+  ]
+ },
+ "470": {
+  "id": "470",
+  "title": "Cable Lateral Raise",
+  "videoUrl": "https://youtu.be/BLydgjgIFUI",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "734"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1714"
+   }
+  ]
+ },
+ "471": {
+  "id": "471",
+  "title": "Cable Overhead Triceps Extension",
+  "videoUrl": "https://youtu.be/Hxkav3DQhcQ",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "735"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1715"
+   }
+  ]
+ },
+ "472": {
+  "id": "472",
+  "title": "Cable Reverse Crunch",
+  "videoUrl": "https://youtu.be/uKjhu1cOEqQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "736"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1716"
+   }
+  ]
+ },
+ "473": {
+  "id": "473",
+  "title": "Cable Shrug",
+  "videoUrl": "https://youtu.be/Gmau_PlqiYk",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "737"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1717"
+   }
+  ]
+ },
+ "474": {
+  "id": "474",
+  "title": "Cable Triceps Pushdown",
+  "videoUrl": "https://youtu.be/8jDz-0VkmIc",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "738"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1718"
+   }
+  ]
+ },
+ "475": {
+  "id": "475",
+  "title": "Cat Cow",
+  "videoUrl": "https://youtu.be/3TF3q7LWCUU",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "739"
+   }
+  ]
+ },
+ "476": {
+  "id": "476",
+  "title": "Childs Pose",
+  "videoUrl": "https://youtu.be/u3BbO6JWEBc",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "740"
+   }
+  ]
+ },
+ "477": {
+  "id": "477",
+  "title": "Clapping Push Up",
+  "videoUrl": "https://youtu.be/zWcQ9tfMnsc",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "741"
+   }
+  ]
+ },
+ "478": {
+  "id": "478",
+  "title": "Clean & Press",
+  "videoUrl": "https://youtu.be/6Gs_HzxYBn8",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "742"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1719"
+   }
+  ]
+ },
+ "479": {
+  "id": "479",
+  "title": "Clean Deadlift",
+  "videoUrl": "https://youtu.be/AakLbnNNAMo",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "743"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1720"
+   }
+  ]
+ },
+ "480": {
+  "id": "480",
+  "title": "Clean Pull",
+  "videoUrl": "https://youtu.be/gHdPK3hxmOY",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "744"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1721"
+   }
+  ]
+ },
+ "481": {
+  "id": "481",
+  "title": "Clean Shrug",
+  "videoUrl": "https://youtu.be/HN8qBL9ifU0",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "745"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1722"
+   }
+  ]
+ },
+ "482": {
+  "id": "482",
+  "title": "Close Grip Barbell Bicep Curl",
+  "videoUrl": "https://youtu.be/MynJiDxwPY8",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "746"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1723"
+   }
+  ]
+ },
+ "483": {
+  "id": "483",
+  "title": "Close Grip DB Press",
+  "videoUrl": "https://youtu.be/9-W28WOqMt8",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "747"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1724"
+   }
+  ]
+ },
+ "484": {
+  "id": "484",
+  "title": "Close Grip EZ Bar Press",
+  "videoUrl": "https://youtu.be/sUJSWbLCMok",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "748"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1725"
+   }
+  ]
+ },
+ "485": {
+  "id": "485",
+  "title": "Close Grip Floor Press",
+  "videoUrl": "https://youtu.be/g14MAkgb3YY",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "749"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1726"
+   }
+  ]
+ },
+ "486": {
+  "id": "486",
+  "title": "Close Grip Incline Bench Press",
+  "videoUrl": "https://youtu.be/0Tbmz8GieYM",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "750"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1727"
+   }
+  ]
+ },
+ "487": {
+  "id": "487",
+  "title": "Close Grip Push Up Off Of DB",
+  "videoUrl": "https://youtu.be/z-8l4nQsRFc",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "751"
+   }
+  ]
+ },
+ "488": {
+  "id": "488",
+  "title": "Close Hand Push Up",
+  "videoUrl": "https://youtu.be/u0qOZXX8_oM",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "752"
+   }
+  ]
+ },
+ "489": {
+  "id": "489",
+  "title": "Cobra",
+  "videoUrl": "https://youtu.be/1RoDIJgKg0I",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "753"
+   }
+  ]
+ },
+ "490": {
+  "id": "490",
+  "title": "Concentration Curl",
+  "videoUrl": "https://youtu.be/IbmDC18m9VE",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "754"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1728"
+   }
+  ]
+ },
+ "491": {
+  "id": "491",
+  "title": "Crab Walk",
+  "videoUrl": "https://youtu.be/eio3xG1EVMA",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceYd",
+    "category": "Distance",
+    "unit": "Yards",
+    "id": "755"
+   }
+  ]
+ },
+ "492": {
+  "id": "492",
+  "title": "Cross Body Hammer Curl",
+  "videoUrl": "https://youtu.be/UUJYGoh51dI",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "756"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1729"
+   }
+  ]
+ },
+ "493": {
+  "id": "493",
+  "title": "Crossover Crunch",
+  "videoUrl": "https://youtu.be/TFs9nJbly7M",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "757"
+   }
+  ]
+ },
+ "494": {
+  "id": "494",
+  "title": "Crossover Reverse Lunge",
+  "videoUrl": "https://youtu.be/JTuEVQ_lEZA",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "758"
+   }
+  ]
+ },
+ "495": {
+  "id": "495",
+  "title": "Crunch",
+  "videoUrl": "https://youtu.be/Z-ZkUct1m4M",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "759"
+   }
+  ]
+ },
+ "496": {
+  "id": "496",
+  "title": "Cuban Press",
+  "videoUrl": "https://youtu.be/4FKxsJEnSww",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "760"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1730"
+   }
+  ]
+ },
+ "497": {
+  "id": "497",
+  "title": "DB Alternating Bicep Curl",
+  "videoUrl": "https://youtu.be/hAVXxC1dMOg",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "761"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1731"
+   }
+  ]
+ },
+ "499": {
+  "id": "499",
+  "title": "DB Box Squat",
+  "videoUrl": "https://youtu.be/a0ewdT5KoB0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "763"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1733"
+   }
+  ]
+ },
+ "500": {
+  "id": "500",
+  "title": "DB Bulgarian Split Squat",
+  "videoUrl": "https://youtu.be/c0Y35rfnKsE",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "764"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1734"
+   }
+  ]
+ },
+ "501": {
+  "id": "501",
+  "title": "DB Curl Lying Against Incline",
+  "videoUrl": "https://youtu.be/ZFK92-Ri5yM",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "765"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1735"
+   }
+  ]
+ },
+ "502": {
+  "id": "502",
+  "title": "DB Front Raise",
+  "videoUrl": "https://youtu.be/T8HjNOZ64n4",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "766"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1736"
+   }
+  ]
+ },
+ "503": {
+  "id": "503",
+  "title": "DB Hang Clean",
+  "videoUrl": "https://youtu.be/ykyl7szE0qU",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "767"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1737"
+   }
+  ]
+ },
+ "504": {
+  "id": "504",
+  "title": "DB Incline Fly",
+  "videoUrl": "https://youtu.be/GdWfZjVW9L8",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "768"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1738"
+   }
+  ]
+ },
+ "505": {
+  "id": "505",
+  "title": "DB Incline Front Raise",
+  "videoUrl": "https://youtu.be/j7VWCX5jMEQ",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "769"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1739"
+   }
+  ]
+ },
+ "506": {
+  "id": "506",
+  "title": "DB Incline Row",
+  "videoUrl": "https://youtu.be/3XgWUZJK8lQ",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "770"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1740"
+   }
+  ]
+ },
+ "507": {
+  "id": "507",
+  "title": "DB Incline Tricep Extension",
+  "videoUrl": "https://youtu.be/6jXq4w0Q5Fc",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "771"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1741"
+   }
+  ]
+ },
+ "508": {
+  "id": "508",
+  "title": "DB Jump Squat",
+  "videoUrl": "https://youtu.be/yaQzkLorww4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "772"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1742"
+   }
+  ]
+ },
+ "509": {
+  "id": "509",
+  "title": "DB Lateral Lunge",
+  "videoUrl": "https://youtu.be/eixAExKBIzs",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "773"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1743"
+   }
+  ]
+ },
+ "510": {
+  "id": "510",
+  "title": "DB Lunge & Curl",
+  "videoUrl": "https://youtu.be/20Big9yTZwE",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "774"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1744"
+   }
+  ]
+ },
+ "511": {
+  "id": "511",
+  "title": "DB Lying Rear Lateral Raise",
+  "videoUrl": "https://youtu.be/Lx37_D8u_zE",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "775"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1745"
+   }
+  ]
+ },
+ "512": {
+  "id": "512",
+  "title": "DB Overhead Squat",
+  "videoUrl": "https://youtu.be/ZqHaYsC0ZBQ",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "776"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1746"
+   }
+  ]
+ },
+ "513": {
+  "id": "513",
+  "title": "DB Pistol Squat",
+  "videoUrl": "https://youtu.be/XpExeOArpXQ",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "777"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1747"
+   }
+  ]
+ },
+ "514": {
+  "id": "514",
+  "title": "DB Plank Pull Through",
+  "videoUrl": "https://youtu.be/JbOaC7lckfI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "778"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1748"
+   }
+  ]
+ },
+ "515": {
+  "id": "515",
+  "title": "DB Roll Back",
+  "videoUrl": "https://youtu.be/_q0UkHtX7p4",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "779"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1749"
+   }
+  ]
+ },
+ "516": {
+  "id": "516",
+  "title": "DB Row",
+  "videoUrl": "https://youtu.be/VZXUUnQP_5Q",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "780"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1750"
+   }
+  ]
+ },
+ "517": {
+  "id": "517",
+  "title": "DB Scaption",
+  "videoUrl": "https://youtu.be/-NkvsUS_1hE",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "781"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1751"
+   }
+  ]
+ },
+ "518": {
+  "id": "518",
+  "title": "DB Seated Bent Over Double Arm Tricep Extension",
+  "videoUrl": "https://youtu.be/DLQwwljB7No",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "782"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1752"
+   }
+  ]
+ },
+ "519": {
+  "id": "519",
+  "title": "DB Seated Box Jump",
+  "videoUrl": "https://youtu.be/TVBAkmFjmrw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "783"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1753"
+   }
+  ]
+ },
+ "520": {
+  "id": "520",
+  "title": "DB Seated Single Leg Calf Raise",
+  "videoUrl": "https://youtu.be/51Nnm1gHrY8",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "784"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1754"
+   }
+  ]
+ },
+ "521": {
+  "id": "521",
+  "title": "DB Side Step Up",
+  "videoUrl": "https://youtu.be/IkAXEZPdHK0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "785"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1755"
+   }
+  ]
+ },
+ "522": {
+  "id": "522",
+  "title": "DB Single Arm Tricep Extension",
+  "videoUrl": "https://youtu.be/1igKfI5dbxc",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "786"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1756"
+   }
+  ]
+ },
+ "523": {
+  "id": "523",
+  "title": "DB Single Leg Deadlift",
+  "videoUrl": "https://youtu.be/mxZU1chONVE",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "787"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1757"
+   }
+  ]
+ },
+ "524": {
+  "id": "524",
+  "title": "DB Split Squat",
+  "videoUrl": "https://youtu.be/FM3NPgdQXSw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "788"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1758"
+   }
+  ]
+ },
+ "525": {
+  "id": "525",
+  "title": "DB Sumo Deadlift",
+  "videoUrl": "https://youtu.be/OKXm6B3MtPI",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "789"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1759"
+   }
+  ]
+ },
+ "526": {
+  "id": "526",
+  "title": "DB Tricep Extension Pronated Grip",
+  "videoUrl": "https://youtu.be/2etCulWj2Ho",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "790"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1760"
+   }
+  ]
+ },
+ "527": {
+  "id": "527",
+  "title": "DB Z Press",
+  "videoUrl": "https://youtu.be/NY_oRRkCmoQ",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "791"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1761"
+   }
+  ]
+ },
+ "528": {
+  "id": "528",
+  "title": "DeadBug",
+  "videoUrl": "https://youtu.be/ma3KSyp_zMQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "792"
+   }
+  ]
+ },
+ "529": {
+  "id": "529",
+  "title": "Deadlift Block Pull",
+  "videoUrl": "https://youtu.be/lgtKHix0Q1Q",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "793"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1762"
+   }
+  ]
+ },
+ "530": {
+  "id": "530",
+  "title": "Decline Forearm Plank",
+  "videoUrl": "https://youtu.be/kdP-ruhiAnA",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "794"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1763"
+   }
+  ]
+ },
+ "531": {
+  "id": "531",
+  "title": "Decline Plank",
+  "videoUrl": "https://youtu.be/W4qL3XC8Kcw",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "795"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1764"
+   }
+  ]
+ },
+ "532": {
+  "id": "532",
+  "title": "Decline Push Up",
+  "videoUrl": "https://youtu.be/S6yfGOQXGz8",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "796"
+   }
+  ]
+ },
+ "533": {
+  "id": "533",
+  "title": "Decline Side Plank",
+  "videoUrl": "https://youtu.be/HMpeEeCQzHQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "797"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1765"
+   }
+  ]
+ },
+ "534": {
+  "id": "534",
+  "title": "Decline Spider",
+  "videoUrl": "https://youtu.be/GZX7BOWbHY8",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "798"
+   }
+  ]
+ },
+ "535": {
+  "id": "535",
+  "title": "Deficit Clean Deadlift",
+  "videoUrl": "https://youtu.be/X0PFv1TstGA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "799"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1766"
+   }
+  ]
+ },
+ "536": {
+  "id": "536",
+  "title": "Deficit Clean Pull",
+  "videoUrl": "https://youtu.be/lVcnOz07w0g",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "800"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1767"
+   }
+  ]
+ },
+ "537": {
+  "id": "537",
+  "title": "Deficit Deadlift",
+  "videoUrl": "https://youtu.be/gLcVTYF6G3I",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "801"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1768"
+   }
+  ]
+ },
+ "538": {
+  "id": "538",
+  "title": "Deficit Snatch Deadlift",
+  "videoUrl": "https://youtu.be/OoUKA4MWYHg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "802"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1769"
+   }
+  ]
+ },
+ "539": {
+  "id": "539",
+  "title": "Deficit Snatch Pull",
+  "videoUrl": "https://youtu.be/N7GPMtCZMzg",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "803"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1770"
+   }
+  ]
+ },
+ "540": {
+  "id": "540",
+  "title": "Depth Jump",
+  "videoUrl": "https://youtu.be/pDuU1cvnuTk",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "804"
+   }
+  ]
+ },
+ "541": {
+  "id": "541",
+  "title": "Dimel Deadlift",
+  "videoUrl": "https://youtu.be/-dujojWW08I",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "805"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1771"
+   }
+  ]
+ },
+ "542": {
+  "id": "542",
+  "title": "Dip Shrug",
+  "videoUrl": "https://youtu.be/GreJw42okI4",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "806"
+   }
+  ]
+ },
+ "543": {
+  "id": "543",
+  "title": "Dip",
+  "videoUrl": "https://youtu.be/TSEN-wJ8TwI",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "807"
+   }
+  ]
+ },
+ "544": {
+  "id": "544",
+  "title": "Dive Bomber Push Up",
+  "videoUrl": "https://youtu.be/FY-skxB_bjs",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "808"
+   }
+  ]
+ },
+ "545": {
+  "id": "545",
+  "title": "Double KB Push Jerk",
+  "videoUrl": "https://youtu.be/4Ku24nfB6t4",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "809"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1772"
+   }
+  ]
+ },
+ "546": {
+  "id": "546",
+  "title": "Double KB Racked Squat",
+  "videoUrl": "https://youtu.be/_6b0E3dUk3Q",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "810"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1773"
+   }
+  ]
+ },
+ "547": {
+  "id": "547",
+  "title": "Double KB Split Jerk",
+  "videoUrl": "https://youtu.be/1AMWESvhFW8",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "811"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1774"
+   }
+  ]
+ },
+ "548": {
+  "id": "548",
+  "title": "Double Pigeon Stretch",
+  "videoUrl": "https://youtu.be/I1R7TG6iV9c",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "812"
+   }
+  ]
+ },
+ "549": {
+  "id": "549",
+  "title": "Drag Curl",
+  "videoUrl": "https://youtu.be/6KdYexgsY0E",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "813"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1775"
+   }
+  ]
+ },
+ "550": {
+  "id": "550",
+  "title": "Dynamic Chest Stretch",
+  "videoUrl": "https://youtu.be/X53-qiytpyI",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "814"
+   }
+  ]
+ },
+ "551": {
+  "id": "551",
+  "title": "Dynamic Clam Shell",
+  "videoUrl": "https://youtu.be/Azd-zukfi-E",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "815"
+   }
+  ]
+ },
+ "552": {
+  "id": "552",
+  "title": "Elbow to Knee",
+  "videoUrl": "https://youtu.be/RbRfLqyR0w8",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "816"
+   }
+  ]
+ },
+ "553": {
+  "id": "553",
+  "title": "Elevated Body Weight Calf Raise",
+  "videoUrl": "https://youtu.be/r_yKQwqiOxE",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "817"
+   }
+  ]
+ },
+ "554": {
+  "id": "554",
+  "title": "Elevated Single Leg Body Weight Calf Raise",
+  "videoUrl": "https://youtu.be/cMybCcNTOf0",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "818"
+   }
+  ]
+ },
+ "555": {
+  "id": "555",
+  "title": "Exercise Ball Crunch",
+  "videoUrl": "https://youtu.be/hhU6sqZoJsU",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "819"
+   }
+  ]
+ },
+ "556": {
+  "id": "556",
+  "title": "Exercise Ball DB Chest Press",
+  "videoUrl": "https://youtu.be/HGpOViGGlP4",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "820"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1776"
+   }
+  ]
+ },
+ "557": {
+  "id": "557",
+  "title": "Exercise Ball DeadBug",
+  "videoUrl": "https://youtu.be/_zU8_C9oi-4",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "821"
+   }
+  ]
+ },
+ "558": {
+  "id": "558",
+  "title": "Exercise Ball Decline Toe Tap",
+  "videoUrl": "https://youtu.be/VknOzOrCOpI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "822"
+   }
+  ]
+ },
+ "559": {
+  "id": "559",
+  "title": "Exercise Ball Forearm Plank",
+  "videoUrl": "https://youtu.be/_Q6QchkAwNQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "823"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1777"
+   }
+  ]
+ },
+ "560": {
+  "id": "560",
+  "title": "Exercise Ball Plank",
+  "videoUrl": "https://youtu.be/ej_ioRLBbkM",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "824"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1778"
+   }
+  ]
+ },
+ "561": {
+  "id": "561",
+  "title": "Exercise Ball Pull In",
+  "videoUrl": "https://youtu.be/Y3aFKkfvwXY",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "825"
+   }
+  ]
+ },
+ "562": {
+  "id": "562",
+  "title": "Extended High Plank",
+  "videoUrl": "https://youtu.be/xSIpHSAsKAU",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "826"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1779"
+   }
+  ]
+ },
+ "563": {
+  "id": "563",
+  "title": "External Rotation",
+  "videoUrl": "https://youtu.be/cw1IaUzxz90",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "827"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1780"
+   }
+  ]
+ },
+ "564": {
+  "id": "564",
+  "title": "EZ Bar Curl",
+  "videoUrl": "https://youtu.be/orBnNfT-pqI",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "828"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1781"
+   }
+  ]
+ },
+ "565": {
+  "id": "565",
+  "title": "EZ Bar Skull Crusher",
+  "videoUrl": "https://youtu.be/tKLDO7vdP8w",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "829"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1782"
+   }
+  ]
+ },
+ "566": {
+  "id": "566",
+  "title": "Flat Bench Leg Pull In",
+  "videoUrl": "https://youtu.be/CdOPa1pMc0E",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "830"
+   }
+  ]
+ },
+ "567": {
+  "id": "567",
+  "title": "Flat Bench Lying Leg Raise",
+  "videoUrl": "https://youtu.be/tntGRp0CudY",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "831"
+   }
+  ]
+ },
+ "568": {
+  "id": "568",
+  "title": "Cable Flat Bench Single Arm Fly",
+  "videoUrl": "https://youtu.be/D4z5EoQa3Ag",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "832"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1783"
+   }
+  ]
+ },
+ "569": {
+  "id": "569",
+  "title": "Floor Press",
+  "videoUrl": "https://youtu.be/qakAJIXeV1Y",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "833"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1784"
+   }
+  ]
+ },
+ "570": {
+  "id": "570",
+  "title": "Flutter Kicks",
+  "videoUrl": "https://youtu.be/XHPFeG-5DhI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "834"
+   }
+  ]
+ },
+ "571": {
+  "id": "571",
+  "title": "Forearm Plank",
+  "videoUrl": "https://youtu.be/tjumnY48d2Q",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "835"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1785"
+   }
+  ]
+ },
+ "572": {
+  "id": "572",
+  "title": "Forearm Plank Hip Dip",
+  "videoUrl": "https://youtu.be/zKgdgd59xHc",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "836"
+   }
+  ]
+ },
+ "573": {
+  "id": "573",
+  "title": "Forearm Plank Jack",
+  "videoUrl": "https://youtu.be/vBUwTFZpUxk",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "837"
+   }
+  ]
+ },
+ "574": {
+  "id": "574",
+  "title": "Frankenstein Squat",
+  "videoUrl": "https://youtu.be/7hQKmpYrhyM",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "838"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1786"
+   }
+  ]
+ },
+ "575": {
+  "id": "575",
+  "title": "Frog Pose",
+  "videoUrl": "https://youtu.be/HntQ38YzGZA",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "839"
+   }
+  ]
+ },
+ "576": {
+  "id": "576",
+  "title": "Frog Sit Up",
+  "videoUrl": "https://youtu.be/blha_1bVVtI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "840"
+   }
+  ]
+ },
+ "577": {
+  "id": "577",
+  "title": "Front Raise & Pull Over",
+  "videoUrl": "https://youtu.be/LqW4AuUSuWQ",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "841"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1787"
+   }
+  ]
+ },
+ "578": {
+  "id": "578",
+  "title": "Full Saddle",
+  "videoUrl": "https://youtu.be/1sIGTTxvDSw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "842"
+   }
+  ]
+ },
+ "579": {
+  "id": "579",
+  "title": "Glute Bridge",
+  "videoUrl": "https://youtu.be/gR-RLIoLCDw",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "843"
+   }
+  ]
+ },
+ "580": {
+  "id": "580",
+  "title": "Glute Bridge Hamstring Walkout",
+  "videoUrl": "https://youtu.be/h9yKMg-k044",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "844"
+   }
+  ]
+ },
+ "581": {
+  "id": "581",
+  "title": "Glute Kick Back",
+  "videoUrl": "https://youtu.be/Ps14jmST2Nc",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "845"
+   }
+  ]
+ },
+ "582": {
+  "id": "582",
+  "title": "Goblet Lateral Lunge",
+  "videoUrl": "https://youtu.be/Pvtn4e8YW84",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "846"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1788"
+   }
+  ]
+ },
+ "583": {
+  "id": "583",
+  "title": "Half Kneeling DB Shoulder Press",
+  "videoUrl": "https://youtu.be/pugHF8joOXE",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "847"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1789"
+   }
+  ]
+ },
+ "584": {
+  "id": "584",
+  "title": "Half Kneeling KB Press",
+  "videoUrl": "https://youtu.be/ZzxkCsWlhJE",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "848"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1790"
+   }
+  ]
+ },
+ "585": {
+  "id": "585",
+  "title": "Half Saddle",
+  "videoUrl": "https://youtu.be/Mk2lA1Lw1xk",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "849"
+   }
+  ]
+ },
+ "586": {
+  "id": "586",
+  "title": "Hamstring Slide",
+  "videoUrl": "https://youtu.be/6vROT2UVyRk",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "850"
+   }
+  ]
+ },
+ "587": {
+  "id": "587",
+  "title": "Hand Release Push Up",
+  "videoUrl": "https://youtu.be/tg8WV14l838",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "851"
+   }
+  ]
+ },
+ "589": {
+  "id": "589",
+  "title": "Hang Clean Pull",
+  "videoUrl": "https://youtu.be/MjyRjA7Krk8",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "853"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1792"
+   }
+  ]
+ },
+ "590": {
+  "id": "590",
+  "title": "Hanging Leg Raise",
+  "videoUrl": "https://youtu.be/5smugF3geFc",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Forearms"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "854"
+   }
+  ]
+ },
+ "591": {
+  "id": "591",
+  "title": "Hanging Knee Raise",
+  "videoUrl": "https://youtu.be/jUd0teBB1kQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "855"
+   }
+  ]
+ },
+ "592": {
+  "id": "592",
+  "title": "Happy Baby",
+  "videoUrl": "https://youtu.be/QT2pOIMkq4s",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "856"
+   }
+  ]
+ },
+ "593": {
+  "id": "593",
+  "title": "Heaving Snatch Bounce",
+  "videoUrl": "https://youtu.be/pQDL4Fg0Vg0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "857"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1793"
+   }
+  ]
+ },
+ "594": {
+  "id": "594",
+  "title": "Heels Elevated Hip Thrust",
+  "videoUrl": "https://youtu.be/EcFIgXGj-TQ",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "858"
+   }
+  ]
+ },
+ "595": {
+  "id": "595",
+  "title": "Hex Bar Bent Over Row",
+  "videoUrl": "https://youtu.be/E-sV8vESqbw",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "859"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1794"
+   }
+  ]
+ },
+ "596": {
+  "id": "596",
+  "title": "High Hang Snatch",
+  "videoUrl": "https://youtu.be/o18px6vhtzY",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "860"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1795"
+   }
+  ]
+ },
+ "597": {
+  "id": "597",
+  "title": "High Plank Jack",
+  "videoUrl": "https://youtu.be/Z5igZfUS9T0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "861"
+   }
+  ]
+ },
+ "598": {
+  "id": "598",
+  "title": "High Plank Shoulder Tap",
+  "videoUrl": "https://youtu.be/5pdWy6pY2uo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "862"
+   }
+  ]
+ },
+ "599": {
+  "id": "599",
+  "title": "High Plank Toe Tap",
+  "videoUrl": "https://youtu.be/1A8v3n8ebmY",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "863"
+   }
+  ]
+ },
+ "600": {
+  "id": "600",
+  "title": "High Plank Walk",
+  "videoUrl": "https://youtu.be/gH3Z7HiitIQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "864"
+   }
+  ]
+ },
+ "601": {
+  "id": "601",
+  "title": "Hip Crossover",
+  "videoUrl": "https://youtu.be/Io2KZNtQ-Yc",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "865"
+   }
+  ]
+ },
+ "602": {
+  "id": "602",
+  "title": "Hip Flexion with Band",
+  "videoUrl": "https://youtu.be/9xHTV-2ESw8",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "866"
+   }
+  ]
+ },
+ "603": {
+  "id": "603",
+  "title": "Ice Skater",
+  "videoUrl": "https://youtu.be/hOrNGqOdw9Q",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "867"
+   }
+  ]
+ },
+ "604": {
+  "id": "604",
+  "title": "In & Out Box Jump",
+  "videoUrl": "https://youtu.be/lsUx-rgD9yA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "868"
+   }
+  ]
+ },
+ "605": {
+  "id": "605",
+  "title": "Inch Worm",
+  "videoUrl": "https://youtu.be/qrl9SypzYt8",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "869"
+   }
+  ]
+ },
+ "606": {
+  "id": "606",
+  "title": "Incline Barbell Tricep Extension",
+  "videoUrl": "https://youtu.be/2dUdF_NXTSk",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "870"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1796"
+   }
+  ]
+ },
+ "607": {
+  "id": "607",
+  "title": "Incline Bench Press",
+  "videoUrl": "https://youtu.be/xalV_vHB2EU",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "871"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1797"
+   }
+  ]
+ },
+ "608": {
+  "id": "608",
+  "title": "Incline Close Grip Push Up",
+  "videoUrl": "https://youtu.be/GNkLedKaZqM",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "872"
+   }
+  ]
+ },
+ "609": {
+  "id": "609",
+  "title": "Incline DB Curl",
+  "videoUrl": "https://youtu.be/YsKvCuDvrKI",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "873"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1798"
+   }
+  ]
+ },
+ "610": {
+  "id": "610",
+  "title": "Incline DB Fly",
+  "videoUrl": "https://youtu.be/iPSsUsShqZs",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "874"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1799"
+   }
+  ]
+ },
+ "611": {
+  "id": "611",
+  "title": "Incline DB Press",
+  "videoUrl": "https://youtu.be/ky9eCfvuLRY",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "875"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1800"
+   }
+  ]
+ },
+ "612": {
+  "id": "612",
+  "title": "Incline DB Press with Palms Facing In",
+  "videoUrl": "https://youtu.be/-DqWCckIlpc",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "876"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1801"
+   }
+  ]
+ },
+ "613": {
+  "id": "613",
+  "title": "Incline Hammer Curl",
+  "videoUrl": "https://youtu.be/ETIcztlqBZI",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "877"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1802"
+   }
+  ]
+ },
+ "614": {
+  "id": "614",
+  "title": "Incline Lateral Raise",
+  "videoUrl": "https://youtu.be/OvH73R0sHWE",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "878"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1803"
+   }
+  ]
+ },
+ "615": {
+  "id": "615",
+  "title": "Incline Mountain Climber",
+  "videoUrl": "https://youtu.be/4NLcvYb0hvs",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "879"
+   }
+  ]
+ },
+ "616": {
+  "id": "616",
+  "title": "Incline Push Up",
+  "videoUrl": "https://youtu.be/JK0Zn6kNs04",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "880"
+   }
+  ]
+ },
+ "617": {
+  "id": "617",
+  "title": "Inverted Row",
+  "videoUrl": "https://youtu.be/bpEndSF0L70",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "881"
+   }
+  ]
+ },
+ "618": {
+  "id": "618",
+  "title": "Isometric Push Up",
+  "videoUrl": "https://youtu.be/zFE7nP8d-h8",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "882"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1804"
+   }
+  ]
+ },
+ "619": {
+  "id": "619",
+  "title": "Isometric Wiper",
+  "videoUrl": "https://youtu.be/gQu_gVlIeI4",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "883"
+   }
+  ]
+ },
+ "620": {
+  "id": "620",
+  "title": "Janda Sit Up",
+  "videoUrl": "https://youtu.be/UAKBqwyVI40",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "884"
+   }
+  ]
+ },
+ "621": {
+  "id": "621",
+  "title": "Jefferson Deadlift",
+  "videoUrl": "https://youtu.be/yYZR8YuPaok",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "885"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1805"
+   }
+  ]
+ },
+ "622": {
+  "id": "622",
+  "title": "Jerk Balance",
+  "videoUrl": "https://youtu.be/CPpd8ODJ8A4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "886"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1806"
+   }
+  ]
+ },
+ "623": {
+  "id": "623",
+  "title": "Jerk Dip",
+  "videoUrl": "https://youtu.be/YSvct6r-ajY",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "887"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1807"
+   }
+  ]
+ },
+ "624": {
+  "id": "624",
+  "title": "JM Press",
+  "videoUrl": "https://youtu.be/gKpYXajgf2w",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [
+   "Chest"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "888"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1808"
+   }
+  ]
+ },
+ "625": {
+  "id": "625",
+  "title": "Jump Rope",
+  "videoUrl": "https://youtu.be/_Rf3Txc-9e4",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "889"
+   }
+  ]
+ },
+ "626": {
+  "id": "626",
+  "title": "KB Arnold Press",
+  "videoUrl": "https://youtu.be/4SI528odfYc",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "890"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1809"
+   }
+  ]
+ },
+ "627": {
+  "id": "627",
+  "title": "KB Clean & Push Press",
+  "videoUrl": "https://youtu.be/UgD7SukHlcY",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "891"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1810"
+   }
+  ]
+ },
+ "628": {
+  "id": "628",
+  "title": "KB Curtsy Lunge",
+  "videoUrl": "https://youtu.be/CREJqm_YY9E",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "892"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1811"
+   }
+  ]
+ },
+ "629": {
+  "id": "629",
+  "title": "KB Deadlift",
+  "videoUrl": "https://youtu.be/zSyyH2m2adI",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "893"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1812"
+   }
+  ]
+ },
+ "630": {
+  "id": "630",
+  "title": "KB Goblet Squat",
+  "videoUrl": "https://youtu.be/ZUBlPgXp7aw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "894"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1813"
+   }
+  ]
+ },
+ "631": {
+  "id": "631",
+  "title": "KB Hang Clean",
+  "videoUrl": "https://youtu.be/_5w3luYQQOU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "895"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1814"
+   }
+  ]
+ },
+ "632": {
+  "id": "632",
+  "title": "KB High Pull",
+  "videoUrl": "https://youtu.be/N31bduLSZuM",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "896"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1815"
+   }
+  ]
+ },
+ "633": {
+  "id": "633",
+  "title": "KB Jack Knife",
+  "videoUrl": "https://youtu.be/7HUveCPz4po",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "897"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1816"
+   }
+  ]
+ },
+ "634": {
+  "id": "634",
+  "title": "KB Lateral Lunge",
+  "videoUrl": "https://youtu.be/grt4fYn1y1c",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "898"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1817"
+   }
+  ]
+ },
+ "635": {
+  "id": "635",
+  "title": "KB Low Windmill",
+  "videoUrl": "https://youtu.be/n1wUEamD9Oo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "899"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1818"
+   }
+  ]
+ },
+ "636": {
+  "id": "636",
+  "title": "KB Lunge with Rotation",
+  "videoUrl": "https://youtu.be/fykIUSOp0aw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "900"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1819"
+   }
+  ]
+ },
+ "637": {
+  "id": "637",
+  "title": "KB Overhead Press",
+  "videoUrl": "https://youtu.be/N4C_7BsCBhQ",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "901"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1820"
+   }
+  ]
+ },
+ "638": {
+  "id": "638",
+  "title": "KB Overhead Reverse Lunge",
+  "videoUrl": "https://youtu.be/nYI8KUh8oQQ",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "902"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1821"
+   }
+  ]
+ },
+ "639": {
+  "id": "639",
+  "title": "KB Pistol Squat - Box Assisted",
+  "videoUrl": "https://youtu.be/gcoHYpCj19Y",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "903"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1822"
+   }
+  ]
+ },
+ "640": {
+  "id": "640",
+  "title": "KB Plank Row",
+  "videoUrl": "https://youtu.be/dyviiBKbIYk",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "904"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1823"
+   }
+  ]
+ },
+ "641": {
+  "id": "641",
+  "title": "KB Press",
+  "videoUrl": "https://youtu.be/JtEvr721AV4",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "905"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1824"
+   }
+  ]
+ },
+ "642": {
+  "id": "642",
+  "title": "KB Push Press",
+  "videoUrl": "https://youtu.be/DD3WCxiHo_k",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "906"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1825"
+   }
+  ]
+ },
+ "643": {
+  "id": "643",
+  "title": "KB Russian Twist",
+  "videoUrl": "https://youtu.be/YHO4MWZV19k",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "907"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1826"
+   }
+  ]
+ },
+ "644": {
+  "id": "644",
+  "title": "KB Seated Press",
+  "videoUrl": "https://youtu.be/UZlVIuwCeBY",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "908"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1827"
+   }
+  ]
+ },
+ "645": {
+  "id": "645",
+  "title": "KB Seesaw Press",
+  "videoUrl": "https://youtu.be/qW7ngqvcTX8",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "909"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1828"
+   }
+  ]
+ },
+ "646": {
+  "id": "646",
+  "title": "KB Shoulder Shrug",
+  "videoUrl": "https://youtu.be/fDiIkAFEu08",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "910"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1829"
+   }
+  ]
+ },
+ "647": {
+  "id": "647",
+  "title": "KB Side Lunge Press",
+  "videoUrl": "https://youtu.be/jHI4Q535QgA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "911"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1830"
+   }
+  ]
+ },
+ "648": {
+  "id": "648",
+  "title": "KB Single Leg Deadlift",
+  "videoUrl": "https://youtu.be/7u1g4JeNBtI",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "912"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1831"
+   }
+  ]
+ },
+ "649": {
+  "id": "649",
+  "title": "KB Squat High Pull",
+  "videoUrl": "https://youtu.be/A_3PONGTlNo",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "913"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1832"
+   }
+  ]
+ },
+ "650": {
+  "id": "650",
+  "title": "KB Sumo High Pull",
+  "videoUrl": "https://youtu.be/ALqQj-H4sHM",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "914"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1833"
+   }
+  ]
+ },
+ "651": {
+  "id": "651",
+  "title": "KB Sumo Squat",
+  "videoUrl": "https://youtu.be/D6cUyT9E8J0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "915"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1834"
+   }
+  ]
+ },
+ "652": {
+  "id": "652",
+  "title": "KB Swing Change Hands",
+  "videoUrl": "https://youtu.be/LBK9bSrp_Cc",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "916"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1835"
+   }
+  ]
+ },
+ "653": {
+  "id": "653",
+  "title": "KB Thruster",
+  "videoUrl": "https://youtu.be/8EAiLcKdDlg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "917"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1836"
+   }
+  ]
+ },
+ "654": {
+  "id": "654",
+  "title": "KB Waiter Press",
+  "videoUrl": "https://youtu.be/lWKnwENZOlo",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "918"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1837"
+   }
+  ]
+ },
+ "655": {
+  "id": "655",
+  "title": "Kipping Handstand Push Up",
+  "videoUrl": "https://youtu.be/9SGubYUi0X0",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "919"
+   }
+  ]
+ },
+ "656": {
+  "id": "656",
+  "title": "Kipping Muscle Up",
+  "videoUrl": "https://youtu.be/ZkqgOHa7w2U",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "920"
+   }
+  ]
+ },
+ "657": {
+  "id": "657",
+  "title": "Kipping Toe to Bar",
+  "videoUrl": "https://youtu.be/vflVFGjPhw8",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "921"
+   }
+  ]
+ },
+ "658": {
+  "id": "658",
+  "title": "Knee Tuck Jump",
+  "videoUrl": "https://youtu.be/aB68A3ZnTdI",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "922"
+   }
+  ]
+ },
+ "659": {
+  "id": "659",
+  "title": "Kneeling Bench Shoulder Stretch",
+  "videoUrl": "https://youtu.be/JhWL5px5-LI",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "923"
+   }
+  ]
+ },
+ "660": {
+  "id": "660",
+  "title": "Cable Kneeling Triceps Extension",
+  "videoUrl": "https://youtu.be/k08XqujKYxI",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "924"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1838"
+   }
+  ]
+ },
+ "661": {
+  "id": "661",
+  "title": "Kneeling Forearm Stretch",
+  "videoUrl": "https://youtu.be/BTWl9pw6B5A",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "925"
+   }
+  ]
+ },
+ "662": {
+  "id": "662",
+  "title": "Kneeling Landmine Press",
+  "videoUrl": "https://youtu.be/3kW1M1_JaVc",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "926"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1839"
+   }
+  ]
+ },
+ "663": {
+  "id": "663",
+  "title": "Kneeling Single Arm High Pulley Row",
+  "videoUrl": "https://youtu.be/Tdt98M59Bbs",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "927"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1840"
+   }
+  ]
+ },
+ "664": {
+  "id": "664",
+  "title": "L Sit Chin Up",
+  "videoUrl": "https://youtu.be/8DrLQTNf1YY",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "928"
+   }
+  ]
+ },
+ "665": {
+  "id": "665",
+  "title": "Landmine Lateral Raise",
+  "videoUrl": "https://youtu.be/Ia9u_VmCyS4",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "929"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1841"
+   }
+  ]
+ },
+ "666": {
+  "id": "666",
+  "title": "Landmine Twist",
+  "videoUrl": "https://youtu.be/GNPwcOl9voA",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "930"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1842"
+   }
+  ]
+ },
+ "667": {
+  "id": "667",
+  "title": "Lateral Burpee Over Barbell",
+  "videoUrl": "https://youtu.be/f9HDNu5a4XQ",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "931"
+   }
+  ]
+ },
+ "668": {
+  "id": "668",
+  "title": "Lateral Raise with Band",
+  "videoUrl": "https://youtu.be/_kZRBTWFjd8",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "932"
+   }
+  ]
+ },
+ "669": {
+  "id": "669",
+  "title": "Leg Lift",
+  "videoUrl": "https://youtu.be/T4n1WrGkLdo",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "933"
+   }
+  ]
+ },
+ "670": {
+  "id": "670",
+  "title": "Leg Pull In",
+  "videoUrl": "https://youtu.be/iKjPev-pgOg",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "934"
+   }
+  ]
+ },
+ "671": {
+  "id": "671",
+  "title": "Leg Raise",
+  "videoUrl": "https://youtu.be/Q2IDEvsU3Cc",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "935"
+   }
+  ]
+ },
+ "672": {
+  "id": "672",
+  "title": "Cable Low Crossover",
+  "videoUrl": "https://youtu.be/e6bZUXvR85I",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "936"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1843"
+   }
+  ]
+ },
+ "673": {
+  "id": "673",
+  "title": "Low Hang Clean",
+  "videoUrl": "https://youtu.be/WBa_9BoWR3Y",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "937"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1844"
+   }
+  ]
+ },
+ "674": {
+  "id": "674",
+  "title": "Low Hang Snatch",
+  "videoUrl": "https://youtu.be/Map2IR0f0x8",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "938"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1845"
+   }
+  ]
+ },
+ "675": {
+  "id": "675",
+  "title": "Lu Raise",
+  "videoUrl": "https://youtu.be/CkOuDRZswZA",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "939"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1846"
+   }
+  ]
+ },
+ "676": {
+  "id": "676",
+  "title": "Lunge Jumps",
+  "videoUrl": "https://youtu.be/_wGXHfif7GY",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "940"
+   }
+  ]
+ },
+ "677": {
+  "id": "677",
+  "title": "Lunge with Twist Stretch",
+  "videoUrl": "https://youtu.be/ddvqJIlrwFA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "941"
+   }
+  ]
+ },
+ "678": {
+  "id": "678",
+  "title": "Cable Lying Triceps Extension",
+  "videoUrl": "https://youtu.be/vuKPFf7T4dY",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "942"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1847"
+   }
+  ]
+ },
+ "679": {
+  "id": "679",
+  "title": "Lying Close Grip Barbell Tricep Extension Behind the Head",
+  "videoUrl": "https://youtu.be/jDKJXI9npN0",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "943"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1848"
+   }
+  ]
+ },
+ "680": {
+  "id": "680",
+  "title": "Lying DB Curl",
+  "videoUrl": "https://youtu.be/IZNcRYZVySk",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "944"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1849"
+   }
+  ]
+ },
+ "681": {
+  "id": "681",
+  "title": "Lying Figure Four Stretch",
+  "videoUrl": "https://youtu.be/1LniuSgGVqw",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "945"
+   }
+  ]
+ },
+ "682": {
+  "id": "682",
+  "title": "Lying Hamstring Stretch with Band",
+  "videoUrl": "https://youtu.be/Cew5quhECZM",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "946"
+   }
+  ]
+ },
+ "683": {
+  "id": "683",
+  "title": "Lying Knees to Chest Stretch",
+  "videoUrl": "https://youtu.be/3wnGJ8mPH_c",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "947"
+   }
+  ]
+ },
+ "684": {
+  "id": "684",
+  "title": "Lying Rear Delt Raise",
+  "videoUrl": "https://youtu.be/IveEYF6SqO8",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "948"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1850"
+   }
+  ]
+ },
+ "685": {
+  "id": "685",
+  "title": "Lying Tricep Extension",
+  "videoUrl": "https://youtu.be/kDagbWNWy3g",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "949"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1851"
+   }
+  ]
+ },
+ "686": {
+  "id": "686",
+  "title": "Manmaker",
+  "videoUrl": "https://youtu.be/FDj23_erXB0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "950"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1852"
+   }
+  ]
+ },
+ "687": {
+  "id": "687",
+  "title": "Medicine Ball Forearm Plank",
+  "videoUrl": "https://youtu.be/Sbcboaim_Yo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "951"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1853"
+   }
+  ]
+ },
+ "688": {
+  "id": "688",
+  "title": "Medicine Ball High Plank Roll",
+  "videoUrl": "https://youtu.be/zL9CKtdfqYE",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "952"
+   }
+  ]
+ },
+ "689": {
+  "id": "689",
+  "title": "Medicine Ball Mountain Climber",
+  "videoUrl": "https://youtu.be/q5OR__Y5FiA",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "953"
+   }
+  ]
+ },
+ "690": {
+  "id": "690",
+  "title": "Medicine Ball Plank",
+  "videoUrl": "https://youtu.be/ZZS6cQpi0o4",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "954"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1854"
+   }
+  ]
+ },
+ "691": {
+  "id": "691",
+  "title": "Middle Back Shrug",
+  "videoUrl": "https://youtu.be/UeUmQpeFzNc",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "955"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1855"
+   }
+  ]
+ },
+ "692": {
+  "id": "692",
+  "title": "Mini Band Lateral Walk",
+  "videoUrl": "https://youtu.be/ngOgvJdH5nY",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "956"
+   }
+  ]
+ },
+ "693": {
+  "id": "693",
+  "title": "Modified Push Up",
+  "videoUrl": "https://youtu.be/QyPJl0S1JZ8",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "957"
+   }
+  ]
+ },
+ "694": {
+  "id": "694",
+  "title": "Muscle Snatch",
+  "videoUrl": "https://youtu.be/yLQDF36Pdes",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "958"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1856"
+   }
+  ]
+ },
+ "695": {
+  "id": "695",
+  "title": "Narrow Grip Bench Press",
+  "videoUrl": "https://youtu.be/MmjrWod65po",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "959"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1857"
+   }
+  ]
+ },
+ "696": {
+  "id": "696",
+  "title": "Narrow Grip Easy Bar Bicep Curl",
+  "videoUrl": "https://youtu.be/MGcll-HdR8c",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "960"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1858"
+   }
+  ]
+ },
+ "697": {
+  "id": "697",
+  "title": "Negative Pull Up",
+  "videoUrl": "https://youtu.be/wx3JCGLnMnk",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "961"
+   }
+  ]
+ },
+ "698": {
+  "id": "698",
+  "title": "No Push Up Burpee",
+  "videoUrl": "https://youtu.be/SB1LcSy4rvA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "962"
+   }
+  ]
+ },
+ "699": {
+  "id": "699",
+  "title": "Oblique Crunch",
+  "videoUrl": "https://youtu.be/JTMIMt4MhP0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "963"
+   }
+  ]
+ },
+ "700": {
+  "id": "700",
+  "title": "One Handed Hang",
+  "videoUrl": "https://youtu.be/_c3-mTm_TYw",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Forearms"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "964"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1859"
+   }
+  ]
+ },
+ "701": {
+  "id": "701",
+  "title": "Otis Up",
+  "videoUrl": "https://youtu.be/tT6ly_ZxYmg",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "965"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1860"
+   }
+  ]
+ },
+ "702": {
+  "id": "702",
+  "title": "Cable Overhead Curl",
+  "videoUrl": "https://youtu.be/HUv7Wc3I9ns",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "966"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1861"
+   }
+  ]
+ },
+ "703": {
+  "id": "703",
+  "title": "Overhead Front Raise",
+  "videoUrl": "https://youtu.be/i5RHgtpmkxE",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "967"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1862"
+   }
+  ]
+ },
+ "704": {
+  "id": "704",
+  "title": "Overhead Squat",
+  "videoUrl": "https://youtu.be/yjzLEf_7Iq8",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "968"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1863"
+   }
+  ]
+ },
+ "705": {
+  "id": "705",
+  "title": "Paloff Press",
+  "videoUrl": "https://youtu.be/rfUtkZRKP3s",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "969"
+   }
+  ]
+ },
+ "706": {
+  "id": "706",
+  "title": "Paloff Press with Rotation",
+  "videoUrl": "https://youtu.be/qu3SHscN9Qk",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "970"
+   }
+  ]
+ },
+ "707": {
+  "id": "707",
+  "title": "Pendlay Row",
+  "videoUrl": "https://youtu.be/BscdNTb_rW0",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "971"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1864"
+   }
+  ]
+ },
+ "708": {
+  "id": "708",
+  "title": "Physio Ball Hip Bridge",
+  "videoUrl": "https://youtu.be/YqDU95G7vbQ",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "972"
+   }
+  ]
+ },
+ "709": {
+  "id": "709",
+  "title": "Pigeon Stretch",
+  "videoUrl": "https://youtu.be/aUSAw196e3U",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "973"
+   }
+  ]
+ },
+ "710": {
+  "id": "710",
+  "title": "Plank Walk front to back",
+  "videoUrl": "https://youtu.be/hnurFwhz8z0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "974"
+   }
+  ]
+ },
+ "711": {
+  "id": "711",
+  "title": "Plank with Twist",
+  "videoUrl": "https://youtu.be/k754iY8bESA",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "975"
+   }
+  ]
+ },
+ "712": {
+  "id": "712",
+  "title": "Plate Flip",
+  "videoUrl": "https://youtu.be/rmvvsBjkkB0",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "976"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1865"
+   }
+  ]
+ },
+ "713": {
+  "id": "713",
+  "title": "Plate Hammer Curl",
+  "videoUrl": "https://youtu.be/-debC7IMFd0",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "977"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1866"
+   }
+  ]
+ },
+ "714": {
+  "id": "714",
+  "title": "Plate Pinch",
+  "videoUrl": "https://youtu.be/or-HfyM79n4",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "978"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1867"
+   }
+  ]
+ },
+ "715": {
+  "id": "715",
+  "title": "Plate Raise",
+  "videoUrl": "https://youtu.be/SwqKujupOfg",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "979"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1868"
+   }
+  ]
+ },
+ "716": {
+  "id": "716",
+  "title": "Plate Twist",
+  "videoUrl": "https://youtu.be/RyvkOlAl8dM",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "980"
+   }
+  ]
+ },
+ "717": {
+  "id": "717",
+  "title": "Plie DB Squat",
+  "videoUrl": "https://youtu.be/xRa8yQ3AFXU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "981"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1869"
+   }
+  ]
+ },
+ "718": {
+  "id": "718",
+  "title": "Plyo Push Up",
+  "videoUrl": "https://youtu.be/biWXRJ4vo9U",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "982"
+   }
+  ]
+ },
+ "719": {
+  "id": "719",
+  "title": "Pop Squat",
+  "videoUrl": "https://youtu.be/UaGbrAfy4fE",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "983"
+   }
+  ]
+ },
+ "720": {
+  "id": "720",
+  "title": "Power Clean & Press",
+  "videoUrl": "https://youtu.be/wogDELTZXpA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "984"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1870"
+   }
+  ]
+ },
+ "721": {
+  "id": "721",
+  "title": "Power Clean from Blocks",
+  "videoUrl": "https://youtu.be/pbdFLAS9iGc",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "985"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1871"
+   }
+  ]
+ },
+ "722": {
+  "id": "722",
+  "title": "Power Jerk",
+  "videoUrl": "https://youtu.be/bpc9cFZP77o",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "986"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1872"
+   }
+  ]
+ },
+ "723": {
+  "id": "723",
+  "title": "Power Snatch",
+  "videoUrl": "https://youtu.be/xs-PuG7Zco8",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "987"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1873"
+   }
+  ]
+ },
+ "724": {
+  "id": "724",
+  "title": "Power Snatch from Blocks",
+  "videoUrl": "https://youtu.be/Daw0RcaFLWI",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "988"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1874"
+   }
+  ]
+ },
+ "725": {
+  "id": "725",
+  "title": "Preacher Curl",
+  "videoUrl": "https://youtu.be/Are_qPcIQ-s",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "989"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1875"
+   }
+  ]
+ },
+ "726": {
+  "id": "726",
+  "title": "Pull Up Iso Hold",
+  "videoUrl": "https://youtu.be/-59FJGvwzDs",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "990"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1876"
+   }
+  ]
+ },
+ "727": {
+  "id": "727",
+  "title": "Puppy Dog Pose",
+  "videoUrl": "https://youtu.be/4rYamEm0QGE",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "991"
+   }
+  ]
+ },
+ "728": {
+  "id": "728",
+  "title": "Push Press",
+  "videoUrl": "https://youtu.be/dDJB2edtZG0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "992"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1877"
+   }
+  ]
+ },
+ "729": {
+  "id": "729",
+  "title": "Push Up to Down Dog",
+  "videoUrl": "https://youtu.be/NQZKcs4tOfM",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "993"
+   }
+  ]
+ },
+ "730": {
+  "id": "730",
+  "title": "Push Up to Side Plank",
+  "videoUrl": "https://youtu.be/TefYTSr7Zcw",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "994"
+   }
+  ]
+ },
+ "731": {
+  "id": "731",
+  "title": "Push Up with Feet on Exercise Ball",
+  "videoUrl": "https://youtu.be/BW42fQ0eUJs",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "995"
+   }
+  ]
+ },
+ "732": {
+  "id": "732",
+  "title": "Quad Hold",
+  "videoUrl": "https://youtu.be/CHvhTMyMH4U",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "996"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1878"
+   }
+  ]
+ },
+ "733": {
+  "id": "733",
+  "title": "RDL to Shrug",
+  "videoUrl": "https://youtu.be/L2YD5asn8L8",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "997"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1879"
+   }
+  ]
+ },
+ "734": {
+  "id": "734",
+  "title": "Rear Delt Fly",
+  "videoUrl": "https://youtu.be/y1FgL163V0g",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "998"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1880"
+   }
+  ]
+ },
+ "735": {
+  "id": "735",
+  "title": "Resistance Band Lat Pull Down",
+  "videoUrl": "https://youtu.be/gbIA_PnNU3U",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "999"
+   }
+  ]
+ },
+ "736": {
+  "id": "736",
+  "title": "Resistance Band Row to External Rotation",
+  "videoUrl": "https://youtu.be/3FUP_Wn8-TY",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1000"
+   }
+  ]
+ },
+ "737": {
+  "id": "737",
+  "title": "Reverse Barbell Curl",
+  "videoUrl": "https://youtu.be/Yz5ynoMDpHM",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1001"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1881"
+   }
+  ]
+ },
+ "738": {
+  "id": "738",
+  "title": "Reverse Barbell Preacher Curl",
+  "videoUrl": "https://youtu.be/ezQxFkokTcQ",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1002"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1882"
+   }
+  ]
+ },
+ "739": {
+  "id": "739",
+  "title": "Reverse Burpee",
+  "videoUrl": "https://youtu.be/6QAKpKtGaq8",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1003"
+   }
+  ]
+ },
+ "740": {
+  "id": "740",
+  "title": "Reverse Crunch",
+  "videoUrl": "https://youtu.be/ChAUrUL0194",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1004"
+   }
+  ]
+ },
+ "741": {
+  "id": "741",
+  "title": "Reverse Fly with External Rotation",
+  "videoUrl": "https://youtu.be/zFZAf7H2NV4",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1005"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1883"
+   }
+  ]
+ },
+ "742": {
+  "id": "742",
+  "title": "Reverse Fly with Pronated Grip",
+  "videoUrl": "https://youtu.be/s9-srORN8Ds",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1006"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1884"
+   }
+  ]
+ },
+ "743": {
+  "id": "743",
+  "title": "Reverse Grip Bent Over Row",
+  "videoUrl": "https://youtu.be/ESr3jXi1jaw",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1007"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1885"
+   }
+  ]
+ },
+ "744": {
+  "id": "744",
+  "title": "Reverse Grip Yates Row",
+  "videoUrl": "https://youtu.be/IlukcIPHP6E",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1008"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1886"
+   }
+  ]
+ },
+ "745": {
+  "id": "745",
+  "title": "Reverse Incline DB Row",
+  "videoUrl": "https://youtu.be/Bk71zNE6FoI",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1009"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1887"
+   }
+  ]
+ },
+ "746": {
+  "id": "746",
+  "title": "Reverse Plate Curl",
+  "videoUrl": "https://youtu.be/SLVxJXyoRvQ",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1010"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1888"
+   }
+  ]
+ },
+ "747": {
+  "id": "747",
+  "title": "Ring Dip",
+  "videoUrl": "https://youtu.be/U3DJTNEZIAY",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1011"
+   }
+  ]
+ },
+ "748": {
+  "id": "748",
+  "title": "Rocker",
+  "videoUrl": "https://youtu.be/x_S3zyRb8Ho",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [
+   "Chest"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1012"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1889"
+   }
+  ]
+ },
+ "749": {
+  "id": "749",
+  "title": "Rocket Jump",
+  "videoUrl": "https://youtu.be/wXbQyXidIt0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1013"
+   }
+  ]
+ },
+ "750": {
+  "id": "750",
+  "title": "Rocking Standing Calf Raise",
+  "videoUrl": "https://youtu.be/HcS0Y9-ssqE",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1014"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1890"
+   }
+  ]
+ },
+ "751": {
+  "id": "751",
+  "title": "Romanian Deadlift from Deficit",
+  "videoUrl": "https://youtu.be/G2ZVKx9Aj9s",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1015"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1891"
+   }
+  ]
+ },
+ "752": {
+  "id": "752",
+  "title": "Romanian Deadlift with DB",
+  "videoUrl": "https://youtu.be/mjPDqVULsj4",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1016"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1892"
+   }
+  ]
+ },
+ "753": {
+  "id": "753",
+  "title": "Romanian Deadlift with KB",
+  "videoUrl": "https://youtu.be/vbsTgWl61Nw",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1017"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1893"
+   }
+  ]
+ },
+ "754": {
+  "id": "754",
+  "title": "Runners Lunge Stretch",
+  "videoUrl": "https://youtu.be/YT0x73_ikKY",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1018"
+   }
+  ]
+ },
+ "755": {
+  "id": "755",
+  "title": "Russian Twist",
+  "videoUrl": "https://youtu.be/8Zd61Jg49Jg",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1019"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1894"
+   }
+  ]
+ },
+ "756": {
+  "id": "756",
+  "title": "Scapular Push Up",
+  "videoUrl": "https://youtu.be/RmyL50JMSfY",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Chest"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1020"
+   }
+  ]
+ },
+ "757": {
+  "id": "757",
+  "title": "Scapular Pull Up",
+  "videoUrl": "https://youtu.be/eaSKVRVVT3U",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1021"
+   }
+  ]
+ },
+ "758": {
+  "id": "758",
+  "title": "Scissor Kick",
+  "videoUrl": "https://youtu.be/V7bEqvFeMhA",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1022"
+   }
+  ]
+ },
+ "759": {
+  "id": "759",
+  "title": "Seated Arnold DB Press",
+  "videoUrl": "https://youtu.be/-KKIPLTKykA",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1023"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1895"
+   }
+  ]
+ },
+ "760": {
+  "id": "760",
+  "title": "Seated Band Hamstring Curl",
+  "videoUrl": "https://youtu.be/OXZByrgt6L8",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1024"
+   }
+  ]
+ },
+ "761": {
+  "id": "761",
+  "title": "Seated Banded Calf Stretch",
+  "videoUrl": "https://youtu.be/gTDJj4ndN5E",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1025"
+   }
+  ]
+ },
+ "762": {
+  "id": "762",
+  "title": "Seated Barbell Military Press",
+  "videoUrl": "https://youtu.be/XfJkevwVeT8",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1026"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1896"
+   }
+  ]
+ },
+ "763": {
+  "id": "763",
+  "title": "Seated Bent Over Rear Delt Raise",
+  "videoUrl": "https://youtu.be/aBBJ1p-Ud0I",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1027"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1897"
+   }
+  ]
+ },
+ "764": {
+  "id": "764",
+  "title": "Cable Seated Crunch",
+  "videoUrl": "https://youtu.be/wrLj9l6sA3s",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1028"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1898"
+   }
+  ]
+ },
+ "765": {
+  "id": "765",
+  "title": "Cable Seated Fly",
+  "videoUrl": "https://youtu.be/LI5cvjBN4o0",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1029"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1899"
+   }
+  ]
+ },
+ "766": {
+  "id": "766",
+  "title": "Cable Seated Row",
+  "videoUrl": "https://youtu.be/pe14jOxwiy4",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1030"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1900"
+   }
+  ]
+ },
+ "767": {
+  "id": "767",
+  "title": "Seated DB Curl",
+  "videoUrl": "https://youtu.be/uRIws8LtIdE",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1031"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1901"
+   }
+  ]
+ },
+ "768": {
+  "id": "768",
+  "title": "Seated DB Front Raise",
+  "videoUrl": "https://youtu.be/zvzJ-TvtUC4",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1032"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1902"
+   }
+  ]
+ },
+ "769": {
+  "id": "769",
+  "title": "Seated DB Palms Down Wrist Curl",
+  "videoUrl": "https://youtu.be/D40fLCvR5_s",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1033"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1903"
+   }
+  ]
+ },
+ "770": {
+  "id": "770",
+  "title": "Seated DB Palms Up Wrist Curl",
+  "videoUrl": "https://youtu.be/2erXCneihUs",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1034"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1904"
+   }
+  ]
+ },
+ "771": {
+  "id": "771",
+  "title": "Seated DB Press",
+  "videoUrl": "https://youtu.be/183BwLcBNqQ",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1035"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1905"
+   }
+  ]
+ },
+ "772": {
+  "id": "772",
+  "title": "Seated DB Tricep Extension",
+  "videoUrl": "https://youtu.be/FA1GJrd1sAk",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1036"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1906"
+   }
+  ]
+ },
+ "773": {
+  "id": "773",
+  "title": "Seated Double DB Tricep Extension",
+  "videoUrl": "https://youtu.be/FZp4sK8yxO8",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1037"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1907"
+   }
+  ]
+ },
+ "774": {
+  "id": "774",
+  "title": "Seated Flat Bench Leg Pull In",
+  "videoUrl": "https://youtu.be/u4-xr2G8jFI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1038"
+   }
+  ]
+ },
+ "775": {
+  "id": "775",
+  "title": "Seated Good Morning",
+  "videoUrl": "https://youtu.be/fUNBp1mRqb0",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1039"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1908"
+   }
+  ]
+ },
+ "776": {
+  "id": "776",
+  "title": "Seated Hammer Curl",
+  "videoUrl": "https://youtu.be/9dcNdoQ7izM",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1040"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1909"
+   }
+  ]
+ },
+ "777": {
+  "id": "777",
+  "title": "Seated Lateral Raise",
+  "videoUrl": "https://youtu.be/D9QydIvJwIQ",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1041"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1910"
+   }
+  ]
+ },
+ "778": {
+  "id": "778",
+  "title": "Seated Leg Tuck",
+  "videoUrl": "https://youtu.be/Z8GcXQCAXcY",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1042"
+   }
+  ]
+ },
+ "779": {
+  "id": "779",
+  "title": "Seated Overhead Tricep Extension",
+  "videoUrl": "https://youtu.be/pkei1tWzrq4",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1043"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1911"
+   }
+  ]
+ },
+ "780": {
+  "id": "780",
+  "title": "Seated Palm Up Barbell Wrist Curl",
+  "videoUrl": "https://youtu.be/UkfPvJD9BX0",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1044"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1912"
+   }
+  ]
+ },
+ "781": {
+  "id": "781",
+  "title": "Seated Palms Down Barbell Wrist Curl",
+  "videoUrl": "https://youtu.be/DWfkkobat4g",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1045"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1913"
+   }
+  ]
+ },
+ "782": {
+  "id": "782",
+  "title": "Seated Single Arm DB Palms Down Wrist Curl",
+  "videoUrl": "https://youtu.be/5rChNqMamrc",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1046"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1914"
+   }
+  ]
+ },
+ "783": {
+  "id": "783",
+  "title": "Seated Single Arm DB Palms Up Wrist Curl",
+  "videoUrl": "https://youtu.be/S_4iJdubJbY",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1047"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1915"
+   }
+  ]
+ },
+ "784": {
+  "id": "784",
+  "title": "Seated Straight Leg Pull In",
+  "videoUrl": "https://youtu.be/Zx__gZyKd3U",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1048"
+   }
+  ]
+ },
+ "785": {
+  "id": "785",
+  "title": "Shoulder Press with Band",
+  "videoUrl": "https://youtu.be/0qpJ0zRk9-s",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1049"
+   }
+  ]
+ },
+ "786": {
+  "id": "786",
+  "title": "Shoulder Tap",
+  "videoUrl": "https://youtu.be/mlgGw5t-Tz8",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1050"
+   }
+  ]
+ },
+ "787": {
+  "id": "787",
+  "title": "Side Bridge",
+  "videoUrl": "https://youtu.be/GXHghtNUBec",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1051"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1916"
+   }
+  ]
+ },
+ "788": {
+  "id": "788",
+  "title": "Side Jack Knife",
+  "videoUrl": "https://youtu.be/SgUBW3QLRRE",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1052"
+   }
+  ]
+ },
+ "789": {
+  "id": "789",
+  "title": "Side Lunge Touching Heel",
+  "videoUrl": "https://youtu.be/ZVAFahvvxA4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1053"
+   }
+  ]
+ },
+ "790": {
+  "id": "790",
+  "title": "Side Lying External Rotation",
+  "videoUrl": "https://youtu.be/1Ot7353Dpsw",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1054"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1917"
+   }
+  ]
+ },
+ "792": {
+  "id": "792",
+  "title": "Side Plank Hip Drop",
+  "videoUrl": "https://youtu.be/b5joCNZDeaE",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1056"
+   }
+  ]
+ },
+ "793": {
+  "id": "793",
+  "title": "Side Plank with Clam Shell Hold",
+  "videoUrl": "https://youtu.be/OvFeBN1SIq0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1057"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1919"
+   }
+  ]
+ },
+ "794": {
+  "id": "794",
+  "title": "Side Plank with Dynamic Clam Shell",
+  "videoUrl": "https://youtu.be/dLknoyfFS3w",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1058"
+   }
+  ]
+ },
+ "795": {
+  "id": "795",
+  "title": "Side Step Squat With Band",
+  "videoUrl": "https://youtu.be/fK_3AmP3SbE",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1059"
+   }
+  ]
+ },
+ "796": {
+  "id": "796",
+  "title": "Side to Side Box Jump",
+  "videoUrl": "https://youtu.be/rOftTUJWZwc",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1060"
+   }
+  ]
+ },
+ "797": {
+  "id": "797",
+  "title": "Side to Side Box Step",
+  "videoUrl": "https://youtu.be/0BKtfiCdtOw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1061"
+   }
+  ]
+ },
+ "798": {
+  "id": "798",
+  "title": "Side to Side Push Up",
+  "videoUrl": "https://youtu.be/Mwp3Mp8S2Hg",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1062"
+   }
+  ]
+ },
+ "799": {
+  "id": "799",
+  "title": "Single Arm Cable Bent Over Row",
+  "videoUrl": "https://youtu.be/ZWaVDg0z-Mw",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1063"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1920"
+   }
+  ]
+ },
+ "800": {
+  "id": "800",
+  "title": "Single Arm Cable Chest Press",
+  "videoUrl": "https://youtu.be/XRa6mRx0Cg0",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1064"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1921"
+   }
+  ]
+ },
+ "801": {
+  "id": "801",
+  "title": "Cable Single Arm Crossover",
+  "videoUrl": "https://youtu.be/nWzyG0lRdoc",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1065"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1922"
+   }
+  ]
+ },
+ "802": {
+  "id": "802",
+  "title": "Cable Single Arm Shoulder Press",
+  "videoUrl": "https://youtu.be/gyGYrRIn8rs",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1066"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1923"
+   }
+  ]
+ },
+ "803": {
+  "id": "803",
+  "title": "Single Arm Cable Tricep Extension",
+  "videoUrl": "https://youtu.be/PqJLfVxgQ_o",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1067"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1924"
+   }
+  ]
+ },
+ "804": {
+  "id": "804",
+  "title": "Single Arm DB Clean & Jerk",
+  "videoUrl": "https://youtu.be/9hgJvIRbg3Y",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1068"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1925"
+   }
+  ]
+ },
+ "805": {
+  "id": "805",
+  "title": "Single Arm DB Overhead Squat",
+  "videoUrl": "https://youtu.be/o_7pqd5ytzo",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1069"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1926"
+   }
+  ]
+ },
+ "806": {
+  "id": "806",
+  "title": "Single Arm DB Tricep Extension",
+  "videoUrl": "https://youtu.be/0IMpf-tzNWM",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1070"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1927"
+   }
+  ]
+ },
+ "807": {
+  "id": "807",
+  "title": "High Pulley Cable Single Arm Side Bend",
+  "videoUrl": "https://youtu.be/_IqUP3_F04U",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1071"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1928"
+   }
+  ]
+ },
+ "808": {
+  "id": "808",
+  "title": "Single Arm Cable Incline Fly",
+  "videoUrl": "https://youtu.be/mi4YmXqgZxc",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1072"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1929"
+   }
+  ]
+ },
+ "809": {
+  "id": "809",
+  "title": "Single Arm KB Clean",
+  "videoUrl": "https://youtu.be/1WfaN3Dcmww",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1073"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1930"
+   }
+  ]
+ },
+ "810": {
+  "id": "810",
+  "title": "Single Arm KB Floor Press",
+  "videoUrl": "https://youtu.be/JbmY7juvCGA",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1074"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1931"
+   }
+  ]
+ },
+ "811": {
+  "id": "811",
+  "title": "Single Arm KB Jerk",
+  "videoUrl": "https://youtu.be/OHSe-_UDLWU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1075"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1932"
+   }
+  ]
+ },
+ "812": {
+  "id": "812",
+  "title": "Single Arm KB Press",
+  "videoUrl": "https://youtu.be/NioxEfufNEk",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1076"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1933"
+   }
+  ]
+ },
+ "813": {
+  "id": "813",
+  "title": "Single Arm KB Row",
+  "videoUrl": "https://youtu.be/Wct-y5IWrgE",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1077"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1934"
+   }
+  ]
+ },
+ "814": {
+  "id": "814",
+  "title": "Single Arm KB Snatch",
+  "videoUrl": "https://youtu.be/7pJDxxX5xSU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1078"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1935"
+   }
+  ]
+ },
+ "815": {
+  "id": "815",
+  "title": "Single Arm KB Swing",
+  "videoUrl": "https://youtu.be/v7vNOmi74KA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1079"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1936"
+   }
+  ]
+ },
+ "816": {
+  "id": "816",
+  "title": "Single Arm Landmine Row",
+  "videoUrl": "https://youtu.be/K7PYPAEG9O0",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1080"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1937"
+   }
+  ]
+ },
+ "817": {
+  "id": "817",
+  "title": "Single Arm Lateral Raise",
+  "videoUrl": "https://youtu.be/gNEIzhLzT9I",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1081"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1938"
+   }
+  ]
+ },
+ "818": {
+  "id": "818",
+  "title": "Single Arm Overhead KB Squat",
+  "videoUrl": "https://youtu.be/hL2F2knUbxI",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1082"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1939"
+   }
+  ]
+ },
+ "819": {
+  "id": "819",
+  "title": "Single Arm Pronated DB Tricep Extension",
+  "videoUrl": "https://youtu.be/MizhHbLyB5M",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1083"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1940"
+   }
+  ]
+ },
+ "820": {
+  "id": "820",
+  "title": "Single Arm Push Up",
+  "videoUrl": "https://youtu.be/FWbpIogS7Yw",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1084"
+   }
+  ]
+ },
+ "821": {
+  "id": "821",
+  "title": "Single Arm Cable Rear Delt Fly",
+  "videoUrl": "https://youtu.be/D39tQljIroU",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1085"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1941"
+   }
+  ]
+ },
+ "822": {
+  "id": "822",
+  "title": "Single Arm Cable Rear Delt Row",
+  "videoUrl": "https://youtu.be/ZgAVwNXSQJg",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1086"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1942"
+   }
+  ]
+ },
+ "823": {
+  "id": "823",
+  "title": "Single Arm Cable Seated Row",
+  "videoUrl": "https://youtu.be/TYbsFTjNrGQ",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1087"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1943"
+   }
+  ]
+ },
+ "824": {
+  "id": "824",
+  "title": "Single Arm Cable Seated High Row",
+  "videoUrl": "https://youtu.be/cpCUM3ZHG5o",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1088"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1944"
+   }
+  ]
+ },
+ "825": {
+  "id": "825",
+  "title": "Single Arm Cable Standing Row",
+  "videoUrl": "https://youtu.be/aj_Ch9H014I",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1089"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1945"
+   }
+  ]
+ },
+ "826": {
+  "id": "826",
+  "title": "Single Leg Ball Curl",
+  "videoUrl": "https://youtu.be/0iAauTE_tb0",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1090"
+   }
+  ]
+ },
+ "827": {
+  "id": "827",
+  "title": "Single Leg Heels Elevated Hip Thrust",
+  "videoUrl": "https://youtu.be/5b0fBOOoK7c",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1091"
+   }
+  ]
+ },
+ "828": {
+  "id": "828",
+  "title": "Single Leg High Box Squat",
+  "videoUrl": "https://youtu.be/A37QeATmXIg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1092"
+   }
+  ]
+ },
+ "829": {
+  "id": "829",
+  "title": "Single Leg Push Off",
+  "videoUrl": "https://youtu.be/A2UH6pwOtj0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1093"
+   }
+  ]
+ },
+ "830": {
+  "id": "830",
+  "title": "Single Leg Skater Squat",
+  "videoUrl": "https://youtu.be/Tz1nX0CY5mU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1094"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1946"
+   }
+  ]
+ },
+ "831": {
+  "id": "831",
+  "title": "Snatch Behind the Neck Overhead Press",
+  "videoUrl": "https://youtu.be/BBCKqRVsNeo",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1095"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1947"
+   }
+  ]
+ },
+ "832": {
+  "id": "832",
+  "title": "Snatch Deadlift",
+  "videoUrl": "https://youtu.be/xNgeb1nMliY",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1096"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1948"
+   }
+  ]
+ },
+ "833": {
+  "id": "833",
+  "title": "Snatch from Blocks",
+  "videoUrl": "https://youtu.be/u1GDH9dg3lE",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1097"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1949"
+   }
+  ]
+ },
+ "834": {
+  "id": "834",
+  "title": "Snatch Grip Deadlift",
+  "videoUrl": "https://youtu.be/tYYsQB0Gfag",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1098"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1950"
+   }
+  ]
+ },
+ "835": {
+  "id": "835",
+  "title": "Snatch High Pull From Hang",
+  "videoUrl": "https://youtu.be/VON8pYLisjc",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1099"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1951"
+   }
+  ]
+ },
+ "836": {
+  "id": "836",
+  "title": "Snatch Pull",
+  "videoUrl": "https://youtu.be/WhP3IwTewG4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1100"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1952"
+   }
+  ]
+ },
+ "837": {
+  "id": "837",
+  "title": "Snatch Push Press",
+  "videoUrl": "https://youtu.be/PuJBafG2DzQ",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1101"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1953"
+   }
+  ]
+ },
+ "838": {
+  "id": "838",
+  "title": "Snatch Shrug",
+  "videoUrl": "https://youtu.be/XWDtN3cgyXQ",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1102"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1954"
+   }
+  ]
+ },
+ "839": {
+  "id": "839",
+  "title": "Sots Press",
+  "videoUrl": "https://youtu.be/jaSzWwEntg8",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1103"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1955"
+   }
+  ]
+ },
+ "840": {
+  "id": "840",
+  "title": "Spider Crawl",
+  "videoUrl": "https://youtu.be/Jezv6Yl1J20",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "1104"
+   }
+  ]
+ },
+ "841": {
+  "id": "841",
+  "title": "Split Clean",
+  "videoUrl": "https://youtu.be/nph81C9ThJY",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1105"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1956"
+   }
+  ]
+ },
+ "842": {
+  "id": "842",
+  "title": "Split Jerk",
+  "videoUrl": "https://youtu.be/BvVHgSLenH4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1106"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1957"
+   }
+  ]
+ },
+ "843": {
+  "id": "843",
+  "title": "Split Snatch",
+  "videoUrl": "https://youtu.be/yGmlxPH_6is",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1107"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1958"
+   }
+  ]
+ },
+ "844": {
+  "id": "844",
+  "title": "Split Squat with KB",
+  "videoUrl": "https://youtu.be/WPsbbZt3HxU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1108"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1959"
+   }
+  ]
+ },
+ "845": {
+  "id": "845",
+  "title": "Squat Abduction With Band",
+  "videoUrl": "https://youtu.be/zHUtpShD8YQ",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1109"
+   }
+  ]
+ },
+ "846": {
+  "id": "846",
+  "title": "Squat Jerk",
+  "videoUrl": "https://youtu.be/p75fpIjxl6I",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1110"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1960"
+   }
+  ]
+ },
+ "847": {
+  "id": "847",
+  "title": "Stability Ball Pike with Knee Tuck",
+  "videoUrl": "https://youtu.be/kCr_XQXT7Ag",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1111"
+   }
+  ]
+ },
+ "848": {
+  "id": "848",
+  "title": "Staggered Hands Push Up",
+  "videoUrl": "https://youtu.be/PHqTvFxj0gA",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1112"
+   }
+  ]
+ },
+ "849": {
+  "id": "849",
+  "title": "Standing Alternating DB Press",
+  "videoUrl": "https://youtu.be/kKzuMTOu6TA",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1113"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1961"
+   }
+  ]
+ },
+ "850": {
+  "id": "850",
+  "title": "Standing Barbell Bicep Curl",
+  "videoUrl": "https://youtu.be/5FSWb16vlEg",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1114"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1962"
+   }
+  ]
+ },
+ "851": {
+  "id": "851",
+  "title": "Standing Barbell Calf Raise",
+  "videoUrl": "https://youtu.be/Zw6z2oXWfGA",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1115"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1963"
+   }
+  ]
+ },
+ "852": {
+  "id": "852",
+  "title": "Standing Barbell Press Behind the Neck",
+  "videoUrl": "https://youtu.be/enf3YmUVoxA",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1116"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1964"
+   }
+  ]
+ },
+ "853": {
+  "id": "853",
+  "title": "Standing Bent Over Single Arm DB Tricep Extension",
+  "videoUrl": "https://youtu.be/SpXU0p2Qz5Y",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1117"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1965"
+   }
+  ]
+ },
+ "854": {
+  "id": "854",
+  "title": "Standing Bent Over Two Arm DB Tricep Extension",
+  "videoUrl": "https://youtu.be/Q5TzTmRiVKI",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1118"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1966"
+   }
+  ]
+ },
+ "855": {
+  "id": "855",
+  "title": "Standing Bicep Stretch",
+  "videoUrl": "https://youtu.be/VGyN93U1bF0",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1119"
+   }
+  ]
+ },
+ "856": {
+  "id": "856",
+  "title": "Standing Bradford Press",
+  "videoUrl": "https://youtu.be/3QvLWNYglNc",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1120"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1967"
+   }
+  ]
+ },
+ "857": {
+  "id": "857",
+  "title": "Standing Broad Jump",
+  "videoUrl": "https://youtu.be/WtkDAW6tYs0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1121"
+   },
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "1968"
+   }
+  ]
+ },
+ "858": {
+  "id": "858",
+  "title": "Cable Standing Wood Chop",
+  "videoUrl": "https://youtu.be/pNvM8P1grhk",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1122"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1969"
+   }
+  ]
+ },
+ "859": {
+  "id": "859",
+  "title": "Standing DB Calf Raise",
+  "videoUrl": "https://youtu.be/C8ZeiGp6Aj0",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1123"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1970"
+   }
+  ]
+ },
+ "860": {
+  "id": "860",
+  "title": "Standing DB Hand Squeeze",
+  "videoUrl": "https://youtu.be/WXfHvv9SV9o",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1124"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1971"
+   }
+  ]
+ },
+ "861": {
+  "id": "861",
+  "title": "Standing DB Reverse Curl",
+  "videoUrl": "https://youtu.be/x4qfN1fwPIs",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1125"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1972"
+   }
+  ]
+ },
+ "862": {
+  "id": "862",
+  "title": "Standing DB Straight Arm Front Delt Raise Above Head",
+  "videoUrl": "https://youtu.be/xkm3IveQLOg",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1126"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1973"
+   }
+  ]
+ },
+ "863": {
+  "id": "863",
+  "title": "Standing DB Upright Row",
+  "videoUrl": "https://youtu.be/1zk8UPVXERk",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1127"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1974"
+   }
+  ]
+ },
+ "864": {
+  "id": "864",
+  "title": "Standing Front Barbell Raise Overhead",
+  "videoUrl": "https://youtu.be/ww4U9xeITAQ",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1128"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1975"
+   }
+  ]
+ },
+ "865": {
+  "id": "865",
+  "title": "Standing Landmine Press",
+  "videoUrl": "https://youtu.be/gV18nWoN_3g",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1129"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1976"
+   }
+  ]
+ },
+ "866": {
+  "id": "866",
+  "title": "Standing Overhead Barbell Tricep Extension",
+  "videoUrl": "https://youtu.be/NUrtw2zeBD0",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1130"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1977"
+   }
+  ]
+ },
+ "867": {
+  "id": "867",
+  "title": "Standing Overhead DB Tricep Extension",
+  "videoUrl": "https://youtu.be/MnejUg5XfU4",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1131"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1978"
+   }
+  ]
+ },
+ "868": {
+  "id": "868",
+  "title": "Standing Palm In Single Arm DB Press",
+  "videoUrl": "https://youtu.be/VXsar9fSDVA",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1132"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1979"
+   }
+  ]
+ },
+ "869": {
+  "id": "869",
+  "title": "Standing Palms Up Barbell Behind the Back Wrist Curl",
+  "videoUrl": "https://youtu.be/EKdlnaV3G34",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1133"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1980"
+   }
+  ]
+ },
+ "870": {
+  "id": "870",
+  "title": "Standing Quad Stretch",
+  "videoUrl": "https://youtu.be/UmiAHxaU57I",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1134"
+   }
+  ]
+ },
+ "871": {
+  "id": "871",
+  "title": "Cable Standing Single Arm Curl",
+  "videoUrl": "https://youtu.be/qjaytG_a0yM",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1135"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1981"
+   }
+  ]
+ },
+ "872": {
+  "id": "872",
+  "title": "Standing Single Arm DB Curl Over Incline Bench",
+  "videoUrl": "https://youtu.be/u3gS4YexHSg",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1136"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1982"
+   }
+  ]
+ },
+ "873": {
+  "id": "873",
+  "title": "Standing Single Arm DB Tricep Extension",
+  "videoUrl": "https://youtu.be/G2lBxy00Iyk",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1137"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1983"
+   }
+  ]
+ },
+ "874": {
+  "id": "874",
+  "title": "Star Jump",
+  "videoUrl": "https://youtu.be/r4Vi7tJ_D8s",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1138"
+   }
+  ]
+ },
+ "875": {
+  "id": "875",
+  "title": "Static Clam Shell Hold",
+  "videoUrl": "https://youtu.be/9PMG-hMMMao",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1139"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1984"
+   }
+  ]
+ },
+ "876": {
+  "id": "876",
+  "title": "Step Up with Knee Raise",
+  "videoUrl": "https://youtu.be/J84nTOUGh0o",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1140"
+   }
+  ]
+ },
+ "877": {
+  "id": "877",
+  "title": "Stiff Leg Deadlift",
+  "videoUrl": "https://youtu.be/QbQtKcj_re8",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1141"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1985"
+   }
+  ]
+ },
+ "878": {
+  "id": "878",
+  "title": "Stiff Legged DB Deadlift",
+  "videoUrl": "https://youtu.be/21Tr0_1OPjE",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1142"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1986"
+   }
+  ]
+ },
+ "879": {
+  "id": "879",
+  "title": "Stir the Pot",
+  "videoUrl": "https://youtu.be/koaV-z2bw04",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1143"
+   }
+  ]
+ },
+ "880": {
+  "id": "880",
+  "title": "Straight Leg Barbell Good Morning",
+  "videoUrl": "https://youtu.be/IjiWQMkB7Mc",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1144"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1987"
+   }
+  ]
+ },
+ "881": {
+  "id": "881",
+  "title": "Straight Leg Bicycle Crunch",
+  "videoUrl": "https://youtu.be/xXS2ZpxHzK0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1145"
+   }
+  ]
+ },
+ "882": {
+  "id": "882",
+  "title": "Straight Leg Boat",
+  "videoUrl": "https://youtu.be/fQJrPXCGUzg",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1146"
+   }
+  ]
+ },
+ "883": {
+  "id": "883",
+  "title": "Straight Leg Crunch",
+  "videoUrl": "https://youtu.be/_oJhY_ykMJc",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1147"
+   }
+  ]
+ },
+ "884": {
+  "id": "884",
+  "title": "Straight Legged Hip Raise",
+  "videoUrl": "https://youtu.be/myT6QCFrJz0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1148"
+   }
+  ]
+ },
+ "885": {
+  "id": "885",
+  "title": "Strict Handstand Push Up",
+  "videoUrl": "https://youtu.be/TCyAxPY3cwo",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1149"
+   }
+  ]
+ },
+ "886": {
+  "id": "886",
+  "title": "Strict Toe to Bar",
+  "videoUrl": "https://youtu.be/D4Bcsm3qEbM",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1150"
+   }
+  ]
+ },
+ "887": {
+  "id": "887",
+  "title": "Suitcase Crunch",
+  "videoUrl": "https://youtu.be/npqxjrPnJCI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1151"
+   }
+  ]
+ },
+ "888": {
+  "id": "888",
+  "title": "Suitcase Deadlift",
+  "videoUrl": "https://youtu.be/9CwjHLpzx-0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1152"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1988"
+   }
+  ]
+ },
+ "889": {
+  "id": "889",
+  "title": "Sumo Deadlift",
+  "videoUrl": "https://youtu.be/vjf5KT55hY4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1153"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1989"
+   }
+  ]
+ },
+ "890": {
+  "id": "890",
+  "title": "Sumo Deadlift Block Pull",
+  "videoUrl": "https://youtu.be/Qhfepv_2r1M",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1154"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1990"
+   }
+  ]
+ },
+ "891": {
+  "id": "891",
+  "title": "Sumo KB Deadlift",
+  "videoUrl": "https://youtu.be/YapqM42tAk4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1155"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1991"
+   }
+  ]
+ },
+ "892": {
+  "id": "892",
+  "title": "Superman Hold",
+  "videoUrl": "https://youtu.be/MRnGANEGaPA",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1156"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1992"
+   }
+  ]
+ },
+ "893": {
+  "id": "893",
+  "title": "Supine Twist",
+  "videoUrl": "https://youtu.be/d2-djDRFMdY",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1157"
+   }
+  ]
+ },
+ "894": {
+  "id": "894",
+  "title": "Supported Calf Stretch",
+  "videoUrl": "https://youtu.be/yxs5G2M4WxY",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1158"
+   }
+  ]
+ },
+ "895": {
+  "id": "895",
+  "title": "Svend Press",
+  "videoUrl": "https://youtu.be/W4ondFgVzCY",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1159"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1993"
+   }
+  ]
+ },
+ "896": {
+  "id": "896",
+  "title": "Swimmer",
+  "videoUrl": "https://youtu.be/sYq1na-wV2Y",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1160"
+   }
+  ]
+ },
+ "897": {
+  "id": "897",
+  "title": "Swiss Ball Leg Curl",
+  "videoUrl": "https://youtu.be/-vW6hhc3_dg",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1161"
+   }
+  ]
+ },
+ "898": {
+  "id": "898",
+  "title": "Swiss Ball Single Leg Curl",
+  "videoUrl": "https://youtu.be/Jz4fZNGotJQ",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1162"
+   }
+  ]
+ },
+ "899": {
+  "id": "899",
+  "title": "Tall Muscle Snatch",
+  "videoUrl": "https://youtu.be/rGfnbRZbY5s",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1163"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1994"
+   }
+  ]
+ },
+ "900": {
+  "id": "900",
+  "title": "Tate Press",
+  "videoUrl": "https://youtu.be/CkV4_ZFtaCQ",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1164"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "1995"
+   }
+  ]
+ },
+ "901": {
+  "id": "901",
+  "title": "Toe Tap",
+  "videoUrl": "https://youtu.be/1sR0wDZZTo0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1165"
+   }
+  ]
+ },
+ "902": {
+  "id": "902",
+  "title": "Toe Touch",
+  "videoUrl": "https://youtu.be/kSmvKK2XVx4",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1166"
+   }
+  ]
+ },
+ "903": {
+  "id": "903",
+  "title": "TrapBar Deadlift",
+  "videoUrl": "https://youtu.be/0ZshUc3sXBk",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1167"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1996"
+   }
+  ]
+ },
+ "904": {
+  "id": "904",
+  "title": "TrapBar Jump",
+  "videoUrl": "https://youtu.be/O2Ww9TtCvTg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1168"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1997"
+   }
+  ]
+ },
+ "905": {
+  "id": "905",
+  "title": "Tuck Crunch",
+  "videoUrl": "https://youtu.be/mHG7xj54GcY",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1169"
+   }
+  ]
+ },
+ "906": {
+  "id": "906",
+  "title": "Twisting Mountain Climber",
+  "videoUrl": "https://youtu.be/y8ymjUhMliI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1170"
+   }
+  ]
+ },
+ "907": {
+  "id": "907",
+  "title": "Cable Twisting Single Arm Chest Press",
+  "videoUrl": "https://youtu.be/kpWnhjFI3xU",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1171"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1998"
+   }
+  ]
+ },
+ "908": {
+  "id": "908",
+  "title": "Cable Twisting Single Arm Overhead Press",
+  "videoUrl": "https://youtu.be/iWT0flUOF3U",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1172"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "1999"
+   }
+  ]
+ },
+ "909": {
+  "id": "909",
+  "title": "Cable Twisting Single Arm Standing Chest Press",
+  "videoUrl": "https://youtu.be/J25q6oVsBiw",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1173"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2000"
+   }
+  ]
+ },
+ "910": {
+  "id": "910",
+  "title": "Two Arm DB Preacher Curl",
+  "videoUrl": "https://youtu.be/KUEPu8wMukU",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1174"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "2001"
+   }
+  ]
+ },
+ "911": {
+  "id": "911",
+  "title": "Two Arm KB Clean",
+  "videoUrl": "https://youtu.be/w-xPd8SLKC8",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1175"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "2002"
+   }
+  ]
+ },
+ "912": {
+  "id": "912",
+  "title": "Two Arm KB Jerk",
+  "videoUrl": "https://youtu.be/fzgn6o-njW0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1176"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "2003"
+   }
+  ]
+ },
+ "913": {
+  "id": "913",
+  "title": "Two Arm KB Press",
+  "videoUrl": "https://youtu.be/1iAUT1YBrTk",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1177"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "2004"
+   }
+  ]
+ },
+ "914": {
+  "id": "914",
+  "title": "Two Arm KB Row",
+  "videoUrl": "https://youtu.be/ppU0eMyEU38",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1178"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "2005"
+   }
+  ]
+ },
+ "915": {
+  "id": "915",
+  "title": "Two Arm Pronated DB Tricep Extension",
+  "videoUrl": "https://youtu.be/od7gRgwABUE",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1179"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "2006"
+   }
+  ]
+ },
+ "916": {
+  "id": "916",
+  "title": "U Ab",
+  "videoUrl": "https://youtu.be/K2NW3ZvoVmQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1180"
+   }
+  ]
+ },
+ "917": {
+  "id": "917",
+  "title": "Underhand Front Raise",
+  "videoUrl": "https://youtu.be/3aq7CQTFaso",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Chest"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1181"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "2007"
+   }
+  ]
+ },
+ "918": {
+  "id": "918",
+  "title": "Upright Row with Band",
+  "videoUrl": "https://youtu.be/ZZPgh0ocuyo",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1182"
+   }
+  ]
+ },
+ "919": {
+  "id": "919",
+  "title": "Upward Facing Dog",
+  "videoUrl": "https://youtu.be/yKilWFKxOnU",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1183"
+   }
+  ]
+ },
+ "920": {
+  "id": "920",
+  "title": "W Raise",
+  "videoUrl": "https://youtu.be/6YCum6_HC44",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1184"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "2008"
+   }
+  ]
+ },
+ "921": {
+  "id": "921",
+  "title": "Waiter's Carry",
+  "videoUrl": "https://youtu.be/dAmA_1sZuyk",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Forearms"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1185"
+   },
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "2009"
+   }
+  ]
+ },
+ "922": {
+  "id": "922",
+  "title": "Walking Barbell Lunge",
+  "videoUrl": "https://youtu.be/oBN3F3ZHNzU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1186"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2010"
+   }
+  ]
+ },
+ "923": {
+  "id": "923",
+  "title": "Walking Knee Hug",
+  "videoUrl": "https://youtu.be/379rCfhVUus",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1187"
+   }
+  ]
+ },
+ "924": {
+  "id": "924",
+  "title": "Walking Lunge with Overhead Weight",
+  "videoUrl": "https://youtu.be/JavS3Zc2MF0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1188"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2011"
+   }
+  ]
+ },
+ "925": {
+  "id": "925",
+  "title": "Wall Walk",
+  "videoUrl": "https://youtu.be/Pisd-F2tAhw",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1189"
+   }
+  ]
+ },
+ "926": {
+  "id": "926",
+  "title": "Weighted Bench Dip",
+  "videoUrl": "https://youtu.be/5ojuhHhXWDo",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1190"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2012"
+   }
+  ]
+ },
+ "927": {
+  "id": "927",
+  "title": "Weighted Chin Up",
+  "videoUrl": "https://youtu.be/SvP5rfxJ7Is",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1191"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2013"
+   }
+  ]
+ },
+ "928": {
+  "id": "928",
+  "title": "Weighted Crunch",
+  "videoUrl": "https://youtu.be/3bp-DAYUJYY",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1192"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2014"
+   }
+  ]
+ },
+ "929": {
+  "id": "929",
+  "title": "Weighted Plank",
+  "videoUrl": "https://youtu.be/fuJ1RxkB0Ac",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1193"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2015"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "2194"
+   }
+  ]
+ },
+ "930": {
+  "id": "930",
+  "title": "Weighted Pull Up",
+  "videoUrl": "https://youtu.be/B7yvs4ufBBc",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1194"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2016"
+   }
+  ]
+ },
+ "931": {
+  "id": "931",
+  "title": "Weighted Push Up",
+  "videoUrl": "https://youtu.be/BimZ_KdF0Lo",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1195"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2017"
+   }
+  ]
+ },
+ "932": {
+  "id": "932",
+  "title": "Weighted Sissy Squat",
+  "videoUrl": "https://youtu.be/m5awTA8jjbk",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1196"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2018"
+   }
+  ]
+ },
+ "933": {
+  "id": "933",
+  "title": "Wide Grip Barbell Bench Press",
+  "videoUrl": "https://youtu.be/ZYBRZXG6oUc",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1197"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2019"
+   }
+  ]
+ },
+ "934": {
+  "id": "934",
+  "title": "Wide Grip Bench Press",
+  "videoUrl": "https://youtu.be/7R69LzYY7VU",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1198"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2020"
+   }
+  ]
+ },
+ "935": {
+  "id": "935",
+  "title": "Wide Grip Lat Pulldown",
+  "videoUrl": "https://youtu.be/WLPlTny86BE",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1199"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2021"
+   }
+  ]
+ },
+ "936": {
+  "id": "936",
+  "title": "Wide Grip Pull Up",
+  "videoUrl": "https://youtu.be/ZPGLEhtlQA0",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1200"
+   }
+  ]
+ },
+ "937": {
+  "id": "937",
+  "title": "Wide Grip Rear Pull Up",
+  "videoUrl": "https://youtu.be/4fQewGpkgHM",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1201"
+   }
+  ]
+ },
+ "938": {
+  "id": "938",
+  "title": "Wide Grip Standing Barbell Curl",
+  "videoUrl": "https://youtu.be/zVMY8R5wQAo",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1202"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2022"
+   }
+  ]
+ },
+ "939": {
+  "id": "939",
+  "title": "Wide Incline Push Up",
+  "videoUrl": "https://youtu.be/e7WSb2t0Nk8",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1203"
+   }
+  ]
+ },
+ "940": {
+  "id": "940",
+  "title": "Wide Legged Forward Fold",
+  "videoUrl": "https://youtu.be/tNc1Gk3nt5c",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "1204"
+   }
+  ]
+ },
+ "941": {
+  "id": "941",
+  "title": "Wide Push Up",
+  "videoUrl": "https://youtu.be/VlDgmc5tX2U",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1205"
+   }
+  ]
+ },
+ "942": {
+  "id": "942",
+  "title": "X Band Walk",
+  "videoUrl": "https://youtu.be/nKR-ZpQFh1s",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "1206"
+   }
+  ]
+ },
+ "943": {
+  "id": "943",
+  "title": "Yates Row",
+  "videoUrl": "https://youtu.be/4qXz4fbXQCg",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1207"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2023"
+   }
+  ]
+ },
+ "944": {
+  "id": "944",
+  "title": "Zercher Squat",
+  "videoUrl": "https://youtu.be/ajOeyp1Kics",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1208"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "2024"
+   }
+  ]
+ },
+ "945": {
+  "id": "945",
+  "title": "Zottman Curl",
+  "videoUrl": "https://youtu.be/44S62yiIhy0",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "1209"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "2025"
+   }
+  ]
+ },
+ "5178": {
+  "id": "5178",
+  "title": "90-90",
+  "videoUrl": "https://youtu.be/RFNf526zhkk",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8397"
+   }
+  ]
+ },
+ "5179": {
+  "id": "5179",
+  "title": "90-90 to Lunge",
+  "videoUrl": "https://youtu.be/TxwRE_voSTU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8398"
+   }
+  ]
+ },
+ "5180": {
+  "id": "5180",
+  "title": "Ab Wheel",
+  "videoUrl": "https://youtu.be/BOLffwrnfBY",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8399"
+   }
+  ]
+ },
+ "5181": {
+  "id": "5181",
+  "title": "Alternating Foot Jump Rope",
+  "videoUrl": "https://youtu.be/ZHQ1XA_vMyM",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8400"
+   }
+  ]
+ },
+ "5182": {
+  "id": "5182",
+  "title": "Alternating KB Lunge",
+  "videoUrl": "https://youtu.be/f6TfQQp2Ikg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8401"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8908"
+   }
+  ]
+ },
+ "5183": {
+  "id": "5183",
+  "title": "Anderson Squat",
+  "videoUrl": "https://youtu.be/9b_0DRELW5w",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8402"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8909"
+   }
+  ]
+ },
+ "5184": {
+  "id": "5184",
+  "title": "Ankle Roll",
+  "videoUrl": "https://youtu.be/_TF8GQm51-I",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8403"
+   }
+  ]
+ },
+ "5185": {
+  "id": "5185",
+  "title": "Archer Pull Up",
+  "videoUrl": "https://youtu.be/0BVoquLf8qw",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8404"
+   }
+  ]
+ },
+ "5186": {
+  "id": "5186",
+  "title": "Archer Push Up",
+  "videoUrl": "https://youtu.be/EwGkK9vOE_Y",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8405"
+   }
+  ]
+ },
+ "5187": {
+  "id": "5187",
+  "title": "Arm Circle",
+  "videoUrl": "https://youtu.be/JnfuIB1ia38",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8406"
+   }
+  ]
+ },
+ "5188": {
+  "id": "5188",
+  "title": "Backward Jogging",
+  "videoUrl": "https://youtu.be/x96GKevST7I",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8407"
+   }
+  ]
+ },
+ "5189": {
+  "id": "5189",
+  "title": "Band Around the World",
+  "videoUrl": "https://youtu.be/FdYdoDrc1HM",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8408"
+   }
+  ]
+ },
+ "5190": {
+  "id": "5190",
+  "title": "Band Chest Press",
+  "videoUrl": "https://youtu.be/O03gaBeRHUQ",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8409"
+   }
+  ]
+ },
+ "5191": {
+  "id": "5191",
+  "title": "Band Crab Walk",
+  "videoUrl": "https://youtu.be/YS0q_CdfyE4",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8410"
+   }
+  ]
+ },
+ "5192": {
+  "id": "5192",
+  "title": "Band Crossbody Tricep Extension",
+  "videoUrl": "https://youtu.be/oqwCLknmg5s",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8411"
+   }
+  ]
+ },
+ "5193": {
+  "id": "5193",
+  "title": "Band Pass Through",
+  "videoUrl": "https://youtu.be/aVko_U_Fd9g",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8412"
+   }
+  ]
+ },
+ "5194": {
+  "id": "5194",
+  "title": "Band Reverse Fly",
+  "videoUrl": "https://youtu.be/uBCM3e_UrDQ",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8413"
+   }
+  ]
+ },
+ "5195": {
+  "id": "5195",
+  "title": "Band Scapular Retraction",
+  "videoUrl": "https://youtu.be/wAcO604Lkdo",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8414"
+   }
+  ]
+ },
+ "5196": {
+  "id": "5196",
+  "title": "Band Seated Row",
+  "videoUrl": "https://youtu.be/a12DYOkNyjs",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8415"
+   }
+  ]
+ },
+ "5197": {
+  "id": "5197",
+  "title": "Band Single Arm Row",
+  "videoUrl": "https://youtu.be/3LeIs-to_ws",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8416"
+   }
+  ]
+ },
+ "5198": {
+  "id": "5198",
+  "title": "Band Squat and Press",
+  "videoUrl": "https://youtu.be/TZkITAvjgIs",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8417"
+   }
+  ]
+ },
+ "5199": {
+  "id": "5199",
+  "title": "Banded Ankle Mobility",
+  "videoUrl": "https://youtu.be/yteCd1xzg14",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8418"
+   }
+  ]
+ },
+ "5200": {
+  "id": "5200",
+  "title": "Banded Bear Crawl",
+  "videoUrl": "https://youtu.be/L29zQioXcgU",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8419"
+   }
+  ]
+ },
+ "5201": {
+  "id": "5201",
+  "title": "Banded Bench Press",
+  "videoUrl": "https://youtu.be/ccmYbnD4o5s",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8420"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8910"
+   }
+  ]
+ },
+ "5202": {
+  "id": "5202",
+  "title": "Banded Bicycle Crunch",
+  "videoUrl": "https://youtu.be/KUNn90bdf2M",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8421"
+   }
+  ]
+ },
+ "5203": {
+  "id": "5203",
+  "title": "Banded Bird Dog",
+  "videoUrl": "https://youtu.be/ypgEmzbx0Sg",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8422"
+   }
+  ]
+ },
+ "5204": {
+  "id": "5204",
+  "title": "Banded Diagonal Lift",
+  "videoUrl": "https://youtu.be/bckZ8SnQ7G0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8423"
+   }
+  ]
+ },
+ "5205": {
+  "id": "5205",
+  "title": "Banded Donkey Kick",
+  "videoUrl": "https://youtu.be/sBcGokc28eA",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8424"
+   }
+  ]
+ },
+ "5206": {
+  "id": "5206",
+  "title": "Banded Front Raise",
+  "videoUrl": "https://youtu.be/zmXZPBGJxfo",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8425"
+   }
+  ]
+ },
+ "5207": {
+  "id": "5207",
+  "title": "Banded Hip Abduction",
+  "videoUrl": "https://youtu.be/aiJ6LEs5Q_0",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8426"
+   }
+  ]
+ },
+ "5208": {
+  "id": "5208",
+  "title": "Banded Hip Flexor Pull",
+  "videoUrl": "https://youtu.be/71QBYabKT9M",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8427"
+   }
+  ]
+ },
+ "5209": {
+  "id": "5209",
+  "title": "Banded Hip Mobility",
+  "videoUrl": "https://youtu.be/OGNFBov5lsI",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8428"
+   }
+  ]
+ },
+ "5210": {
+  "id": "5210",
+  "title": "Banded Lat Pull Down",
+  "videoUrl": "https://youtu.be/8Wdw2Sx6Dd0",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8429"
+   }
+  ]
+ },
+ "5211": {
+  "id": "5211",
+  "title": "Banded Lateral Raise",
+  "videoUrl": "https://youtu.be/GKfgfJ2-Q-w",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8430"
+   }
+  ]
+ },
+ "5212": {
+  "id": "5212",
+  "title": "Banded Overhead Press",
+  "videoUrl": "https://youtu.be/pNQ1e7GWQyo",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8431"
+   }
+  ]
+ },
+ "5213": {
+  "id": "5213",
+  "title": "Banded Overhead Squat",
+  "videoUrl": "https://youtu.be/E3yWk3mHNyI",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8432"
+   }
+  ]
+ },
+ "5214": {
+  "id": "5214",
+  "title": "Banded Overhead Tricep Extension",
+  "videoUrl": "https://youtu.be/dgzd7K-rQT8",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8433"
+   }
+  ]
+ },
+ "5215": {
+  "id": "5215",
+  "title": "Banded Plank Leg Lift",
+  "videoUrl": "https://youtu.be/4OzwVHpZH84",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8434"
+   }
+  ]
+ },
+ "5216": {
+  "id": "5216",
+  "title": "Banded Plank Row",
+  "videoUrl": "https://youtu.be/3kPTMG3wegY",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8435"
+   }
+  ]
+ },
+ "5217": {
+  "id": "5217",
+  "title": "Banded Psoas Distraction",
+  "videoUrl": "https://youtu.be/9NK6JjoIjlE",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8436"
+   }
+  ]
+ },
+ "5218": {
+  "id": "5218",
+  "title": "Banded Push Up",
+  "videoUrl": "https://youtu.be/5H8bXzfByHg",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8437"
+   }
+  ]
+ },
+ "5219": {
+  "id": "5219",
+  "title": "Banded Row",
+  "videoUrl": "https://youtu.be/BhQyUzWEqlo",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8438"
+   }
+  ]
+ },
+ "5220": {
+  "id": "5220",
+  "title": "Banded Shin Crunch",
+  "videoUrl": "https://youtu.be/4foLiuYGaes",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8439"
+   }
+  ]
+ },
+ "5221": {
+  "id": "5221",
+  "title": "Banded Squat",
+  "videoUrl": "https://youtu.be/FD4oJaP-T0o",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8440"
+   }
+  ]
+ },
+ "5222": {
+  "id": "5222",
+  "title": "Banded Tricep Extension",
+  "videoUrl": "https://youtu.be/0S6p6mZspsA",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8441"
+   }
+  ]
+ },
+ "5223": {
+  "id": "5223",
+  "title": "Banded Tricep Kick Back",
+  "videoUrl": "https://youtu.be/j3tMwx8jLQI",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8442"
+   }
+  ]
+ },
+ "5224": {
+  "id": "5224",
+  "title": "Banded Upright Row",
+  "videoUrl": "https://youtu.be/Xnhd9h1dyp0",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8443"
+   }
+  ]
+ },
+ "5225": {
+  "id": "5225",
+  "title": "Banded Wood Chopper",
+  "videoUrl": "https://youtu.be/2rVYuZ0OaR0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8444"
+   }
+  ]
+ },
+ "5226": {
+  "id": "5226",
+  "title": "Bear Crawl",
+  "videoUrl": "https://youtu.be/IXHOFBIr8qI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8445"
+   }
+  ]
+ },
+ "5227": {
+  "id": "5227",
+  "title": "Behind the Neck Pull Up",
+  "videoUrl": "https://youtu.be/188J1u3c6w8",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8446"
+   }
+  ]
+ },
+ "5228": {
+  "id": "5228",
+  "title": "Bird Dog Row",
+  "videoUrl": "https://youtu.be/ouLO3DWyoJY",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8447"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8911"
+   }
+  ]
+ },
+ "5229": {
+  "id": "5229",
+  "title": "Body Weight Good Morning",
+  "videoUrl": "https://youtu.be/6dK_dGs3Z3E",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8448"
+   }
+  ]
+ },
+ "5230": {
+  "id": "5230",
+  "title": "Box Dip",
+  "videoUrl": "https://youtu.be/SsAXHt_2oXU",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8449"
+   }
+  ]
+ },
+ "5231": {
+  "id": "5231",
+  "title": "Box Donkey Kick",
+  "videoUrl": "https://youtu.be/ljjccN_F_ak",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8450"
+   }
+  ]
+ },
+ "5232": {
+  "id": "5232",
+  "title": "Box Jump to Tuck Jump",
+  "videoUrl": "https://youtu.be/mMw7CCCyGMo",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8451"
+   }
+  ]
+ },
+ "5233": {
+  "id": "5233",
+  "title": "Box Pigeon Stretch",
+  "videoUrl": "https://youtu.be/JejoxnnvUpw",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8452"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8912"
+   }
+  ]
+ },
+ "5234": {
+  "id": "5234",
+  "title": "Box Pike Push Up",
+  "videoUrl": "https://youtu.be/GLMxmqz5msA",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8453"
+   }
+  ]
+ },
+ "5235": {
+  "id": "5235",
+  "title": "Box Plank with Leg Lift",
+  "videoUrl": "https://youtu.be/EMyiRrNifow",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8454"
+   }
+  ]
+ },
+ "5236": {
+  "id": "5236",
+  "title": "Box Push Up",
+  "videoUrl": "https://youtu.be/JrhfYSwxFpA",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8455"
+   }
+  ]
+ },
+ "5237": {
+  "id": "5237",
+  "title": "Box Reverse Lunge",
+  "videoUrl": "https://youtu.be/5Ho1SDhkRF4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8456"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8913"
+   }
+  ]
+ },
+ "5238": {
+  "id": "5238",
+  "title": "Box Seated Leg Tuck",
+  "videoUrl": "https://youtu.be/Kcc9Q-dvruo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8457"
+   }
+  ]
+ },
+ "5239": {
+  "id": "5239",
+  "title": "Box Thruster",
+  "videoUrl": "https://youtu.be/UKv7keK0REs",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8458"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8914"
+   }
+  ]
+ },
+ "5240": {
+  "id": "5240",
+  "title": "Box V Sit",
+  "videoUrl": "https://youtu.be/LaqhlAuT8LA",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8459"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8915"
+   }
+  ]
+ },
+ "5241": {
+  "id": "5241",
+  "title": "Bridge Pose",
+  "videoUrl": "https://youtu.be/1JBhEJcm0fc",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8460"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8916"
+   }
+  ]
+ },
+ "5242": {
+  "id": "5242",
+  "title": "Burpee Box Jump Over",
+  "videoUrl": "https://youtu.be/jhbQFxWSG-I",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8461"
+   }
+  ]
+ },
+ "5243": {
+  "id": "5243",
+  "title": "Butt Kick Rope Jump",
+  "videoUrl": "https://youtu.be/ZXVdzboX9as",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8462"
+   }
+  ]
+ },
+ "5244": {
+  "id": "5244",
+  "title": "Butterfly Crunch",
+  "videoUrl": "https://youtu.be/yhltdM0nLbk",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8463"
+   }
+  ]
+ },
+ "5245": {
+  "id": "5245",
+  "title": "Butterfly Pull Up",
+  "videoUrl": "https://youtu.be/LFhi7fQOvj8",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8464"
+   }
+  ]
+ },
+ "5246": {
+  "id": "5246",
+  "title": "Butterfly Stretch",
+  "videoUrl": "https://youtu.be/kjeyLG-P-Vc",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8465"
+   }
+  ]
+ },
+ "5247": {
+  "id": "5247",
+  "title": "Calf Foam Roll",
+  "videoUrl": "https://youtu.be/T7eLQcSRO9I",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8466"
+   }
+  ]
+ },
+ "5248": {
+  "id": "5248",
+  "title": "Carioca Drill",
+  "videoUrl": "https://youtu.be/laFblMkLo9A",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8467"
+   }
+  ]
+ },
+ "5249": {
+  "id": "5249",
+  "title": "Chain Bench Press",
+  "videoUrl": "https://youtu.be/_pghpqpifq8",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8468"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8917"
+   }
+  ]
+ },
+ "5250": {
+  "id": "5250",
+  "title": "Chain Deadlift",
+  "videoUrl": "https://youtu.be/9T0QsFTODVk",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8469"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8918"
+   }
+  ]
+ },
+ "5251": {
+  "id": "5251",
+  "title": "Chair Pose",
+  "videoUrl": "https://youtu.be/iEQSfIiPNC0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8470"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8919"
+   }
+  ]
+ },
+ "5252": {
+  "id": "5252",
+  "title": "Close Grip Pull Up",
+  "videoUrl": "https://youtu.be/183V-wdxdVU",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8471"
+   }
+  ]
+ },
+ "5253": {
+  "id": "5253",
+  "title": "Cloud Pose",
+  "videoUrl": "https://youtu.be/7Oy3pbs-ohQ",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8472"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8920"
+   }
+  ]
+ },
+ "5254": {
+  "id": "5254",
+  "title": "Cobra Pose",
+  "videoUrl": "https://youtu.be/65wv7PURy2w",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8473"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8921"
+   }
+  ]
+ },
+ "5255": {
+  "id": "5255",
+  "title": "Commando Pull Up",
+  "videoUrl": "https://youtu.be/SEdgUZ07AQU",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8474"
+   }
+  ]
+ },
+ "5256": {
+  "id": "5256",
+  "title": "Copenhagen Plank",
+  "videoUrl": "https://youtu.be/50oiBd2eARs",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8475"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8922"
+   }
+  ]
+ },
+ "5257": {
+  "id": "5257",
+  "title": "Cossack Squat",
+  "videoUrl": "https://youtu.be/jT_2BXAZknM",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8476"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8923"
+   }
+  ]
+ },
+ "5258": {
+  "id": "5258",
+  "title": "Couch Stretch",
+  "videoUrl": "https://youtu.be/IaR_ETK_AO8",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8477"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8924"
+   }
+  ]
+ },
+ "5259": {
+  "id": "5259",
+  "title": "Counterbalance Pistol Squat",
+  "videoUrl": "https://youtu.be/jHSD86SG1Vg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8478"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8925"
+   }
+  ]
+ },
+ "5260": {
+  "id": "5260",
+  "title": "Cross Body Push Up",
+  "videoUrl": "https://youtu.be/QoIY0uEWrQA",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8479"
+   }
+  ]
+ },
+ "5261": {
+  "id": "5261",
+  "title": "Cross Over Double Under",
+  "videoUrl": "https://youtu.be/AJKRIo1g698",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8480"
+   }
+  ]
+ },
+ "5262": {
+  "id": "5262",
+  "title": "Crossover",
+  "videoUrl": "https://youtu.be/eE6F4EC1rXg",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8481"
+   }
+  ]
+ },
+ "5263": {
+  "id": "5263",
+  "title": "Curtsy Lunge",
+  "videoUrl": "https://youtu.be/jhtWRTK-F5c",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8482"
+   }
+  ]
+ },
+ "5264": {
+  "id": "5264",
+  "title": "DB Clean",
+  "videoUrl": "https://youtu.be/_HU2OzCqGws",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8483"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8926"
+   }
+  ]
+ },
+ "5265": {
+  "id": "5265",
+  "title": "DB Crunch",
+  "videoUrl": "https://youtu.be/n9T1qub9qFY",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8484"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8927"
+   }
+  ]
+ },
+ "5266": {
+  "id": "5266",
+  "title": "DB Russian Twist",
+  "videoUrl": "https://youtu.be/Oo5hSQDbZy8",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8485"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8928"
+   }
+  ]
+ },
+ "5267": {
+  "id": "5267",
+  "title": "DB Snatch",
+  "videoUrl": "https://youtu.be/nrytysWsegs",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8486"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8929"
+   }
+  ]
+ },
+ "5268": {
+  "id": "5268",
+  "title": "Dead Hang",
+  "videoUrl": "https://youtu.be/Be-KNBUvCFs",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8487"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8930"
+   }
+  ]
+ },
+ "5269": {
+  "id": "5269",
+  "title": "Decline Bench Crunch",
+  "videoUrl": "https://youtu.be/TvUHg0yfyz4",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8488"
+   }
+  ]
+ },
+ "5270": {
+  "id": "5270",
+  "title": "Decline Bench Press",
+  "videoUrl": "https://youtu.be/BsxpWj547z4",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8489"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8931"
+   }
+  ]
+ },
+ "5271": {
+  "id": "5271",
+  "title": "Decline Mountain Climber",
+  "videoUrl": "https://youtu.be/2V-BlQWMeQo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8490"
+   }
+  ]
+ },
+ "5272": {
+  "id": "5272",
+  "title": "Decline Sit Up",
+  "videoUrl": "https://youtu.be/CRYHF-dVkso",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8491"
+   }
+  ]
+ },
+ "5273": {
+  "id": "5273",
+  "title": "Deficit Push Up",
+  "videoUrl": "https://youtu.be/1FtSgHr8YHA",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8492"
+   }
+  ]
+ },
+ "5274": {
+  "id": "5274",
+  "title": "Double Crunch",
+  "videoUrl": "https://youtu.be/lTqppP-fFVs",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8493"
+   }
+  ]
+ },
+ "5275": {
+  "id": "5275",
+  "title": "Double KB Clean & Push Press",
+  "videoUrl": "https://youtu.be/4ulKLgL9g5E",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8494"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8932"
+   }
+  ]
+ },
+ "5276": {
+  "id": "5276",
+  "title": "Double KB Row",
+  "videoUrl": "https://youtu.be/bSk9g49X_tY",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8495"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8933"
+   }
+  ]
+ },
+ "5277": {
+  "id": "5277",
+  "title": "Double Under",
+  "videoUrl": "https://youtu.be/dXpfRTRr9tU",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8496"
+   }
+  ]
+ },
+ "5278": {
+  "id": "5278",
+  "title": "Downward Dog Lunge Rotation",
+  "videoUrl": "https://youtu.be/BbHzhZakamk",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8497"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8934"
+   }
+  ]
+ },
+ "5279": {
+  "id": "5279",
+  "title": "Drop Jump",
+  "videoUrl": "https://youtu.be/OUL11FnxICQ",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8498"
+   }
+  ]
+ },
+ "5280": {
+  "id": "5280",
+  "title": "Eagle Arms Stretch",
+  "videoUrl": "https://youtu.be/xhEGbUY-WHA",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8499"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8935"
+   }
+  ]
+ },
+ "5281": {
+  "id": "5281",
+  "title": "Feet On Swiss Ball Plank",
+  "videoUrl": "https://youtu.be/pCI3G2AxAAw",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8500"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8936"
+   }
+  ]
+ },
+ "5282": {
+  "id": "5282",
+  "title": "Feet On Swiss Ball Push Up",
+  "videoUrl": "https://youtu.be/ydXnHktdtrg",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8501"
+   }
+  ]
+ },
+ "5283": {
+  "id": "5283",
+  "title": "Finger Tip Push Up",
+  "videoUrl": "https://youtu.be/kF-HN2pmfVk",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8502"
+   }
+  ]
+ },
+ "5284": {
+  "id": "5284",
+  "title": "Floor L Sit",
+  "videoUrl": "https://youtu.be/jjGye5husWo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8503"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8937"
+   }
+  ]
+ },
+ "5285": {
+  "id": "5285",
+  "title": "Forward Leg Swing",
+  "videoUrl": "https://youtu.be/mOU52EXbS0o",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8504"
+   }
+  ]
+ },
+ "5286": {
+  "id": "5286",
+  "title": "Frankenstein Walk",
+  "videoUrl": "https://youtu.be/Qol4UvKES0E",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8505"
+   }
+  ]
+ },
+ "5287": {
+  "id": "5287",
+  "title": "Free Standing Hand Stand Push Up",
+  "videoUrl": "https://youtu.be/xLKdhJ8oQlQ",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8506"
+   }
+  ]
+ },
+ "5288": {
+  "id": "5288",
+  "title": "Frog Crunch",
+  "videoUrl": "https://youtu.be/APGaCLQUIlc",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8507"
+   }
+  ]
+ },
+ "5289": {
+  "id": "5289",
+  "title": "Front Squat Static Hold",
+  "videoUrl": "https://youtu.be/jiavh91cjWg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8508"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8938"
+   }
+  ]
+ },
+ "5290": {
+  "id": "5290",
+  "title": "Glute Foam Roll",
+  "videoUrl": "https://youtu.be/03klb-rmrIo",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8509"
+   }
+  ]
+ },
+ "5291": {
+  "id": "5291",
+  "title": "Gorilla Pull Up",
+  "videoUrl": "https://youtu.be/KgyoukL8iFs",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8510"
+   }
+  ]
+ },
+ "5292": {
+  "id": "5292",
+  "title": "Hack Squat",
+  "videoUrl": "https://youtu.be/dvikkJT1qmg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8511"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8939"
+   }
+  ]
+ },
+ "5293": {
+  "id": "5293",
+  "title": "Hand Stand Pirouette",
+  "videoUrl": "https://youtu.be/gBu11bKitVk",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8512"
+   }
+  ]
+ },
+ "5294": {
+  "id": "5294",
+  "title": "Hand Stand Walk",
+  "videoUrl": "https://youtu.be/e6Z8L-lyzYc",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8513"
+   }
+  ]
+ },
+ "5295": {
+  "id": "5295",
+  "title": "Hand Stand Walk to Wall",
+  "videoUrl": "https://youtu.be/iH923uea6L4",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8514"
+   }
+  ]
+ },
+ "5296": {
+  "id": "5296",
+  "title": "Hand Stand Walk with Step Obstacle",
+  "videoUrl": "https://youtu.be/4fi3_xaTrGQ",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8515"
+   }
+  ]
+ },
+ "5297": {
+  "id": "5297",
+  "title": "Hands On Swiss Ball Plank",
+  "videoUrl": "https://youtu.be/GdRHwt71Knk",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8516"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8940"
+   }
+  ]
+ },
+ "5298": {
+  "id": "5298",
+  "title": "Hands On Swiss Ball Push Up",
+  "videoUrl": "https://youtu.be/X5HSyjz08H0",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8517"
+   }
+  ]
+ },
+ "5299": {
+  "id": "5299",
+  "title": "Hanging L Sit",
+  "videoUrl": "https://youtu.be/bM_dzs08NTE",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Forearms"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8518"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8941"
+   }
+  ]
+ },
+ "5300": {
+  "id": "5300",
+  "title": "Hat Twist",
+  "videoUrl": "https://youtu.be/xMoNE_c0AsU",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8519"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8942"
+   }
+  ]
+ },
+ "5301": {
+  "id": "5301",
+  "title": "Head Stand",
+  "videoUrl": "https://youtu.be/Hg_k4PX2oxc",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8520"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8943"
+   }
+  ]
+ },
+ "5302": {
+  "id": "5302",
+  "title": "Heel Elevated Back Squat",
+  "videoUrl": "https://youtu.be/rtBINByhbLo",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8521"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8944"
+   }
+  ]
+ },
+ "5303": {
+  "id": "5303",
+  "title": "High Knee",
+  "videoUrl": "https://youtu.be/3oGGhXiCoEA",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8522"
+   }
+  ]
+ },
+ "5304": {
+  "id": "5304",
+  "title": "High Knee Jump Rope",
+  "videoUrl": "https://youtu.be/eWPnRQ9G1tI",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8523"
+   }
+  ]
+ },
+ "5305": {
+  "id": "5305",
+  "title": "Hip Circle",
+  "videoUrl": "https://youtu.be/fcvCWtJkm2o",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8524"
+   }
+  ]
+ },
+ "5306": {
+  "id": "5306",
+  "title": "Hip Flexor Knee Drive",
+  "videoUrl": "https://youtu.be/3xsNSvs0kpA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8525"
+   }
+  ]
+ },
+ "5307": {
+  "id": "5307",
+  "title": "Hip Flexor Stretch",
+  "videoUrl": "https://youtu.be/PqMyyC2p4Vk",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8526"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8945"
+   }
+  ]
+ },
+ "5308": {
+  "id": "5308",
+  "title": "Hip Thrust Band Around Knees",
+  "videoUrl": "https://youtu.be/1AkAz_Cn2eg",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8527"
+   }
+  ]
+ },
+ "5309": {
+  "id": "5309",
+  "title": "Hollow Body Crunches",
+  "videoUrl": "https://youtu.be/plKYjb5S3JM",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8528"
+   }
+  ]
+ },
+ "5310": {
+  "id": "5310",
+  "title": "Hollow Hold",
+  "videoUrl": "https://youtu.be/ie71bIyBa5g",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8529"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8946"
+   }
+  ]
+ },
+ "5311": {
+  "id": "5311",
+  "title": "Hollow Rock",
+  "videoUrl": "https://youtu.be/LtPp1K2-3fU",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8530"
+   }
+  ]
+ },
+ "5312": {
+  "id": "5312",
+  "title": "Ipsilateral Dead Bug",
+  "videoUrl": "https://youtu.be/zLoSunLqYb0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8531"
+   }
+  ]
+ },
+ "5313": {
+  "id": "5313",
+  "title": "IT Foam Roll",
+  "videoUrl": "https://youtu.be/4OpPxVViX6g",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8532"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8947"
+   }
+  ]
+ },
+ "5314": {
+  "id": "5314",
+  "title": "Jog In Place",
+  "videoUrl": "https://youtu.be/3kJhVoSqbFg",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8533"
+   }
+  ]
+ },
+ "5315": {
+  "id": "5315",
+  "title": "KB Farmer's Walk",
+  "videoUrl": "https://youtu.be/2uGpEARE2l0",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Forearms"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8534"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8948"
+   }
+  ]
+ },
+ "5316": {
+  "id": "5316",
+  "title": "KB Figure Eight",
+  "videoUrl": "https://youtu.be/Q4FgHVX27Dg",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Forearms"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8535"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8949"
+   }
+  ]
+ },
+ "5317": {
+  "id": "5317",
+  "title": "KB Front Rack Carry",
+  "videoUrl": "https://youtu.be/vNlvbH1KxCk",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8536"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8950"
+   }
+  ]
+ },
+ "5318": {
+  "id": "5318",
+  "title": "KB Halo",
+  "videoUrl": "https://youtu.be/HZqyRlFetkw",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8537"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8951"
+   }
+  ]
+ },
+ "5319": {
+  "id": "5319",
+  "title": "KB Marching Farmer's Walk",
+  "videoUrl": "https://youtu.be/WFLUZna9sLk",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Forearms"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8538"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8952"
+   }
+  ]
+ },
+ "5320": {
+  "id": "5320",
+  "title": "KB Overhead Carry",
+  "videoUrl": "https://youtu.be/883FdTQfTWM",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8539"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8953"
+   }
+  ]
+ },
+ "5321": {
+  "id": "5321",
+  "title": "KB Pistol Squat",
+  "videoUrl": "https://youtu.be/OGAabox_Bgk",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8540"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8954"
+   }
+  ]
+ },
+ "5322": {
+  "id": "5322",
+  "title": "KB Push Up to Renegade Row",
+  "videoUrl": "https://youtu.be/zg6OcdXiMHg",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8541"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8955"
+   }
+  ]
+ },
+ "5323": {
+  "id": "5323",
+  "title": "KB Renegade Row",
+  "videoUrl": "https://youtu.be/dw51ccwdfh8",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8542"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8956"
+   }
+  ]
+ },
+ "5324": {
+  "id": "5324",
+  "title": "KB Swing Squat",
+  "videoUrl": "https://youtu.be/Lc5qQepUR4s",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8543"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "8957"
+   }
+  ]
+ },
+ "5325": {
+  "id": "5325",
+  "title": "KB Windmill",
+  "videoUrl": "https://youtu.be/1O0-4toitBI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8544"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8958"
+   }
+  ]
+ },
+ "5326": {
+  "id": "5326",
+  "title": "Kipping Pull Up",
+  "videoUrl": "https://youtu.be/x9Azp0XLOOU",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8545"
+   }
+  ]
+ },
+ "5327": {
+  "id": "5327",
+  "title": "Knee Skip",
+  "videoUrl": "https://youtu.be/Q5Vda1RZrtw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8546"
+   }
+  ]
+ },
+ "5328": {
+  "id": "5328",
+  "title": "Knuckle Push Up",
+  "videoUrl": "https://youtu.be/o-XjzZs6wtE",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8547"
+   }
+  ]
+ },
+ "5329": {
+  "id": "5329",
+  "title": "L Sit on DB",
+  "videoUrl": "https://youtu.be/Va3q5V3XwVM",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8548"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8959"
+   }
+  ]
+ },
+ "5330": {
+  "id": "5330",
+  "title": "Lat Foam Roll",
+  "videoUrl": "https://youtu.be/6fDnPJWj2mc",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8549"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8960"
+   }
+  ]
+ },
+ "5331": {
+  "id": "5331",
+  "title": "Lateral Box Jump",
+  "videoUrl": "https://youtu.be/2EqGOLiO71A",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8550"
+   }
+  ]
+ },
+ "5332": {
+  "id": "5332",
+  "title": "Lateral Lunge",
+  "videoUrl": "https://youtu.be/Y6toL-AtdNo",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8551"
+   }
+  ]
+ },
+ "5333": {
+  "id": "5333",
+  "title": "Lateral Shuffle",
+  "videoUrl": "https://youtu.be/m-THHWwBKXA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8552"
+   }
+  ]
+ },
+ "5334": {
+  "id": "5334",
+  "title": "Lateral Toe Tap",
+  "videoUrl": "https://youtu.be/ISbruySOGWc",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8553"
+   }
+  ]
+ },
+ "5335": {
+  "id": "5335",
+  "title": "Lateral Toe Tap on Elevated Surface",
+  "videoUrl": "https://youtu.be/Ka3qQSq1bww",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8554"
+   }
+  ]
+ },
+ "5336": {
+  "id": "5336",
+  "title": "Long Arm Crunch",
+  "videoUrl": "https://youtu.be/L7AuhkyWzc4",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8555"
+   }
+  ]
+ },
+ "5337": {
+  "id": "5337",
+  "title": "Lying Knee to Chest Stretch",
+  "videoUrl": "https://youtu.be/FYXpphZV7h4",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8556"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8961"
+   }
+  ]
+ },
+ "5338": {
+  "id": "5338",
+  "title": "Medicine Ball Alternating Lunge",
+  "videoUrl": "https://youtu.be/6h683H1cDGY",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8557"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8962"
+   }
+  ]
+ },
+ "5339": {
+  "id": "5339",
+  "title": "Medicine Ball Burpee",
+  "videoUrl": "https://youtu.be/Xl_qaQvt5Ec",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8558"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8963"
+   }
+  ]
+ },
+ "5340": {
+  "id": "5340",
+  "title": "Medicine Ball Chest Pass",
+  "videoUrl": "https://youtu.be/X0vtVTTfDC0",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8559"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8964"
+   }
+  ]
+ },
+ "5341": {
+  "id": "5341",
+  "title": "Medicine Ball Push Up",
+  "videoUrl": "https://youtu.be/zSao3ltQ92s",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8560"
+   }
+  ]
+ },
+ "5342": {
+  "id": "5342",
+  "title": "Medicine Ball Rainbow Slam",
+  "videoUrl": "https://youtu.be/qAY6QNxUhp4",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8561"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8965"
+   }
+  ]
+ },
+ "5343": {
+  "id": "5343",
+  "title": "Medicine Ball Reverse Lunge",
+  "videoUrl": "https://youtu.be/9gSSHYgS9es",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8562"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8966"
+   }
+  ]
+ },
+ "5344": {
+  "id": "5344",
+  "title": "Medicine Ball Rotational Row",
+  "videoUrl": "https://youtu.be/T1gIKaueShk",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8563"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8967"
+   }
+  ]
+ },
+ "5345": {
+  "id": "5345",
+  "title": "Medicine Ball Sit Up",
+  "videoUrl": "https://youtu.be/CVhSeuI0O5c",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8564"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8968"
+   }
+  ]
+ },
+ "5346": {
+  "id": "5346",
+  "title": "Medicine Ball Squat",
+  "videoUrl": "https://youtu.be/3S-KT6l9KZU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8565"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8969"
+   }
+  ]
+ },
+ "5347": {
+  "id": "5347",
+  "title": "Medicine Ball Squat to Press",
+  "videoUrl": "https://youtu.be/D-V1kWVLJ5M",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8566"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8970"
+   }
+  ]
+ },
+ "5348": {
+  "id": "5348",
+  "title": "Medicine Ball Toe Touch",
+  "videoUrl": "https://youtu.be/xkt22898L-c",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8567"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8971"
+   }
+  ]
+ },
+ "5349": {
+  "id": "5349",
+  "title": "Medicine Ball V Up",
+  "videoUrl": "https://youtu.be/pwBDeNXwCaM",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8568"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8972"
+   }
+  ]
+ },
+ "5350": {
+  "id": "5350",
+  "title": "Medicine Ball Walking Lunge",
+  "videoUrl": "https://youtu.be/-0txh9YnY3g",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8569"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8973"
+   }
+  ]
+ },
+ "5351": {
+  "id": "5351",
+  "title": "Medicine Ball Wood Chopper",
+  "videoUrl": "https://youtu.be/gVdCkQwQkVo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8570"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8974"
+   }
+  ]
+ },
+ "5352": {
+  "id": "5352",
+  "title": "Mixed Grip Pull Up",
+  "videoUrl": "https://youtu.be/YuIrHrlPDTw",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8571"
+   }
+  ]
+ },
+ "5353": {
+  "id": "5353",
+  "title": "Mountain Pose",
+  "videoUrl": "https://youtu.be/DpEVwJAEzBc",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8572"
+   }
+  ]
+ },
+ "5354": {
+  "id": "5354",
+  "title": "One Legged L Sit",
+  "videoUrl": "https://youtu.be/09mZeQ-tseQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8573"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8975"
+   }
+  ]
+ },
+ "5355": {
+  "id": "5355",
+  "title": "Parallettes L Sit",
+  "videoUrl": "https://youtu.be/GrlHs-ZxAMQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8574"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8976"
+   }
+  ]
+ },
+ "5356": {
+  "id": "5356",
+  "title": "Paused Back Squat",
+  "videoUrl": "https://youtu.be/WlN8Ty93qg8",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8575"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8977"
+   }
+  ]
+ },
+ "5357": {
+  "id": "5357",
+  "title": "Paused Bench Press",
+  "videoUrl": "https://youtu.be/I796VyOLa2M",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8576"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8978"
+   }
+  ]
+ },
+ "5358": {
+  "id": "5358",
+  "title": "Paused Deadlift",
+  "videoUrl": "https://youtu.be/jtNY8PuMk4M",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8577"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8979"
+   }
+  ]
+ },
+ "5359": {
+  "id": "5359",
+  "title": "Paused Front Squat",
+  "videoUrl": "https://youtu.be/wVQD-bvVccc",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8578"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8980"
+   }
+  ]
+ },
+ "5360": {
+  "id": "5360",
+  "title": "Paused Push Up",
+  "videoUrl": "https://youtu.be/8iqv7RHEgN4",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8579"
+   }
+  ]
+ },
+ "5361": {
+  "id": "5361",
+  "title": "Pin Press",
+  "videoUrl": "https://youtu.be/jblm82IYgU4",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8580"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8981"
+   }
+  ]
+ },
+ "5362": {
+  "id": "5362",
+  "title": "Plank Crunch",
+  "videoUrl": "https://youtu.be/dBg-NVbA5m0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8581"
+   }
+  ]
+ },
+ "5363": {
+  "id": "5363",
+  "title": "Plank to Down Dog",
+  "videoUrl": "https://youtu.be/AEZGdxPi0v0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8582"
+   }
+  ]
+ },
+ "5364": {
+  "id": "5364",
+  "title": "Pretzel",
+  "videoUrl": "https://youtu.be/iLrBtr5fQyI",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8583"
+   }
+  ]
+ },
+ "5365": {
+  "id": "5365",
+  "title": "Pull Up Negative",
+  "videoUrl": "https://youtu.be/ebn_iJMvTkw",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8584"
+   }
+  ]
+ },
+ "5366": {
+  "id": "5366",
+  "title": "Push Up",
+  "videoUrl": "https://youtu.be/27qO210FJDU",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8585"
+   }
+  ]
+ },
+ "5367": {
+  "id": "5367",
+  "title": "Quad Foam Roll",
+  "videoUrl": "https://youtu.be/qpcafPYVw2I",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8586"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8982"
+   }
+  ]
+ },
+ "5368": {
+  "id": "5368",
+  "title": "Quad Stretch",
+  "videoUrl": "https://youtu.be/Aeab5mjLciI",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8587"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8983"
+   }
+  ]
+ },
+ "5369": {
+  "id": "5369",
+  "title": "Quick Rebounding Heel Raise",
+  "videoUrl": "https://youtu.be/wobr4R0PitY",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8588"
+   }
+  ]
+ },
+ "5370": {
+  "id": "5370",
+  "title": "Raised Leg Crunch",
+  "videoUrl": "https://youtu.be/HeuaGxs5I3M",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8589"
+   }
+  ]
+ },
+ "5371": {
+  "id": "5371",
+  "title": "Reverse Grip Bench Press",
+  "videoUrl": "https://youtu.be/WScGH6QxDMM",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8590"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8984"
+   }
+  ]
+ },
+ "5372": {
+  "id": "5372",
+  "title": "Reverse Sled Drag",
+  "videoUrl": "https://youtu.be/v0f-VA0HPQc",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8591"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8985"
+   }
+  ]
+ },
+ "5373": {
+  "id": "5373",
+  "title": "Ring Bicep Curl",
+  "videoUrl": "https://youtu.be/j9OSNyny5O0",
+  "primaryMuscleGroups": [
+   "Biceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8592"
+   }
+  ]
+ },
+ "5374": {
+  "id": "5374",
+  "title": "Ring False Grip Hang",
+  "videoUrl": "https://youtu.be/HXsjMLcpnMU",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Forearms"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8593"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8986"
+   }
+  ]
+ },
+ "5375": {
+  "id": "5375",
+  "title": "Ring Fly",
+  "videoUrl": "https://youtu.be/ss2aH2s_QZw",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8594"
+   }
+  ]
+ },
+ "5376": {
+  "id": "5376",
+  "title": "Ring Hamstring Curl",
+  "videoUrl": "https://youtu.be/z4NTMrzgpDQ",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8595"
+   }
+  ]
+ },
+ "5377": {
+  "id": "5377",
+  "title": "Ring Knee Tuck",
+  "videoUrl": "https://youtu.be/HHoAdtPbsyU",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8596"
+   }
+  ]
+ },
+ "5378": {
+  "id": "5378",
+  "title": "Ring L Sit",
+  "videoUrl": "https://youtu.be/vuPMJ5PStLc",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8597"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8987"
+   }
+  ]
+ },
+ "5379": {
+  "id": "5379",
+  "title": "Ring Pike Pull Through",
+  "videoUrl": "https://youtu.be/UTufFp7g2DU",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8598"
+   }
+  ]
+ },
+ "5380": {
+  "id": "5380",
+  "title": "Ring Pull Up",
+  "videoUrl": "https://youtu.be/aLMpCveKWgQ",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8599"
+   }
+  ]
+ },
+ "5381": {
+  "id": "5381",
+  "title": "Ring Push Up",
+  "videoUrl": "https://youtu.be/di8Xg1N12Ag",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8600"
+   }
+  ]
+ },
+ "5382": {
+  "id": "5382",
+  "title": "Ring Row",
+  "videoUrl": "https://youtu.be/y6MPOUPhkx8",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8601"
+   }
+  ]
+ },
+ "5383": {
+  "id": "5383",
+  "title": "Ring Tricep Extension",
+  "videoUrl": "https://youtu.be/2Hj09nVcFtE",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8602"
+   }
+  ]
+ },
+ "5384": {
+  "id": "5384",
+  "title": "Rowing",
+  "videoUrl": "https://youtu.be/SR912dRt8Ls",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8603"
+   }
+  ]
+ },
+ "5385": {
+  "id": "5385",
+  "title": "Safety Bar Box Squat",
+  "videoUrl": "https://youtu.be/IhCL10n7_8s",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8604"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8988"
+   }
+  ]
+ },
+ "5386": {
+  "id": "5386",
+  "title": "Safety Bar Bulgarian Split Squat",
+  "videoUrl": "https://youtu.be/IApNmJNq2LY",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8605"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8989"
+   }
+  ]
+ },
+ "5387": {
+  "id": "5387",
+  "title": "Safety Bar Front Squat",
+  "videoUrl": "https://youtu.be/PQrPQ5WNduI",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8606"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8990"
+   }
+  ]
+ },
+ "5388": {
+  "id": "5388",
+  "title": "Safety Bar Good Morning",
+  "videoUrl": "https://youtu.be/NeefvODIbGI",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8607"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8991"
+   }
+  ]
+ },
+ "5389": {
+  "id": "5389",
+  "title": "Safety Bar Half Heeled Split Squat",
+  "videoUrl": "https://youtu.be/8N4aXba4LLE",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8608"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8992"
+   }
+  ]
+ },
+ "5390": {
+  "id": "5390",
+  "title": "Safety Bar Half Heeled Squat",
+  "videoUrl": "https://youtu.be/85mazfkOQzU",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8609"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8993"
+   }
+  ]
+ },
+ "5391": {
+  "id": "5391",
+  "title": "Safety Bar Reverse Lunge",
+  "videoUrl": "https://youtu.be/IXeV5oFY7Lo",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8610"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8994"
+   }
+  ]
+ },
+ "5392": {
+  "id": "5392",
+  "title": "Safety Bar Split Squat",
+  "videoUrl": "https://youtu.be/Qwi__0dO-u4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8611"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8995"
+   }
+  ]
+ },
+ "5393": {
+  "id": "5393",
+  "title": "Safety Bar Squat",
+  "videoUrl": "https://youtu.be/FyaZdG87Pa4",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8612"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8996"
+   }
+  ]
+ },
+ "5394": {
+  "id": "5394",
+  "title": "Seal Jack",
+  "videoUrl": "https://youtu.be/Y-3DU0m3J1E",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8613"
+   }
+  ]
+ },
+ "5395": {
+  "id": "5395",
+  "title": "Seated Forward Fold",
+  "videoUrl": "https://youtu.be/T5tgqhI-Xf8",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8614"
+   }
+  ]
+ },
+ "5396": {
+  "id": "5396",
+  "title": "Seated L Sit Leg Lift",
+  "videoUrl": "https://youtu.be/D9BmqrS8Qak",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8615"
+   }
+  ]
+ },
+ "5397": {
+  "id": "5397",
+  "title": "Shoulder Stand",
+  "videoUrl": "https://youtu.be/qHc62kMWb_A",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8616"
+   }
+  ]
+ },
+ "5398": {
+  "id": "5398",
+  "title": "Shoulder Stretch",
+  "videoUrl": "https://youtu.be/OWjBB9iHDuw",
+  "primaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8617"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8997"
+   }
+  ]
+ },
+ "5399": {
+  "id": "5399",
+  "title": "Side Leg Swing",
+  "videoUrl": "https://youtu.be/AWxg11s3UxE",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8618"
+   }
+  ]
+ },
+ "5400": {
+  "id": "5400",
+  "title": "Side Stretch",
+  "videoUrl": "https://youtu.be/MnXoi_JV0ec",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8619"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8998"
+   }
+  ]
+ },
+ "5401": {
+  "id": "5401",
+  "title": "Single KB Row",
+  "videoUrl": "https://youtu.be/BADBGgrMqaw",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8620"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "8999"
+   }
+  ]
+ },
+ "5402": {
+  "id": "5402",
+  "title": "Single Leg Box Squat",
+  "videoUrl": "https://youtu.be/g2jf0Wy0fbA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8621"
+   }
+  ]
+ },
+ "5403": {
+  "id": "5403",
+  "title": "Single Leg KB Pass Over",
+  "videoUrl": "https://youtu.be/faJ_unIX0is",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8622"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "9000"
+   }
+  ]
+ },
+ "5404": {
+  "id": "5404",
+  "title": "Single Leg Pogo Hop",
+  "videoUrl": "https://youtu.be/Q5pu9D2OMx4",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8623"
+   }
+  ]
+ },
+ "5405": {
+  "id": "5405",
+  "title": "Single Leg Standing Squat",
+  "videoUrl": "https://youtu.be/C_vMW0bQQoE",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8624"
+   }
+  ]
+ },
+ "5406": {
+  "id": "5406",
+  "title": "Single Under",
+  "videoUrl": "https://youtu.be/VHOtRE-Z6WA",
+  "primaryMuscleGroups": [
+   "Calves"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8625"
+   }
+  ]
+ },
+ "5407": {
+  "id": "5407",
+  "title": "Sled Drag",
+  "videoUrl": "https://youtu.be/pkt1j-prAVI",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Calves"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8626"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "9001"
+   }
+  ]
+ },
+ "5408": {
+  "id": "5408",
+  "title": "Sled Push",
+  "videoUrl": "https://youtu.be/-PAbT1usLDk",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8627"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "9002"
+   }
+  ]
+ },
+ "5409": {
+  "id": "5409",
+  "title": "Spider Man Step",
+  "videoUrl": "https://youtu.be/rikcTv-XJ6I",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8628"
+   }
+  ]
+ },
+ "5410": {
+  "id": "5410",
+  "title": "Spoto Press",
+  "videoUrl": "https://youtu.be/6w-ZjMCSlqY",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8629"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "9003"
+   }
+  ]
+ },
+ "5411": {
+  "id": "5411",
+  "title": "Squat Walk Out",
+  "videoUrl": "https://youtu.be/0a0fYTvvZYg",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8630"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "9004"
+   }
+  ]
+ },
+ "5412": {
+  "id": "5412",
+  "title": "Standing Forward Fold",
+  "videoUrl": "https://youtu.be/Qp-pw0KcjzE",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8631"
+   }
+  ]
+ },
+ "5413": {
+  "id": "5413",
+  "title": "Standing IT Band Stretch",
+  "videoUrl": "https://youtu.be/HtKz8LmL_p8",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8632"
+   }
+  ]
+ },
+ "5414": {
+  "id": "5414",
+  "title": "Star Crunch",
+  "videoUrl": "https://youtu.be/FscXXjJiMUU",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8633"
+   }
+  ]
+ },
+ "5415": {
+  "id": "5415",
+  "title": "Stationary Bike",
+  "videoUrl": "https://youtu.be/ywVuBoEDmzI",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8634"
+   }
+  ]
+ },
+ "5416": {
+  "id": "5416",
+  "title": "Straddle L Sit",
+  "videoUrl": "https://youtu.be/bwwzFX6akVI",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8635"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "9005"
+   }
+  ]
+ },
+ "5417": {
+  "id": "5417",
+  "title": "Suitcase Carry",
+  "videoUrl": "https://youtu.be/j0Q4Tm7rKP4",
+  "primaryMuscleGroups": [
+   "Forearms"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "DistanceFt",
+    "category": "Distance",
+    "unit": "Feet",
+    "id": "8636"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "9006"
+   }
+  ]
+ },
+ "5418": {
+  "id": "5418",
+  "title": "Sumo Romanian Deadlift",
+  "videoUrl": "https://youtu.be/NCY7iabeRGU",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8637"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "9007"
+   }
+  ]
+ },
+ "5419": {
+  "id": "5419",
+  "title": "Sun Salutation A",
+  "videoUrl": "https://youtu.be/XZJulaFVFrE",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8638"
+   }
+  ]
+ },
+ "5420": {
+  "id": "5420",
+  "title": "Sun Salutation B",
+  "videoUrl": "https://youtu.be/5-TfTOVwAhY",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8639"
+   }
+  ]
+ },
+ "5421": {
+  "id": "5421",
+  "title": "Swiss Ball Back Extension",
+  "videoUrl": "https://youtu.be/5fP72dGxWjY",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8640"
+   }
+  ]
+ },
+ "5422": {
+  "id": "5422",
+  "title": "Swiss Ball Bird Dog",
+  "videoUrl": "https://youtu.be/JEnuWitM1F0",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8641"
+   }
+  ]
+ },
+ "5423": {
+  "id": "5423",
+  "title": "Swiss Ball Bridge",
+  "videoUrl": "https://youtu.be/ETR1W9Innf4",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8642"
+   }
+  ]
+ },
+ "5424": {
+  "id": "5424",
+  "title": "Swiss Ball Chest Fly",
+  "videoUrl": "https://youtu.be/vJ5kXHGpmW8",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Shoulders"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8643"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "9008"
+   }
+  ]
+ },
+ "5425": {
+  "id": "5425",
+  "title": "Swiss Ball Crunch",
+  "videoUrl": "https://youtu.be/LpozZnIX0Zo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8644"
+   }
+  ]
+ },
+ "5426": {
+  "id": "5426",
+  "title": "Swiss Ball DB Press",
+  "videoUrl": "https://youtu.be/y6ROBUCKvuk",
+  "primaryMuscleGroups": [
+   "Chest"
+  ],
+  "secondaryMuscleGroups": [
+   "Triceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8645"
+   },
+   {
+    "parameter": "WeightPerSideLb",
+    "category": "Weight/side",
+    "unit": "Pounds",
+    "id": "9009"
+   }
+  ]
+ },
+ "5427": {
+  "id": "5427",
+  "title": "Swiss Ball Hip Thrust",
+  "videoUrl": "https://youtu.be/zr7kJqLlT0M",
+  "primaryMuscleGroups": [
+   "Glute"
+  ],
+  "secondaryMuscleGroups": [
+   "Abs"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8646"
+   }
+  ]
+ },
+ "5428": {
+  "id": "5428",
+  "title": "Swiss Ball Jack Knife",
+  "videoUrl": "https://youtu.be/QLsyFIJ2cLc",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8647"
+   }
+  ]
+ },
+ "5429": {
+  "id": "5429",
+  "title": "Swiss Ball Lunge",
+  "videoUrl": "https://youtu.be/sC4jHVrp7k0",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8648"
+   }
+  ]
+ },
+ "5430": {
+  "id": "5430",
+  "title": "Swiss Ball Pike",
+  "videoUrl": "https://youtu.be/DG9e_xAKCSM",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8649"
+   }
+  ]
+ },
+ "5431": {
+  "id": "5431",
+  "title": "Swiss Ball Russian Twist",
+  "videoUrl": "https://youtu.be/qEsavXhnPUo",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8650"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "9010"
+   }
+  ]
+ },
+ "5432": {
+  "id": "5432",
+  "title": "Swiss Ball Squat",
+  "videoUrl": "https://youtu.be/1woAEKRJQ_Y",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8651"
+   }
+  ]
+ },
+ "5433": {
+  "id": "5433",
+  "title": "Swiss Ball Superman",
+  "videoUrl": "https://youtu.be/bZaqams_GIo",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8652"
+   }
+  ]
+ },
+ "5434": {
+  "id": "5434",
+  "title": "T Spine Foam Roll",
+  "videoUrl": "https://youtu.be/inYkxnD_tUA",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8653"
+   }
+  ]
+ },
+ "5435": {
+  "id": "5435",
+  "title": "Torso Twist",
+  "videoUrl": "https://youtu.be/JNLRrIJqMQg",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8654"
+   }
+  ]
+ },
+ "5436": {
+  "id": "5436",
+  "title": "Tree Pose",
+  "videoUrl": "https://youtu.be/iOtpDIAHdSc",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8655"
+   }
+  ]
+ },
+ "5437": {
+  "id": "5437",
+  "title": "Triangle Pose",
+  "videoUrl": "https://youtu.be/fLwT_vK2s1w",
+  "primaryMuscleGroups": [
+   "Hamstrings"
+  ],
+  "secondaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8656"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "9011"
+   }
+  ]
+ },
+ "5438": {
+  "id": "5438",
+  "title": "Tricep Kick Back",
+  "videoUrl": "https://youtu.be/ketkGfCv-8U",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8657"
+   },
+   {
+    "parameter": "WeightLb",
+    "category": "Weight",
+    "unit": "Pounds",
+    "id": "9012"
+   }
+  ]
+ },
+ "5439": {
+  "id": "5439",
+  "title": "Triceps Stretch",
+  "videoUrl": "https://youtu.be/jy4Olzhzi0A",
+  "primaryMuscleGroups": [
+   "Triceps"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8658"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "9013"
+   }
+  ]
+ },
+ "5440": {
+  "id": "5440",
+  "title": "Tuck Hold",
+  "videoUrl": "https://youtu.be/WjZy_Bz5RYQ",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8659"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "9014"
+   }
+  ]
+ },
+ "5441": {
+  "id": "5441",
+  "title": "Tuck L Sit",
+  "videoUrl": "https://youtu.be/Ny180iXcR9g",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [
+   "Quads"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8660"
+   },
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "9015"
+   }
+  ]
+ },
+ "5442": {
+  "id": "5442",
+  "title": "Twisting Crunch",
+  "videoUrl": "https://youtu.be/jUzWDU5O5us",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "RepsPerSide",
+    "category": "Reps/side",
+    "unit": "Reps",
+    "id": "8661"
+   }
+  ]
+ },
+ "5443": {
+  "id": "5443",
+  "title": "Typewriter Pull Up",
+  "videoUrl": "https://youtu.be/oXGv8ihH3mQ",
+  "primaryMuscleGroups": [
+   "UpperBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Biceps"
+  ],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8662"
+   }
+  ]
+ },
+ "5444": {
+  "id": "5444",
+  "title": "V Sit",
+  "videoUrl": "https://youtu.be/wx3lYPaedWg",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8663"
+   }
+  ]
+ },
+ "5445": {
+  "id": "5445",
+  "title": "Vertical Leg Crunch",
+  "videoUrl": "https://youtu.be/EhcUvsCemro",
+  "primaryMuscleGroups": [
+   "Abs"
+  ],
+  "secondaryMuscleGroups": [],
+  "parameters": [
+   {
+    "parameter": "Reps",
+    "category": "Reps",
+    "unit": "Reps",
+    "id": "8664"
+   }
+  ]
+ },
+ "5446": {
+  "id": "5446",
+  "title": "Warrior 1",
+  "videoUrl": "https://youtu.be/gRMsotT00IA",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8665"
+   }
+  ]
+ },
+ "5447": {
+  "id": "5447",
+  "title": "Warrior 2",
+  "videoUrl": "https://youtu.be/0R7oxXrfMLw",
+  "primaryMuscleGroups": [
+   "Quads"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8666"
+   }
+  ]
+ },
+ "5448": {
+  "id": "5448",
+  "title": "Wheel Pose",
+  "videoUrl": "https://youtu.be/eedu5ive7Jk",
+  "primaryMuscleGroups": [
+   "LowerBack"
+  ],
+  "secondaryMuscleGroups": [
+   "Glute"
+  ],
+  "parameters": [
+   {
+    "parameter": "Duration",
+    "category": "Duration",
+    "unit": "Seconds",
+    "id": "8667"
+   }
+  ]
+ }
+}

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -27,12 +27,14 @@ from tp_mcp.tools import (
     tp_create_library,
     tp_create_library_item,
     tp_create_note,
+    tp_create_strength_workout,
     tp_create_workout,
     tp_delete_availability,
     tp_delete_equipment,
     tp_delete_event,
     tp_delete_library,
     tp_delete_note,
+    tp_delete_strength_workout,
     tp_delete_workout,
     tp_delete_workout_file,
     tp_download_workout_file,
@@ -54,6 +56,7 @@ from tp_mcp.tools import (
     tp_get_peaks,
     tp_get_pool_length_settings,
     tp_get_profile,
+    tp_get_strength_summary,
     tp_get_weekly_summary,
     tp_get_workout,
     tp_get_workout_comments,
@@ -68,6 +71,7 @@ from tp_mcp.tools import (
     tp_refresh_auth,
     tp_reorder_workouts,
     tp_schedule_library_workout,
+    tp_search_exercises,
     tp_set_workout_note,
     tp_unpair_workout,
     tp_update_equipment,
@@ -994,6 +998,76 @@ TOOLS = [
             "properties": {},
         },
     ),
+    # --- Structured strength / gym workouts ---
+    Tool(
+        name="tp_search_exercises",
+        description=(
+            "Search the built-in strength exercise library by name (offline). "
+            "Returns library exercise IDs to use in tp_create_strength_workout, "
+            "plus each exercise's native parameters and a demo video URL."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Exercise name substring (case-insensitive)."},
+                "limit": {"type": "integer", "description": "Max results, 1-100 (default 20)."},
+                "muscle_group": {
+                    "type": "string",
+                    "description": "Optional muscle-group filter, e.g. 'glute', 'hamstring', 'chest'.",
+                },
+            },
+            "required": ["query"],
+        },
+    ),
+    Tool(
+        name="tp_create_strength_workout",
+        description=(
+            "Create a structured strength/gym workout on the athlete's calendar. "
+            "Blocks of exercises (from tp_search_exercises) with sets and "
+            "parameters (Reps, WeightKg, Duration, …)."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "date": {"type": "string", "description": "Planned date YYYY-MM-DD."},
+                "title": {"type": "string", "description": "Workout title, e.g. 'Upper Body'."},
+                "instructions": {"type": "string", "description": "Optional session instructions."},
+                "blocks": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "Ordered blocks. Each block: {type: WarmUp|SingleExercise|"
+                        "Superset|Circuit|CoolDown, title?, notes?, exercises: "
+                        "[{id: '<library id>', notes?, sets: [{<param>: <value>}, ...]}]}. "
+                        "Parameters: Reps, RepsPerSide, WeightKg, WeightLb, "
+                        "WeightPerSideKg, WeightPerSideLb, WeightPercentage, Duration "
+                        "(seconds), DistanceMeters/Km/Ft/Yd/Miles, HeightCm/M/In/Ft, "
+                        "RPE, Watts, VelocityMetersPerSec, Cals. Superset/Circuit blocks "
+                        "require the same number of sets for every exercise."
+                    ),
+                },
+            },
+            "required": ["date", "title", "blocks"],
+        },
+    ),
+    Tool(
+        name="tp_get_strength_summary",
+        description="Get a strength workout's compliance summary (blocks/prescriptions/sets completed).",
+        inputSchema={
+            "type": "object",
+            "properties": {"workout_id": {"type": "string", "description": "Strength workout ID."}},
+            "required": ["workout_id"],
+        },
+    ),
+    Tool(
+        name="tp_delete_strength_workout",
+        description="Delete a strength workout by ID.",
+        inputSchema={
+            "type": "object",
+            "properties": {"workout_id": {"type": "string", "description": "Strength workout ID."}},
+            "required": ["workout_id"],
+        },
+    ),
 ]
 
 # ---------------------------------------------------------------------------
@@ -1002,6 +1076,8 @@ TOOLS = [
 _ATHLETE_EXEMPT_TOOLS = {
     "tp_auth_status", "tp_refresh_auth", "tp_validate_structure",
     "tp_list_athletes", "tp_get_workout_types",
+    # Offline exercise-library search — not athlete-scoped.
+    "tp_search_exercises",
 }
 
 _ATHLETE_PARAM = {
@@ -1161,6 +1237,27 @@ async def _h_get_peaks(args):
 
 @_handler("tp_analyze_workout")
 async def _h_analyze(args): return await tp_analyze_workout(workout_id=args["workout_id"])
+
+# --- Structured strength / gym ---
+@_handler("tp_search_exercises")
+async def _h_search_exercises(args):
+    return await tp_search_exercises(
+        query=args.get("query", ""), limit=args.get("limit", 20),
+        muscle_group=args.get("muscle_group"))
+
+@_handler("tp_create_strength_workout")
+async def _h_create_strength(args):
+    return await tp_create_strength_workout(
+        date=args["date"], title=args["title"],
+        blocks=args.get("blocks") or [], instructions=args.get("instructions"))
+
+@_handler("tp_get_strength_summary")
+async def _h_get_strength_summary(args):
+    return await tp_get_strength_summary(workout_id=args["workout_id"])
+
+@_handler("tp_delete_strength_workout")
+async def _h_delete_strength(args):
+    return await tp_delete_strength_workout(workout_id=args["workout_id"])
 
 # --- Fitness & Summary ---
 @_handler("tp_get_fitness")

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -50,6 +50,12 @@ from tp_mcp.tools.settings import (
     tp_update_nutrition,
     tp_update_speed_zones,
 )
+from tp_mcp.tools.strength import (
+    tp_create_strength_workout,
+    tp_delete_strength_workout,
+    tp_get_strength_summary,
+    tp_search_exercises,
+)
 from tp_mcp.tools.structure import tp_validate_structure
 from tp_mcp.tools.weekly_summary import tp_get_weekly_summary
 from tp_mcp.tools.workout_files import (
@@ -140,4 +146,8 @@ __all__ = [
     "tp_update_workout",
     "tp_upload_workout_file",
     "tp_validate_structure",
+    "tp_search_exercises",
+    "tp_create_strength_workout",
+    "tp_get_strength_summary",
+    "tp_delete_strength_workout",
 ]

--- a/src/tp_mcp/tools/strength.py
+++ b/src/tp_mcp/tools/strength.py
@@ -1,0 +1,447 @@
+"""Structured strength / gym workouts via the Peaksware strength API.
+
+Endurance workouts (`tp_create_workout`) use the main TrainingPeaks fitness API
+with power/HR/pace interval structures. Strength workouts are a completely
+different model — `workoutType: "StructuredStrength"` posted to the Peaksware
+strength API (`api.peakswaresb.com`, same Bearer token we already use for
+`tp_analyze_workout`). Exercises come from a fixed library (numeric string IDs);
+the catalogue is baked into `tp_mcp/data/exercises.json` (no search endpoint
+exists server-side), so `tp_search_exercises` runs fully offline.
+
+Verified against the live API:
+  • create  → POST   /rx/activity/v1/workouts/save        (returns numeric id)
+  • summary → GET    /rx/activity/v1/workouts/{id}/summary
+  • delete  → DELETE /rx/activity/v1/workouts/{id}
+  • a prescription must declare its own `parameters` (the prescribed columns),
+    distinct from the exercise's library parameters and each set's values;
+  • parameter metadata may be minimal (`{parameter, inputFormat}`);
+  • Superset/Circuit blocks require an equal number of sets across exercises.
+
+This tool is intentionally unit-agnostic: it passes through whatever weight
+parameter the caller supplies (`WeightKg`, `WeightLb`, `WeightPercentage`, …).
+Choosing a default unit (e.g. kg) is the caller's concern, not the connector's.
+"""
+
+import json
+import logging
+import uuid
+from functools import lru_cache
+from typing import Any
+
+import httpx
+
+from tp_mcp.client import TPClient
+
+logger = logging.getLogger("tp-mcp")
+
+STRENGTH_API_BASE = "https://api.peakswaresb.com"
+STRENGTH_TIMEOUT = 30.0
+
+# The full parameter catalogue (per exercise sets). Integer-format ones are
+# whole counts; everything else is decimal. Anything outside this set is
+# rejected so a typo can't silently produce an empty column.
+_INTEGER_PARAMS = {"Reps", "RepsPerSide", "Cals"}
+_KNOWN_PARAMS = _INTEGER_PARAMS | {
+    "WeightKg", "WeightLb", "WeightPerSideKg", "WeightPerSideLb", "WeightPercentage",
+    "Duration", "DistanceMeters", "DistanceKm", "DistanceFt", "DistanceYd",
+    "DistanceMiles", "HeightCm", "HeightM", "HeightIn", "HeightFt",
+    "RPE", "Watts", "VelocityMetersPerSec",
+}
+_BLOCK_TYPES = {"WarmUp", "SingleExercise", "Superset", "Circuit", "CoolDown"}
+# Blocks where every exercise must share the same number of sets (verified
+# server constraint — otherwise save returns 400).
+_EQUAL_SET_BLOCKS = {"Superset", "Circuit"}
+
+
+def _input_format(parameter: str) -> str:
+    return "Integer" if parameter in _INTEGER_PARAMS else "Decimal"
+
+
+def _err(code: str, message: str) -> dict[str, Any]:
+    return {"isError": True, "error_code": code, "message": message}
+
+
+# ── Exercise catalogue (baked, offline) ─────────────────────────────────────
+
+
+@lru_cache(maxsize=1)
+def _catalogue() -> dict[str, dict[str, Any]]:
+    """The built-in exercise library, keyed by string id."""
+    try:
+        from importlib.resources import files
+
+        text = files("tp_mcp").joinpath("data/exercises.json").read_text(encoding="utf-8")
+    except Exception:  # dev / editable install fallback
+        from pathlib import Path
+
+        path = Path(__file__).resolve().parent.parent / "data" / "exercises.json"
+        text = path.read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+async def tp_search_exercises(
+    query: str,
+    limit: int = 20,
+    muscle_group: str | None = None,
+) -> dict[str, Any]:
+    """Search the built-in exercise library by name (offline, no API call).
+
+    Args:
+        query: Substring to match against exercise titles (case-insensitive).
+            Empty query with a muscle_group returns exercises for that muscle.
+        limit: Max results (1-100).
+        muscle_group: Optional filter on primary/secondary muscle group
+            (case-insensitive substring, e.g. "glute", "ham").
+
+    Returns:
+        Dict with `count` and `exercises` (id, title, video_url, muscle_groups,
+        and the parameter names the exercise natively prescribes).
+    """
+    q = (query or "").strip().lower()
+    mg = (muscle_group or "").strip().lower()
+    limit = max(1, min(int(limit or 20), 100))
+    if not q and not mg:
+        return _err("VALIDATION_ERROR", "Provide a search query or a muscle_group.")
+
+    out: list[dict[str, Any]] = []
+    for ex in _catalogue().values():
+        if q and q not in ex["title"].lower():
+            continue
+        if mg:
+            groups = " ".join(
+                ex.get("primaryMuscleGroups", []) + ex.get("secondaryMuscleGroups", [])
+            ).lower()
+            if mg not in groups:
+                continue
+        out.append(
+            {
+                "id": ex["id"],
+                "title": ex["title"],
+                "video_url": ex.get("videoUrl"),
+                "muscle_groups": ex.get("primaryMuscleGroups", []),
+                "parameters": [p["parameter"] for p in ex.get("parameters", [])],
+            }
+        )
+        if len(out) >= limit:
+            break
+    # Exact / prefix matches first for a name query.
+    if q:
+        out.sort(key=lambda e: (e["title"].lower() != q, not e["title"].lower().startswith(q)))
+    return {"count": len(out), "exercises": out}
+
+
+# ── Payload construction ────────────────────────────────────────────────────
+
+
+def _validate_blocks(blocks: list[dict[str, Any]]) -> str | None:
+    """Return an error string if the blocks are invalid, else None."""
+    if not blocks:
+        return "At least one block with one exercise is required."
+    catalogue = _catalogue()
+    for bi, block in enumerate(blocks):
+        btype = block.get("type", "SingleExercise")
+        if btype not in _BLOCK_TYPES:
+            return f"block[{bi}].type {btype!r} is invalid. Allowed: {sorted(_BLOCK_TYPES)}."
+        exercises = block.get("exercises") or []
+        if not exercises:
+            return f"block[{bi}] ({btype}) has no exercises."
+        set_counts = []
+        for ei, ex in enumerate(exercises):
+            eid = str(ex.get("id", "")).strip()
+            if eid not in catalogue:
+                return f"block[{bi}].exercise[{ei}] id {eid!r} not in the exercise library."
+            sets = ex.get("sets") or []
+            if not sets:
+                return f"block[{bi}].exercise[{ei}] ({catalogue[eid]['title']}) has no sets."
+            set_counts.append(len(sets))
+            for si, s in enumerate(sets):
+                if not isinstance(s, dict) or not s:
+                    return f"block[{bi}].exercise[{ei}].set[{si}] must be a non-empty map of parameter→value."
+                bad = [p for p in s if p not in _KNOWN_PARAMS]
+                if bad:
+                    return (
+                        f"block[{bi}].exercise[{ei}].set[{si}] has unknown parameter(s) {bad}. "
+                        f"Allowed: {sorted(_KNOWN_PARAMS)}."
+                    )
+        if btype in _EQUAL_SET_BLOCKS and len(set(set_counts)) > 1:
+            return (
+                f"block[{bi}] ({btype}) requires the same number of sets for every "
+                f"exercise (got {set_counts})."
+            )
+    return None
+
+
+def _u() -> str:
+    return str(uuid.uuid4())
+
+
+def _build_prescription(ex: dict[str, Any], catalogue: dict[str, Any]) -> dict[str, Any]:
+    eid = str(ex["id"])
+    meta = catalogue[eid]
+    sets_in = ex.get("sets") or []
+    # Prescribed columns = union of parameters used across this exercise's sets,
+    # in first-seen order.
+    columns: list[str] = []
+    for s in sets_in:
+        for p in s:
+            if p not in columns:
+                columns.append(p)
+    sets_out = []
+    for s in sets_in:
+        values = [
+            {
+                "id": _u(),
+                "parameter": p,
+                "prescribedValue": str(v),
+                "executedValue": None,
+                "inputFormat": _input_format(p),
+            }
+            for p, v in s.items()
+        ]
+        sets_out.append({"id": _u(), "parameterValues": values})
+    return {
+        "id": _u(),
+        # Send only id + title; the server enriches the exercise's parameter
+        # metadata from its own library. (Our baked catalogue flattens `unit`
+        # to a string for search, which the save API rejects.)
+        "exercise": {"id": eid, "title": meta["title"], "parameters": []},
+        "parameters": [{"parameter": p, "inputFormat": _input_format(p)} for p in columns],
+        "sets": sets_out,
+        "coachNotes": ex.get("notes"),
+        "setSummaryTemplate": None,
+    }
+
+
+def _build_payload(
+    athlete_id: int,
+    date: str,
+    title: str,
+    blocks: list[dict[str, Any]],
+    instructions: str | None,
+) -> dict[str, Any]:
+    catalogue = _catalogue()
+    blocks_out = []
+    total_sets = 0
+    for block in blocks:
+        prescs = [_build_prescription(ex, catalogue) for ex in block["exercises"]]
+        total_sets += sum(len(p["sets"]) for p in prescs)
+        blocks_out.append(
+            {
+                "id": _u(),
+                "blockType": block.get("type", "SingleExercise"),
+                "title": block.get("title"),
+                "coachNotes": block.get("notes"),
+                "prescriptions": prescs,
+            }
+        )
+    return {
+        "id": _u(),
+        "workoutType": "StructuredStrength",
+        "calendarId": athlete_id,
+        "title": title,
+        "prescribedDate": date,
+        "instructions": instructions,
+        "blocks": blocks_out,
+        "snapshot": {
+            "totalBlocks": len(blocks_out),
+            "completedBlocks": 0,
+            "totalSets": total_sets,
+            "completedSets": 0,
+        },
+    }
+
+
+# ── Auth boilerplate (mirrors analyze.py — strength API is a different host) ──
+
+
+async def _access(client: TPClient) -> tuple[int | None, str | None, dict[str, Any] | None]:
+    athlete_id = await client.ensure_athlete_id()
+    if not athlete_id:
+        return None, None, _err("AUTH_INVALID", "Could not get athlete ID. Re-authenticate.")
+    token = await client._ensure_access_token()
+    if not token.success:
+        return None, None, _err("AUTH_INVALID", token.message or "Failed to obtain access token.")
+    access = client._token_cache.access_token
+    if not access:
+        return None, None, _err("AUTH_INVALID", "No access token available. Re-authenticate.")
+    return athlete_id, access, None
+
+
+def _headers(access: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {access}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Origin": "https://app.trainingpeaks.com",
+        "Referer": "https://app.trainingpeaks.com/",
+    }
+
+
+def _map_status(status: int, body: str) -> dict[str, Any]:
+    if status == 401:
+        return _err("AUTH_EXPIRED", "Session expired. Run 'tp-mcp auth' to re-authenticate.")
+    if status == 403:
+        return _err("AUTH_INVALID", "Access denied. Check permissions or re-authenticate.")
+    if status == 404:
+        return _err("NOT_FOUND", "Strength workout not found.")
+    if status == 429:
+        return _err("RATE_LIMITED", "Rate limited. Please wait before retrying.")
+    return _err("API_ERROR", f"Strength API error: {status} {body[:200]}")
+
+
+# ── Tools ───────────────────────────────────────────────────────────────────
+
+
+async def tp_create_strength_workout(
+    date: str,
+    title: str,
+    blocks: list[dict[str, Any]],
+    instructions: str | None = None,
+) -> dict[str, Any]:
+    """Create a structured strength (gym) workout on the athlete's calendar.
+
+    Args:
+        date: Planned date, YYYY-MM-DD.
+        title: Workout title (e.g. "Upper Body").
+        blocks: Ordered list of blocks. Each block is
+            {"type": "WarmUp"|"SingleExercise"|"Superset"|"Circuit"|"CoolDown",
+             "title": optional, "notes": optional,
+             "exercises": [{"id": "<library id from tp_search_exercises>",
+                            "notes": optional,
+                            "sets": [{"Reps": "10", "WeightKg": "60"}, ...]}]}.
+            Set values are a map of parameter name → value (strings or numbers).
+            Weight unit is the caller's choice (WeightKg / WeightLb / …).
+            For Superset / Circuit blocks every exercise must have the same
+            number of sets.
+        instructions: Optional free-text instructions for the whole session.
+
+    Returns:
+        Dict with the created `workout_id`, date, title, and block/set counts.
+    """
+    if not str(date).strip():
+        return _err("VALIDATION_ERROR", "date is required (YYYY-MM-DD).")
+    if not str(title).strip():
+        return _err("VALIDATION_ERROR", "title is required.")
+    if not isinstance(blocks, list):
+        return _err("VALIDATION_ERROR", "blocks must be a list.")
+    invalid = _validate_blocks(blocks)
+    if invalid:
+        return _err("VALIDATION_ERROR", invalid)
+
+    async with TPClient() as client:
+        athlete_id, access, err = await _access(client)
+        if err:
+            return err
+        payload = _build_payload(athlete_id, date.strip(), title.strip(), blocks, instructions)
+        try:
+            async with httpx.AsyncClient(timeout=STRENGTH_TIMEOUT) as h:
+                r = await h.post(
+                    f"{STRENGTH_API_BASE}/rx/activity/v1/workouts/save",
+                    headers=_headers(access),
+                    json=payload,
+                )
+        except httpx.TimeoutException:
+            return _err("NETWORK_ERROR", "Strength create timed out.")
+        except httpx.RequestError:
+            logger.exception("Network error creating strength workout")
+            return _err("NETWORK_ERROR", "A network error occurred.")
+
+        if r.status_code != 200:
+            body = r.text
+            # Surface the server's field-level validation verbatim — it is precise.
+            try:
+                errs = r.json().get("errors")
+                if errs:
+                    return _err("API_ERROR", f"Strength API rejected the workout: {errs}")
+            except Exception:
+                pass
+            return _map_status(r.status_code, body)
+
+        data = r.json().get("data", {})
+        snap = data.get("snapshot") or payload["snapshot"]
+        return {
+            "workout_id": str(data.get("id")),
+            "date": date.strip(),
+            "title": title.strip(),
+            "total_blocks": snap.get("totalBlocks"),
+            "total_sets": snap.get("totalSets"),
+        }
+
+
+async def tp_get_strength_summary(workout_id: str) -> dict[str, Any]:
+    """Get a strength workout's compliance summary (blocks / sets completed).
+
+    Args:
+        workout_id: The strength workout ID (from tp_create_strength_workout).
+
+    Returns:
+        Dict with compliance state/percent and block/prescription/set totals.
+    """
+    wid = str(workout_id).strip()
+    if not wid:
+        return _err("VALIDATION_ERROR", "workout_id is required.")
+    async with TPClient() as client:
+        _, access, err = await _access(client)
+        if err:
+            return err
+        try:
+            async with httpx.AsyncClient(timeout=STRENGTH_TIMEOUT) as h:
+                r = await h.get(
+                    f"{STRENGTH_API_BASE}/rx/activity/v1/workouts/{wid}/summary",
+                    headers=_headers(access),
+                )
+        except httpx.TimeoutException:
+            return _err("NETWORK_ERROR", "Strength summary timed out.")
+        except httpx.RequestError:
+            logger.exception("Network error reading strength summary")
+            return _err("NETWORK_ERROR", "A network error occurred.")
+
+        if r.status_code != 200:
+            return _map_status(r.status_code, r.text)
+        d = r.json().get("data", {})
+        return {
+            "workout_id": wid,
+            "compliance_state": d.get("complianceState"),
+            "compliance_percent": d.get("compliancePercent"),
+            "total_blocks": d.get("totalBlocks"),
+            "completed_blocks": d.get("completedBlocks"),
+            "total_prescriptions": d.get("totalPrescriptions"),
+            "completed_prescriptions": d.get("completedPrescriptions"),
+            "total_sets": d.get("totalSets"),
+            "completed_sets": d.get("completedSets"),
+            "rpe": d.get("rpe"),
+            "feel": d.get("feel"),
+        }
+
+
+async def tp_delete_strength_workout(workout_id: str) -> dict[str, Any]:
+    """Delete a strength workout.
+
+    Args:
+        workout_id: The strength workout ID to delete.
+
+    Returns:
+        Dict confirming deletion.
+    """
+    wid = str(workout_id).strip()
+    if not wid:
+        return _err("VALIDATION_ERROR", "workout_id is required.")
+    async with TPClient() as client:
+        _, access, err = await _access(client)
+        if err:
+            return err
+        try:
+            async with httpx.AsyncClient(timeout=STRENGTH_TIMEOUT) as h:
+                r = await h.delete(
+                    f"{STRENGTH_API_BASE}/rx/activity/v1/workouts/{wid}",
+                    headers=_headers(access),
+                )
+        except httpx.TimeoutException:
+            return _err("NETWORK_ERROR", "Strength delete timed out.")
+        except httpx.RequestError:
+            logger.exception("Network error deleting strength workout")
+            return _err("NETWORK_ERROR", "A network error occurred.")
+
+        if r.status_code not in (200, 204):
+            return _map_status(r.status_code, r.text)
+        return {"deleted": True, "workout_id": wid}

--- a/src/tp_mcp/tools/strength.py
+++ b/src/tp_mcp/tools/strength.py
@@ -62,11 +62,24 @@ def _err(code: str, message: str) -> dict[str, Any]:
 
 
 # ── Exercise catalogue (baked, offline) ─────────────────────────────────────
+#
+# PROVENANCE of `tp_mcp/data/exercises.json` (944 exercises):
+#   The Peaksware strength API exposes NO list/search endpoint for the exercise
+#   library, but each exercise IS readable individually by its numeric id (same
+#   `api.peakswaresb.com` host + Bearer token as the workout endpoints). This
+#   file is a one-time static snapshot built by fetching the exercises by id and
+#   projecting each to the fields the tools use (id, title, videoUrl,
+#   primary/secondary MuscleGroups, parameters). TP's library changes rarely;
+#   the snapshot is refreshable by re-fetching by id if it ever drifts. It is
+#   data, not code — reviewers can skip its contents.
 
 
 @lru_cache(maxsize=1)
 def _catalogue() -> dict[str, dict[str, Any]]:
-    """The built-in exercise library, keyed by string id."""
+    """The built-in exercise library, keyed by string id.
+
+    Static snapshot baked from the per-id Peaksware endpoint — see the
+    PROVENANCE note above for how it was generated / how to refresh it."""
     try:
         from importlib.resources import files
 
@@ -122,11 +135,11 @@ async def tp_search_exercises(
                 "parameters": [p["parameter"] for p in ex.get("parameters", [])],
             }
         )
-        if len(out) >= limit:
-            break
-    # Exact / prefix matches first for a name query.
+    # Rank exact / prefix matches first for a name query — BEFORE truncating, so
+    # an exact match that sits past `limit` in catalogue order isn't dropped.
     if q:
         out.sort(key=lambda e: (e["title"].lower() != q, not e["title"].lower().startswith(q)))
+    out = out[:limit]
     return {"count": len(out), "exercises": out}
 
 

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -103,6 +103,10 @@ class TestListTools:
             "tp_unpair_workout",
             "tp_set_workout_note",
             "tp_get_workout_note",
+            "tp_search_exercises",
+            "tp_create_strength_workout",
+            "tp_get_strength_summary",
+            "tp_delete_strength_workout",
         }
         assert v2_tools.issubset(names)
         assert len(names) == len(core_tools) + len(v2_tools)

--- a/tests/test_tools/test_strength.py
+++ b/tests/test_tools/test_strength.py
@@ -1,0 +1,234 @@
+"""Tests for structured strength workout tools."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tp_mcp.client.http import APIResponse
+from tp_mcp.tools.strength import (
+    _build_payload,
+    _input_format,
+    _validate_blocks,
+    tp_create_strength_workout,
+    tp_delete_strength_workout,
+    tp_get_strength_summary,
+    tp_search_exercises,
+)
+
+TEST_ATHLETE_ID = 123456
+TEST_ACCESS_TOKEN = "test_access_token"
+
+
+def _mock_tp_client(athlete_id=TEST_ATHLETE_ID):
+    mock_client = AsyncMock()
+    mock_client.ensure_athlete_id = AsyncMock(return_value=athlete_id)
+    mock_client._ensure_access_token = AsyncMock(return_value=APIResponse(success=True))
+    cache = MagicMock()
+    cache.access_token = TEST_ACCESS_TOKEN
+    mock_client._token_cache = cache
+    return mock_client
+
+
+def _mock_http(status_code, json_data):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.text = str(json_data)
+    http = AsyncMock()
+    http.post.return_value = resp
+    http.get.return_value = resp
+    http.delete.return_value = resp
+    return http
+
+
+# ── Offline exercise search ──────────────────────────────────────────────────
+
+
+class TestSearchExercises:
+    @pytest.mark.asyncio
+    async def test_name_match_exact_first(self):
+        r = await tp_search_exercises("air squat")
+        assert r["count"] >= 1
+        assert r["exercises"][0]["title"] == "Air Squat"
+        assert r["exercises"][0]["id"] == "1"
+        assert r["exercises"][0]["video_url"]
+
+    @pytest.mark.asyncio
+    async def test_substring(self):
+        r = await tp_search_exercises("squat", limit=5)
+        assert r["count"] == 5
+        assert all("squat" in e["title"].lower() for e in r["exercises"])
+
+    @pytest.mark.asyncio
+    async def test_muscle_group_filter(self):
+        r = await tp_search_exercises("", muscle_group="glute", limit=3)
+        assert r["count"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_empty_query_errors(self):
+        r = await tp_search_exercises("")
+        assert r.get("error_code") == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_limit_capped(self):
+        r = await tp_search_exercises("a", limit=1000)
+        assert r["count"] <= 100
+
+
+# ── Validation (returns before any network call) ─────────────────────────────
+
+
+class TestValidation:
+    def test_empty_blocks(self):
+        assert _validate_blocks([]) is not None
+
+    def test_bad_block_type(self):
+        err = _validate_blocks([{"type": "Nope", "exercises": [{"id": "1", "sets": [{"Reps": "8"}]}]}])
+        assert err and "type" in err
+
+    def test_unknown_exercise(self):
+        err = _validate_blocks([{"type": "SingleExercise", "exercises": [{"id": "999999", "sets": [{"Reps": "8"}]}]}])
+        assert err and "not in the exercise library" in err
+
+    def test_unknown_parameter(self):
+        err = _validate_blocks([{"type": "SingleExercise", "exercises": [{"id": "1", "sets": [{"Repz": "8"}]}]}])
+        assert err and "unknown parameter" in err
+
+    def test_no_sets(self):
+        err = _validate_blocks([{"type": "SingleExercise", "exercises": [{"id": "1", "sets": []}]}])
+        assert err and "no sets" in err
+
+    def test_superset_unequal_sets(self):
+        err = _validate_blocks([{
+            "type": "Superset",
+            "exercises": [
+                {"id": "1", "sets": [{"Reps": "8"}, {"Reps": "8"}]},
+                {"id": "6", "sets": [{"Reps": "8"}]},
+            ],
+        }])
+        assert err and "same number of sets" in err
+
+    def test_superset_equal_sets_ok(self):
+        err = _validate_blocks([{
+            "type": "Superset",
+            "exercises": [
+                {"id": "1", "sets": [{"Reps": "8"}, {"Reps": "8"}]},
+                {"id": "6", "sets": [{"Reps": "12"}, {"Reps": "12"}]},
+            ],
+        }])
+        assert err is None
+
+
+# ── Payload construction ─────────────────────────────────────────────────────
+
+
+class TestBuildPayload:
+    def test_input_format(self):
+        assert _input_format("Reps") == "Integer"
+        assert _input_format("RepsPerSide") == "Integer"
+        assert _input_format("WeightKg") == "Decimal"
+        assert _input_format("Duration") == "Decimal"
+
+    def test_structure_and_counts(self):
+        blocks = [
+            {"type": "WarmUp", "exercises": [{"id": "1", "sets": [{"Reps": "10"}]}]},
+            {"type": "Superset", "exercises": [
+                {"id": "50", "sets": [{"Reps": "8", "WeightKg": "24"}, {"Reps": "6", "WeightKg": "28"}]},
+                {"id": "6", "sets": [{"Reps": "12"}, {"Reps": "12"}]},
+            ]},
+        ]
+        p = _build_payload(999, "2027-01-06", "Day", blocks, "instr")
+        assert p["workoutType"] == "StructuredStrength"
+        assert p["calendarId"] == 999
+        assert p["prescribedDate"] == "2027-01-06"
+        assert p["snapshot"] == {"totalBlocks": 2, "completedBlocks": 0, "totalSets": 5, "completedSets": 0}
+        assert [b["blockType"] for b in p["blocks"]] == ["WarmUp", "Superset"]
+        # exercise.parameters is sent empty (server enriches from its library)
+        assert p["blocks"][0]["prescriptions"][0]["exercise"]["parameters"] == []
+
+    def test_prescription_columns_and_format(self):
+        blocks = [{"type": "SingleExercise", "exercises": [
+            {"id": "50", "sets": [{"Reps": "8", "WeightKg": "24"}]}]}]
+        presc = _build_payload(1, "2027-01-06", "x", blocks, None)["blocks"][0]["prescriptions"][0]
+        cols = {c["parameter"]: c["inputFormat"] for c in presc["parameters"]}
+        assert cols == {"Reps": "Integer", "WeightKg": "Decimal"}
+        pv = presc["sets"][0]["parameterValues"]
+        assert {v["parameter"]: v["prescribedValue"] for v in pv} == {"Reps": "8", "WeightKg": "24"}
+        assert all(v["executedValue"] is None for v in pv)
+
+
+# ── API-calling tools (mocked) ───────────────────────────────────────────────
+
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_success(self):
+        blocks = [{"type": "SingleExercise", "exercises": [{"id": "1", "sets": [{"Reps": "10"}]}]}]
+        http = _mock_http(200, {"data": {"id": "555", "snapshot": {"totalBlocks": 1, "totalSets": 1}}})
+        with patch("tp_mcp.tools.strength.TPClient") as mtp:
+            mtp.return_value.__aenter__.return_value = _mock_tp_client()
+            with patch("tp_mcp.tools.strength.httpx.AsyncClient") as mh:
+                mh.return_value.__aenter__.return_value = http
+                r = await tp_create_strength_workout(date="2027-01-06", title="Day", blocks=blocks)
+        assert r["workout_id"] == "555"
+        assert r["total_sets"] == 1
+
+    @pytest.mark.asyncio
+    async def test_validation_blocks_before_network(self):
+        # Unknown exercise → VALIDATION_ERROR, no client touched.
+        blocks = [{"type": "SingleExercise", "exercises": [{"id": "0", "sets": [{"Reps": "8"}]}]}]
+        r = await tp_create_strength_workout(date="2027-01-06", title="x", blocks=blocks)
+        assert r["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_api_error_surfaces_server_validation(self):
+        blocks = [{"type": "SingleExercise", "exercises": [{"id": "1", "sets": [{"Reps": "10"}]}]}]
+        http = _mock_http(400, {"errors": {"blocks[0]": ["bad"]}})
+        with patch("tp_mcp.tools.strength.TPClient") as mtp:
+            mtp.return_value.__aenter__.return_value = _mock_tp_client()
+            with patch("tp_mcp.tools.strength.httpx.AsyncClient") as mh:
+                mh.return_value.__aenter__.return_value = http
+                r = await tp_create_strength_workout(date="2027-01-06", title="Day", blocks=blocks)
+        assert r["error_code"] == "API_ERROR"
+        assert "bad" in r["message"]
+
+    @pytest.mark.asyncio
+    async def test_auth_failure(self):
+        blocks = [{"type": "SingleExercise", "exercises": [{"id": "1", "sets": [{"Reps": "10"}]}]}]
+        with patch("tp_mcp.tools.strength.TPClient") as mtp:
+            mtp.return_value.__aenter__.return_value = _mock_tp_client(athlete_id=None)
+            r = await tp_create_strength_workout(date="2027-01-06", title="Day", blocks=blocks)
+        assert r["error_code"] == "AUTH_INVALID"
+
+
+class TestSummaryAndDelete:
+    @pytest.mark.asyncio
+    async def test_summary(self):
+        http = _mock_http(200, {"data": {"complianceState": "NoCompletion", "totalSets": 6, "completedSets": 2}})
+        with patch("tp_mcp.tools.strength.TPClient") as mtp:
+            mtp.return_value.__aenter__.return_value = _mock_tp_client()
+            with patch("tp_mcp.tools.strength.httpx.AsyncClient") as mh:
+                mh.return_value.__aenter__.return_value = http
+                r = await tp_get_strength_summary(workout_id="555")
+        assert r["compliance_state"] == "NoCompletion"
+        assert r["total_sets"] == 6 and r["completed_sets"] == 2
+
+    @pytest.mark.asyncio
+    async def test_delete(self):
+        http = _mock_http(200, {"data": 555, "errors": {}})
+        with patch("tp_mcp.tools.strength.TPClient") as mtp:
+            mtp.return_value.__aenter__.return_value = _mock_tp_client()
+            with patch("tp_mcp.tools.strength.httpx.AsyncClient") as mh:
+                mh.return_value.__aenter__.return_value = http
+                r = await tp_delete_strength_workout(workout_id="555")
+        assert r["deleted"] is True
+
+    @pytest.mark.asyncio
+    async def test_summary_not_found(self):
+        http = _mock_http(404, {"message": "nope"})
+        with patch("tp_mcp.tools.strength.TPClient") as mtp:
+            mtp.return_value.__aenter__.return_value = _mock_tp_client()
+            with patch("tp_mcp.tools.strength.httpx.AsyncClient") as mh:
+                mh.return_value.__aenter__.return_value = http
+                r = await tp_get_strength_summary(workout_id="555")
+        assert r["error_code"] == "NOT_FOUND"

--- a/tests/test_tools/test_strength.py
+++ b/tests/test_tools/test_strength.py
@@ -74,6 +74,25 @@ class TestSearchExercises:
         r = await tp_search_exercises("a", limit=1000)
         assert r["count"] <= 100
 
+    @pytest.mark.asyncio
+    async def test_exact_match_past_limit_still_surfaces(self):
+        """Regression: ranking must happen BEFORE truncation. With the exact
+        match last in catalogue order and limit=1, it must still win — not be
+        cut by an earlier substring match."""
+        def _ex(eid, title):
+            return {"id": eid, "title": title, "videoUrl": None,
+                    "primaryMuscleGroups": [], "secondaryMuscleGroups": [],
+                    "parameters": []}
+        catalogue = {
+            "1": _ex("1", "Back Squat"),
+            "2": _ex("2", "Front Squat"),
+            "3": _ex("3", "Squat"),  # exact, but last
+        }
+        with patch("tp_mcp.tools.strength._catalogue", return_value=catalogue):
+            r = await tp_search_exercises("squat", limit=1)
+        assert r["count"] == 1
+        assert r["exercises"][0]["title"] == "Squat"
+
 
 # ── Validation (returns before any network call) ─────────────────────────────
 


### PR DESCRIPTION
Implements #17 — structured strength/gym workouts. Four tools, all live-verified against the Peaksware strength API (same bearer as analyze):

- **`tp_search_exercises`** — offline search over a baked catalogue of **944 exercises** (id + native parameters + demo video URL). No network/owner lookup needed.
- **`tp_create_strength_workout`** — blocks (WarmUp/SingleExercise/Superset/Circuit/CoolDown) with per-set prescriptions (reps/weight/duration/etc.) → `POST /rx/activity/v1/workouts/save`.
- **`tp_get_strength_summary`** — compliance (blocks/prescriptions/sets completed).
- **`tp_delete_strength_workout`**.

Wire-format notes from live reconnaissance (not obvious from the API): `prescription.parameters` is mandatory; Superset/Circuit require an equal set-count across exercises; `exercise.parameters` stays empty; `WeightKg` is accepted. The exercise catalogue is baked (`data/exercises.json`) because there's no list endpoint — only `GET /rx/activity/v1/exercises/{id}`.

Unit-agnostic by design (kg/lb both pass through). Tests: `tests/test_tools/test_strength.py` (22). Full suite green (413).

Closes #17.