### PR TITLE
fix(library): allow setting workout type on tp_update_library_item (#98)

### DIFF
--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -969,6 +969,14 @@ TOOLS = [
                 "tss": {"type": "number"},
                 "description": {"type": "string"},
                 "structure": {"type": "object"},
+                "workout_type_id": {
+                    "type": "integer",
+                    "description": (
+                        "Sport/workout type: 1=swim, 2=bike, 3=run, etc. "
+                        "Sets the sport on templates saved without one."
+                    ),
+                },
+                "workout_sub_type_id": {"type": "integer"},
             },
             "required": ["library_id", "item_id"],
         },
@@ -1364,6 +1372,8 @@ async def _h_update_lib_item(args):
         name=args.get("name"), duration_hours=args.get("duration_hours"),
         tss=args.get("tss"), description=args.get("description"),
         structure=args.get("structure"),
+        workout_type_id=args.get("workout_type_id"),
+        workout_sub_type_id=args.get("workout_sub_type_id"),
     )
 
 @_handler("tp_schedule_library_workout")

--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -355,6 +355,8 @@ async def tp_update_library_item(
     tss: float | None = None,
     description: str | None = None,
     structure: dict[str, Any] | None = None,
+    workout_type_id: int | None = None,
+    workout_sub_type_id: int | None = None,
 ) -> dict[str, Any]:
     """Edit a workout template.
 
@@ -366,6 +368,9 @@ async def tp_update_library_item(
         tss: Optional planned TSS.
         description: Optional description.
         structure: Optional structure (nested object).
+        workout_type_id: Optional sport/workout type (1=swim, 2=bike, 3=run, ...).
+            Use to set the sport on templates that were saved without one.
+        workout_sub_type_id: Optional workout subtype id (e.g. 6=Indoor Bike).
 
     Returns:
         Dict with confirmation or error.
@@ -428,6 +433,10 @@ async def tp_update_library_item(
             existing["description"] = description
         if structure is not None:
             existing["structure"] = structure
+        if workout_type_id is not None:
+            existing["workoutTypeId"] = workout_type_id
+        if workout_sub_type_id is not None:
+            existing["workoutSubTypeId"] = workout_sub_type_id
 
         put_endpoint = (
             f"/exerciselibrary/v1/libraries/{lib_validated.workout_id}"

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -12,6 +12,7 @@ from tp_mcp.tools.library import (
     tp_get_libraries,
     tp_get_library_items,
     tp_schedule_library_workout,
+    tp_update_library_item,
 )
 
 
@@ -124,6 +125,56 @@ class TestCreateLibraryItem:
         assert payload["workoutSubTypeId"] == 3
         assert "workoutTypeFamilyId" not in payload
         assert "workoutTypeValueId" not in payload
+
+
+class TestUpdateLibraryItem:
+    @pytest.mark.asyncio
+    async def test_sets_workout_type_on_sportless_template(self):
+        """A template saved with workoutTypeId=0 gets its sport set, and the
+        merged value reaches the PUT payload."""
+        existing = {"exerciseLibraryItemId": 20, "itemName": "Tempo", "workoutTypeId": 0}
+        get_resp = APIResponse(success=True, data=[existing])
+        put_resp = APIResponse(success=True, data=None)
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_resp)
+            mock_instance.put = AsyncMock(return_value=put_resp)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_library_item(
+                library_id="1", item_id="20",
+                workout_type_id=2, workout_sub_type_id=6,
+            )
+
+        assert result["success"] is True
+        payload = mock_instance.put.call_args[1]["json"]
+        assert payload["workoutTypeId"] == 2
+        assert payload["workoutSubTypeId"] == 6
+
+    @pytest.mark.asyncio
+    async def test_workout_type_untouched_when_not_passed(self):
+        """Omitting the sport params leaves the existing workoutTypeId alone and
+        adds no workoutSubTypeId key."""
+        existing = {"exerciseLibraryItemId": 21, "itemName": "Endurance", "workoutTypeId": 2}
+        get_resp = APIResponse(success=True, data=[existing])
+        put_resp = APIResponse(success=True, data=None)
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_resp)
+            mock_instance.put = AsyncMock(return_value=put_resp)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_library_item(
+                library_id="1", item_id="21", name="Endurance v2",
+            )
+
+        assert result["success"] is True
+        payload = mock_instance.put.call_args[1]["json"]
+        assert payload["workoutTypeId"] == 2          # unchanged
+        assert "workoutSubTypeId" not in payload
+        assert payload["itemName"] == "Endurance v2"  # the field we did change
 
 
 class TestScheduleLibraryWorkout:


### PR DESCRIPTION
Closes #98.

`tp_update_library_item` could edit name / duration / TSS / description / structure, but had **no way to set the sport** on a template. Templates saved with `workoutTypeId=0` (no sport) were therefore stuck — the update path silently ignored any sport field, and the connector has no per-item delete to recreate them.

### Change
- Add two optional params to `tp_update_library_item`: `workout_type_id` (1=swim, 2=bike, 3=run, …) and `workout_sub_type_id`. They are merged into the existing item before the PUT round-trip.
- Wire both through the `tp_update_library_item` tool schema in `server.py`.

Additive only — existing callers are unaffected (params default to `None`, nothing is touched unless supplied).

### Verification
- `ruff check src/` ✅ · `mypy src/` ✅ · `pytest tests/` ✅
- Verified live against TrainingPeaks: a template saved without a sport gets its `workoutTypeId` set and persists across a GET round-trip.
