### PR TITLE
fix(library): correct tp_create_library payload + library listing fields (#100)

### DIFF
--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -41,9 +41,14 @@ async def tp_get_libraries() -> dict[str, Any]:
         libraries = [
             {
                 "id": lib.get("exerciseLibraryId", lib.get("id")),
+                # v2 libraries endpoint returns "libraryName"/"isDefaultContent";
+                # keep the old keys as fallbacks for safety.
                 "name": lib.get("libraryName", lib.get("name", "")),
-                "is_default": lib.get("isDefaultContent", False),
+                "is_default": lib.get("isDefaultContent", lib.get("isDefault", False)),
                 "owner_name": lib.get("ownerName"),
+                # NOTE: the v2 libraries endpoint does not return an item count.
+                "item_count": lib.get("itemCount", 0),
+                "owner_id": lib.get("ownerId"),
             }
             for lib in data
         ]
@@ -188,8 +193,16 @@ async def tp_create_library(name: str) -> dict[str, Any]:
                 "message": "Could not get athlete ID. Re-authenticate.",
             }
 
+        # TP expects "libraryName" and the owner's personId, not "name".
+        owner_id = None
+        user_data = await client._get_user_data()
+        if user_data:
+            owner_id = user_data.get("personId")
+
         endpoint = "/exerciselibrary/v1/libraries"
-        payload = {"name": name.strip()}
+        payload: dict[str, Any] = {"libraryName": name.strip()}
+        if owner_id is not None:
+            payload["ownerId"] = owner_id
         response = await client.post(endpoint, json=payload)
 
         if response.is_error:

--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -46,7 +46,8 @@ async def tp_get_libraries() -> dict[str, Any]:
                 "name": lib.get("libraryName", lib.get("name", "")),
                 "is_default": lib.get("isDefaultContent", lib.get("isDefault", False)),
                 "owner_name": lib.get("ownerName"),
-                # NOTE: the v2 libraries endpoint does not return an item count.
+                # The v2 libraries endpoint usually omits an item count; read it
+                # if present, otherwise fall back to 0.
                 "item_count": lib.get("itemCount", 0),
                 "owner_id": lib.get("ownerId"),
             }

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -19,8 +19,10 @@ class TestGetLibraries:
     @pytest.mark.asyncio
     async def test_list_libraries(self):
         data = [
-            {"exerciseLibraryId": 1, "libraryName": "My Workouts", "isDefaultContent": False, "ownerName": "Athlete"},
-            {"exerciseLibraryId": 2, "libraryName": "Default", "isDefaultContent": True, "ownerName": "Joe Friel"},
+            {"exerciseLibraryId": 1, "libraryName": "My Workouts", "isDefaultContent": False,
+             "ownerName": "Athlete", "ownerId": 7, "itemCount": 5},
+            {"exerciseLibraryId": 2, "libraryName": "Default", "isDefaultContent": True,
+             "ownerName": "Joe Friel", "ownerId": 7},
         ]
         response = APIResponse(success=True, data=data)
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
@@ -34,6 +36,8 @@ class TestGetLibraries:
         assert result["count"] == 2
         assert result["libraries"][0]["name"] == "My Workouts"
         assert result["libraries"][0]["owner_name"] == "Athlete"
+        assert result["libraries"][0]["owner_id"] == 7
+        assert result["libraries"][0]["item_count"] == 5
         assert result["libraries"][1]["is_default"] is True
 
 
@@ -70,6 +74,7 @@ class TestCreateLibrary:
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
             mock_instance = AsyncMock()
             mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance._get_user_data = AsyncMock(return_value={"personId": 999})
             mock_instance.post = AsyncMock(return_value=response)
             mock_client.return_value.__aenter__.return_value = mock_instance
 
@@ -78,7 +83,8 @@ class TestCreateLibrary:
         assert result["success"] is True
         assert result["library_id"] == 3
         payload = mock_instance.post.call_args[1]["json"]
-        assert payload["name"] == "Race Prep"
+        assert payload["libraryName"] == "Race Prep"
+        assert payload["ownerId"] == 999
 
 
 class TestDeleteLibrary:


### PR DESCRIPTION
Closes #100.

Two TrainingPeaks library bugs, both from field-name drift between the v1 write endpoint and the v2 read endpoint:

1. **`tp_create_library` returned HTTP 400.** It POSTed `{"name": ...}`, but the v1 endpoint expects `"libraryName"` plus the owner's `personId`. Creating a library always failed.
2. **`tp_get_libraries` showed empty folder names.** It read `"name"` / `"isDefault"`, but the v2 libraries payload uses `"libraryName"` / `"isDefaultContent"`, so every folder came back nameless.

### Change
- `tp_create_library`: send `{"libraryName", "ownerId": personId}` (personId resolved from `_get_user_data()`).
- `tp_get_libraries`: read `libraryName` / `isDefaultContent` (old keys kept as fallbacks), expose `owner_id`. The v2 endpoint returns no item count, so `item_count` stays `0` (documented inline).

### Verification
- `ruff check src/` ✅ · `mypy src/` ✅ · `pytest tests/` ✅ (listing-field test updated)
- Verified live: creating a library now succeeds and the new folder lists with its real name.
