### PR TITLE
feat(zones): per-sport zone update + create + method discovery (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,25 @@ Ask your AI assistant things like:
 | Tool | Description |
 |------|-------------|
 | `tp_get_athlete_settings` | Get FTP, thresholds, zones, profile |
-| `tp_update_ftp` | Update FTP and recalculate the default power zones |
-| `tp_update_hr_zones` | Update heart rate zones |
-| `tp_update_speed_zones` | Update run/swim pace zones |
+| `tp_update_ftp` | Update FTP for a sport's power set (bike default; preserves the set's calculation method) |
+| `tp_update_hr_zones` | Update HR threshold/max/resting for a sport (general/bike/run/swim), preserving the method |
+| `tp_update_speed_zones` | Update run/swim threshold pace, preserving the method |
 | `tp_update_nutrition` | Update daily planned calories |
 | `tp_get_pool_length_settings` | Get pool length options |
+
+**Zone updates — how they work & one limitation.** The zone setters target the
+right per-sport zone set (by `workoutTypeId`) and recompute the bands with
+**TrainingPeaks' own zone calculator** (the same call the web UI's *Calculate*
+makes), so the athlete's calculation method (%LTHR, Karvonen, Andy Coggan, …) is
+honoured exactly. They update a **threshold** (FTP / LTHR / threshold pace).
+
+> **Limitation — test-based (Distance/Time) methods.** A zone set whose method
+> *derives* its threshold from a test result (Speed/Pace **Distance / Time**)
+> cannot have a threshold set directly — there is no stable value to set. These
+> tools detect that case and return `TEST_BASED_METHOD` (writing nothing) rather
+> than storing a wrong threshold; configure such a set via a test in the
+> TrainingPeaks UI. This is deliberate: the connector owns threshold-anchored
+> zones; test-protocol setup stays in the UI.
 
 ### Health Metrics
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ask your AI assistant things like:
 - "Set my FTP to 310 and update my power zones"
 - "Add a calendar note for next Monday: rest day, travel"
 
-## Tools (64)
+## Tools (66)
 
 ### Workouts
 | Tool | Description |
@@ -63,6 +63,8 @@ Ask your AI assistant things like:
 | `tp_update_ftp` | Update FTP for a sport's power set (bike default; preserves the set's calculation method) |
 | `tp_update_hr_zones` | Update HR threshold/max/resting for a sport (general/bike/run/swim), preserving the method |
 | `tp_update_speed_zones` | Update run/swim threshold pace, preserving the method |
+| `tp_create_zones` | Create a NEW per-sport zone set from scratch (choose the calculation method); errors if one already exists |
+| `tp_get_zone_methods` | List available zone-calculation methods per metric (power/HR/pace) with each method's zone count and labels |
 | `tp_update_nutrition` | Update daily planned calories |
 | `tp_get_pool_length_settings` | Get pool length options |
 

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -62,6 +62,7 @@ from tp_mcp.tools import (
     tp_get_workout_prs,
     tp_get_workout_types,
     tp_get_workouts,
+    tp_get_zone_methods,
     tp_list_athletes,
     tp_list_notes,
     tp_log_metrics,
@@ -929,6 +930,30 @@ TOOLS = [
         description="List all sport types and subtypes with IDs. Use to find subtype_id for create/update.",
         inputSchema={"type": "object", "properties": {}, "required": []},
     ),
+    # --- Zone Calculation Methods ---
+    Tool(
+        name="tp_get_zone_methods",
+        description=(
+            "List available zone-calculation methods per metric (power / heartrate "
+            "/ speed), each with its zone count and zone labels. TP has no method-"
+            "names endpoint and settings store only an opaque method int; this "
+            "probes the zone calculator (read-only) to fingerprint each method by "
+            "its zone labels. `derives_threshold` marks methods that derive the "
+            "threshold from a (field-)test, so a direct threshold can't be set. "
+            "Coach-scoped (uses your own user), not athlete-specific."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "metric": {
+                    "type": "string",
+                    "enum": ["power", "heartrate", "speed"],
+                    "description": "Limit to one metric. Omit to list all three.",
+                }
+            },
+            "required": [],
+        },
+    ),
     # --- Workout Library ---
     Tool(
         name="tp_get_libraries",
@@ -1044,6 +1069,8 @@ TOOLS = [
 _ATHLETE_EXEMPT_TOOLS = {
     "tp_auth_status", "tp_refresh_auth", "tp_validate_structure",
     "tp_list_athletes", "tp_get_workout_types",
+    # Coach-scoped — enumerates methods under the caller's own user, not an athlete.
+    "tp_get_zone_methods",
 }
 
 _ATHLETE_PARAM = {
@@ -1383,6 +1410,9 @@ async def _h_delete_avail(args): return await tp_delete_availability(availabilit
 # --- Workout Types ---
 @_handler("tp_get_workout_types")
 async def _h_workout_types(args): return await tp_get_workout_types()
+
+@_handler("tp_get_zone_methods")
+async def _h_zone_methods(args): return await tp_get_zone_methods(metric=args.get("metric"))
 
 # --- Workout Library ---
 @_handler("tp_get_libraries")

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -535,10 +535,19 @@ TOOLS = [
     ),
     Tool(
         name="tp_update_ftp",
-        description="Update FTP and recalculate the default power zones.",
+        description="Update FTP (power threshold) and rescale the matching power-zone "
+                    "set, preserving its calculation method.",
         inputSchema={
             "type": "object",
-            "properties": {"ftp": {"type": "integer", "description": "FTP in watts"}},
+            "properties": {
+                "ftp": {"type": "integer", "description": "FTP in watts"},
+                "workout_type": {
+                    "type": "string",
+                    "enum": ["bike", "run", "xcski", "mtnbike", "rowing", "default"],
+                    "default": "bike",
+                    "description": "Which power set (FTP is cycling -> 'bike' default; "
+                                   "falls back to default if absent)."},
+            },
             "required": ["ftp"],
         },
     ),
@@ -551,7 +560,10 @@ TOOLS = [
                 "threshold_hr": {"type": "integer"},
                 "max_hr": {"type": "integer"},
                 "resting_hr": {"type": "integer"},
-                "workout_type": {"type": "string", "enum": ["general", "bike"], "default": "general"},
+                "workout_type": {
+                    "type": "string",
+                    "enum": ["general", "bike", "run", "swim", "xcski", "mtnbike", "rowing"],
+                    "default": "general"},
             },
             "required": [],
         },
@@ -1181,7 +1193,8 @@ async def _h_get_atp(args): return await tp_get_atp(start_date=args["start_date"
 async def _h_get_settings(args): return await tp_get_athlete_settings()
 
 @_handler("tp_update_ftp")
-async def _h_update_ftp(args): return await tp_update_ftp(ftp=args["ftp"])
+async def _h_update_ftp(args):
+    return await tp_update_ftp(ftp=args["ftp"], workout_type=args.get("workout_type", "bike"))
 
 @_handler("tp_update_hr_zones")
 async def _h_update_hr(args):

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -28,6 +28,7 @@ from tp_mcp.tools import (
     tp_create_library_item,
     tp_create_note,
     tp_create_workout,
+    tp_create_zones,
     tp_delete_availability,
     tp_delete_equipment,
     tp_delete_event,
@@ -578,6 +579,35 @@ TOOLS = [
                 "swim_threshold_pace": {"type": "string", "description": "e.g. '1:45/100m'"},
             },
             "required": [],
+        },
+    ),
+    Tool(
+        name="tp_create_zones",
+        description=(
+            "Create a NEW per-sport zone set for an athlete that has none for that "
+            "sport (use tp_update_ftp/hr_zones/speed_zones to change an EXISTING "
+            "set). Bands are computed by TrainingPeaks' calculator for the chosen "
+            "method (see tp_get_zone_methods). Returns ZONES_EXIST if the set is "
+            "already present, or TEST_BASED_METHOD for test-derived methods "
+            "(Distance/Time) — those are set up via a test in the TP UI."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "metric": {"type": "string", "enum": ["power", "heartrate", "speed"]},
+                "workout_type": {"type": "string",
+                                 "description": "Sport for the set, e.g. bike/run/swim/xcski"},
+                "calculation_method": {"type": "integer",
+                                       "description": "Method int (see tp_get_zone_methods)"},
+                "threshold": {"type": "number",
+                              "description": "FTP watts (power) or LTHR bpm (heartrate)"},
+                "pace": {"type": "string",
+                         "description": "Threshold pace for speed, e.g. '4:30/km' / '1:45/100m'"},
+                "max_hr": {"type": "integer"},
+                "resting_hr": {"type": "integer"},
+                "distance": {"type": "integer"},
+            },
+            "required": ["metric", "workout_type", "calculation_method"],
         },
     ),
     Tool(
@@ -1208,6 +1238,16 @@ async def _h_update_speed(args):
     return await tp_update_speed_zones(
         run_threshold_pace=args.get("run_threshold_pace"),
         swim_threshold_pace=args.get("swim_threshold_pace"),
+    )
+
+@_handler("tp_create_zones")
+async def _h_create_zones(args):
+    return await tp_create_zones(
+        metric=args["metric"], workout_type=args["workout_type"],
+        calculation_method=args["calculation_method"],
+        threshold=args.get("threshold"), pace=args.get("pace"),
+        max_hr=args.get("max_hr"), resting_hr=args.get("resting_hr"),
+        distance=args.get("distance", 0),
     )
 
 @_handler("tp_update_nutrition")

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -74,6 +74,7 @@ from tp_mcp.tools.workouts import (
     tp_unpair_workout,
     tp_update_workout,
 )
+from tp_mcp.tools.zone_methods import tp_get_zone_methods
 
 __all__ = [
     "tp_add_note_comment",
@@ -121,6 +122,7 @@ __all__ = [
     "tp_get_workout_note",
     "tp_get_workout_prs",
     "tp_get_workout_types",
+    "tp_get_zone_methods",
     "tp_list_athletes",
     "tp_get_workouts",
     "tp_log_metrics",

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -43,6 +43,7 @@ from tp_mcp.tools.peaks import tp_get_peaks, tp_get_workout_prs
 from tp_mcp.tools.profile import tp_get_profile, tp_list_athletes
 from tp_mcp.tools.refresh_auth import tp_refresh_auth
 from tp_mcp.tools.settings import (
+    tp_create_zones,
     tp_get_athlete_settings,
     tp_get_pool_length_settings,
     tp_update_ftp,
@@ -129,6 +130,7 @@ __all__ = [
     "tp_schedule_library_workout",
     "tp_set_workout_note",
     "tp_unpair_workout",
+    "tp_create_zones",
     "tp_update_equipment",
     "tp_update_event",
     "tp_update_note",

--- a/src/tp_mcp/tools/settings.py
+++ b/src/tp_mcp/tools/settings.py
@@ -209,18 +209,19 @@ async def _get_user_id(client: "TPClient") -> int | None:
 async def _calculated_zones(
     client: "TPClient", metric: str, group: dict[str, Any],
     new_threshold: float | None, extra_fields: dict[str, Any] | None,
-) -> list[dict[str, Any]] | None:
+) -> tuple[list[dict[str, Any]] | None, float | None]:
     """METHOD-CORRECT bands from TP's own zone calculator (the same call the web
-    UI "Calculate" makes), so Max-HR / Karvonen / Distance-Time are computed by
-    TP's real formula, not a proportional approximation. Returns mapped
-    [{label, minimum, maximum}] or None (manual method / no calculator / bad
-    response) so the caller falls back to a proportional rescale."""
+    UI "Calculate" makes). Returns (mapped [{label,minimum,maximum}],
+    derived_threshold) — the calculator ECHOES the threshold for threshold-anchored
+    methods but DERIVES a different one for test-based methods (Distance-Time), so
+    the caller stores the derived value and can detect the test-based case.
+    Returns (None, None) on manual method / no calculator / bad response."""
     method = group.get("calculationMethod")
     if not isinstance(method, int):
-        return None
+        return None, None
     uid = await _get_user_id(client)
     if uid is None:
-        return None
+        return None, None
     extra = extra_fields or {}
     thr = group.get("threshold") if new_threshold is None else new_threshold
     body: dict[str, Any] = {"zoneType": method}
@@ -235,26 +236,29 @@ async def _calculated_zones(
         if group.get("distance") is not None:
             body["distance"] = group.get("distance")
     else:
-        return None
+        return None, None
     resp = await client.post(
         f"/trainingzones/v1/users/{uid}/{metric}/calculate/{method}", json=body)
     if resp.is_error or not isinstance(resp.data, dict):
-        return None
+        return None, None
     raw = resp.data.get("zones")
     if not isinstance(raw, list) or not raw:
-        return None
+        return None, None
     use_double = metric == "speed"
     out: list[dict[str, Any]] = []
     for z in raw:
         if not isinstance(z, dict):
-            return None
+            return None, None
         mn = z.get("minimumAsDouble") if use_double else z.get("minimum")
         mx = z.get("maximumAsDouble") if use_double else z.get("maximum")
         # reject non-numeric / NaN (NaN != NaN) -> caller falls back
         if not isinstance(mn, (int, float)) or not isinstance(mx, (int, float)) or mn != mn or mx != mx:
-            return None
+            return None, None
         out.append({"label": z.get("label"), "minimum": mn, "maximum": mx})
-    return out
+    derived = resp.data.get("thresholdSpeed")
+    if not isinstance(derived, (int, float)):
+        derived = resp.data.get("lactateThreshold")
+    return out, (derived if isinstance(derived, (int, float)) else None)
 
 
 async def _put_zone_array(
@@ -290,12 +294,21 @@ async def _update_single_zone_set(
                 "message": f"No {settings_key} found in athlete settings."}
     idx, note = _select_group_index(groups, wtid)
     metric = _CALC_METRIC.get(put_path, "")
-    calc_zones = await _calculated_zones(client, metric, groups[idx], new_threshold, extra_fields)
+    calc_zones, derived = await _calculated_zones(client, metric, groups[idx], new_threshold, extra_fields)
     method_correct = calc_zones is not None
     if method_correct:
+        # Test-based methods (e.g. Distance/Time) DERIVE the threshold from the
+        # input as a test result — they can't have a threshold set directly.
+        if (new_threshold is not None and derived is not None
+                and abs(derived - new_threshold) > 0.02 * max(abs(new_threshold), 1.0)):
+            return {"isError": True, "error_code": "TEST_BASED_METHOD",
+                    "message": "This zone set derives its threshold from a test "
+                               "(e.g. Distance/Time); a threshold can't be set directly. "
+                               "Change the calculation method or enter a test in TrainingPeaks."}
         new_group = copy.deepcopy(groups[idx])
         if new_threshold is not None:
-            new_group["threshold"] = round(new_threshold) if integer else new_threshold
+            store = derived if derived is not None else new_threshold
+            new_group["threshold"] = round(store) if integer else store
         if extra_fields:
             for k, v in extra_fields.items():
                 if v is not None:
@@ -503,11 +516,16 @@ async def tp_update_speed_zones(
             except ValueError as e:
                 return {"isError": True, "error_code": "VALIDATION_ERROR", "message": str(e)}
             idx, note = _select_group_index(working, wtid)
-            calc_zones = await _calculated_zones(client, "speed", working[idx], speed_ms, None)
+            calc_zones, derived = await _calculated_zones(client, "speed", working[idx], speed_ms, None)
             method_correct = calc_zones is not None
             if method_correct:
+                if derived is not None and abs(derived - speed_ms) > 0.02 * max(abs(speed_ms), 1.0):
+                    return {"isError": True, "error_code": "TEST_BASED_METHOD",
+                            "message": f"{sport}: zone set derives its threshold from a test "
+                                       "(e.g. Distance/Time); set it via a test in TrainingPeaks "
+                                       "or change the method."}
                 new_group = copy.deepcopy(working[idx])
-                new_group["threshold"] = speed_ms
+                new_group["threshold"] = derived if derived is not None else speed_ms
                 new_group["zones"] = calc_zones
             else:
                 new_group, err = _rescaled_group(working[idx], speed_ms, integer=False)

--- a/src/tp_mcp/tools/settings.py
+++ b/src/tp_mcp/tools/settings.py
@@ -563,6 +563,138 @@ async def tp_update_speed_zones(
         return result
 
 
+# metric -> (settings array key, PUT path)
+_METRIC_KEYS = {
+    "power": ("powerZones", "powerzones"),
+    "heartrate": ("heartRateZones", "heartratezones"),
+    "speed": ("speedZones", "speedzones"),
+}
+
+
+async def tp_create_zones(
+    metric: str,
+    workout_type: str,
+    calculation_method: int,
+    threshold: float | None = None,
+    pace: str | None = None,
+    max_hr: int | None = None,
+    resting_hr: int | None = None,
+    distance: int = 0,
+) -> dict[str, Any]:
+    """Create a NEW per-sport zone set for an athlete that has none for that
+    sport (use tp_update_ftp/hr_zones/speed_zones to change an EXISTING set).
+    Bands are computed by TrainingPeaks' own calculator for the chosen method.
+
+    Args:
+        metric: 'power' | 'heartrate' | 'speed'.
+        workout_type: sport for the set (e.g. 'bike', 'run', 'swim', 'xcski').
+        calculation_method: the method int (see tp_get_zone_methods).
+        threshold: FTP watts (power) or LTHR bpm (heartrate).
+        pace: threshold pace (speed), e.g. '4:30/km' or '1:45/100m'.
+        max_hr, resting_hr: optional anchors for heartrate methods.
+        distance: optional, for speed sets.
+
+    Limitation: test-based methods (Distance/Time) DERIVE the threshold from a
+    test and can't be created from a plain threshold — return TEST_BASED_METHOD;
+    set those up via a test in the TrainingPeaks UI.
+    """
+    metric = (metric or "").lower()
+    if metric not in _METRIC_KEYS:
+        return {"isError": True, "error_code": "VALIDATION_ERROR",
+                "message": f"metric must be one of {sorted(_METRIC_KEYS)}."}
+    wt = (workout_type or "").lower()
+    if wt not in _ZONE_WTID:
+        return {"isError": True, "error_code": "VALIDATION_ERROR",
+                "message": f"workout_type must be one of {sorted(_ZONE_WTID)}."}
+    if not isinstance(calculation_method, int) or isinstance(calculation_method, bool):
+        return {"isError": True, "error_code": "VALIDATION_ERROR",
+                "message": "calculation_method must be an integer (see tp_get_zone_methods)."}
+
+    # Resolve the threshold value in the calculator's native units.
+    if metric == "speed":
+        if not pace:
+            return {"isError": True, "error_code": "VALIDATION_ERROR",
+                    "message": "pace is required for speed zones (e.g. '4:30/km')."}
+        try:
+            thr_value: float = _parse_pace_to_ms(pace, is_swim=(wt == "swim"))
+        except ValueError as e:
+            return {"isError": True, "error_code": "VALIDATION_ERROR", "message": str(e)}
+    else:
+        if threshold is None or float(threshold) <= 0:
+            return {"isError": True, "error_code": "VALIDATION_ERROR",
+                    "message": "threshold (watts for power, bpm for heartrate) is required."}
+        thr_value = float(threshold)
+
+    settings_key, put_path = _METRIC_KEYS[metric]
+    wtid = _ZONE_WTID[wt]
+    integer = metric != "speed"
+
+    async with TPClient() as client:
+        athlete_id = await client.ensure_athlete_id()
+        if not athlete_id:
+            return {"isError": True, "error_code": "AUTH_INVALID",
+                    "message": "Could not get athlete ID. Re-authenticate."}
+        sr = await client.get(f"/fitness/v1/athletes/{athlete_id}/settings")
+        if sr.is_error:
+            return {"isError": True,
+                    "error_code": sr.error_code.value if sr.error_code else "API_ERROR",
+                    "message": sr.message}
+        if not isinstance(sr.data, dict):
+            return {"isError": True, "error_code": "API_ERROR", "message": "No settings data returned."}
+        groups = sr.data.get(settings_key)
+        groups = list(groups) if isinstance(groups, list) else []
+        if any(isinstance(g, dict) and g.get("workoutTypeId") == wtid for g in groups):
+            return {"isError": True, "error_code": "ZONES_EXIST",
+                    "message": f"{metric} zones already exist for workout_type '{wt}' "
+                               "(workoutTypeId={}); use the update tool to change the "
+                               "threshold.".format(wtid)}
+
+        # Synthetic group carrying the chosen method/anchors → calculator.
+        seed: dict[str, Any] = {"calculationMethod": calculation_method, "threshold": thr_value}
+        extra: dict[str, Any] = {}
+        if metric == "heartrate":
+            extra = {"maximumHeartRate": max_hr, "restingHeartRate": resting_hr}
+        elif metric == "speed":
+            seed["distance"] = distance or 0
+        calc_zones, derived = await _calculated_zones(client, metric, seed, None, extra)
+        if calc_zones is None:
+            return {"isError": True, "error_code": "API_ERROR",
+                    "message": f"Calculator returned no zones for method {calculation_method} "
+                               f"({metric}); check the method int (see tp_get_zone_methods)."}
+        if derived is not None and abs(derived - thr_value) > 0.02 * max(abs(thr_value), 1.0):
+            return {"isError": True, "error_code": "TEST_BASED_METHOD",
+                    "message": "This method derives its threshold from a test "
+                               "(e.g. Distance/Time); create it via a test in the "
+                               "TrainingPeaks UI, or pick a threshold-anchored method."}
+
+        new_group: dict[str, Any] = {
+            "zoneCalculatorId": None,
+            "threshold": round(thr_value) if integer else thr_value,
+            "calculationMethod": calculation_method,
+            "workoutTypeId": wtid,
+            "zones": calc_zones,
+        }
+        if metric == "heartrate":
+            new_group["maximumHeartRate"] = max_hr
+            new_group["restingHeartRate"] = resting_hr
+        elif metric == "speed":
+            new_group["distance"] = distance or 0
+
+        put_err = await _put_zone_array(client, athlete_id, put_path, groups + [new_group])
+        if put_err:
+            return put_err
+        return {
+            "success": True,
+            "created": True,
+            "metric": metric,
+            "workout_type": wt,
+            "workout_type_id": wtid,
+            "calculation_method": calculation_method,
+            "threshold": new_group["threshold"],
+            "zones": calc_zones,
+        }
+
+
 async def tp_update_nutrition(planned_calories: int) -> dict[str, Any]:
     """Update nutrition settings.
 

--- a/src/tp_mcp/tools/settings.py
+++ b/src/tp_mcp/tools/settings.py
@@ -467,8 +467,15 @@ async def tp_update_speed_zones(
     run_threshold_pace: str | None = None,
     swim_threshold_pace: str | None = None,
 ) -> dict[str, Any]:
-    """Update run/swim pace zones, preserving each set's method and (for swim
-    Distance/Time sets) its `distance` — only the threshold pace and bands move.
+    """Update run/swim THRESHOLD pace, recomputing bands with TP's own zone
+    calculator (method preserved). Pace honours its unit (km / mi / 100m / 100yd).
+
+    LIMITATION: a set whose method DERIVES its threshold from a test result
+    (Speed/Pace "Distance / Time") cannot have a threshold set directly — the
+    input would be treated as a test, deriving a different value. Such sets
+    return ``TEST_BASED_METHOD`` (nothing written); configure them via a test in
+    the TrainingPeaks UI. Threshold-anchored methods (Threshold Pace) update
+    exactly.
 
     Args:
         run_threshold_pace: e.g. '4:30/km'.

--- a/src/tp_mcp/tools/settings.py
+++ b/src/tp_mcp/tools/settings.py
@@ -194,6 +194,69 @@ def _rescaled_group(
     return new_group, None
 
 
+_CALC_METRIC = {"powerzones": "power", "heartratezones": "heartrate",
+               "speedzones": "speed"}
+
+
+async def _get_user_id(client: "TPClient") -> int | None:
+    """Authenticated (coach) user id for the zone-calculator URL — distinct from
+    the targeted athlete; the calculator runs under the caller's user."""
+    ud = await client._get_user_data()
+    uid = (ud or {}).get("userId") or (ud or {}).get("personId")
+    return uid if isinstance(uid, int) else None
+
+
+async def _calculated_zones(
+    client: "TPClient", metric: str, group: dict[str, Any],
+    new_threshold: float | None, extra_fields: dict[str, Any] | None,
+) -> list[dict[str, Any]] | None:
+    """METHOD-CORRECT bands from TP's own zone calculator (the same call the web
+    UI "Calculate" makes), so Max-HR / Karvonen / Distance-Time are computed by
+    TP's real formula, not a proportional approximation. Returns mapped
+    [{label, minimum, maximum}] or None (manual method / no calculator / bad
+    response) so the caller falls back to a proportional rescale."""
+    method = group.get("calculationMethod")
+    if not isinstance(method, int):
+        return None
+    uid = await _get_user_id(client)
+    if uid is None:
+        return None
+    extra = extra_fields or {}
+    thr = group.get("threshold") if new_threshold is None else new_threshold
+    body: dict[str, Any] = {"zoneType": method}
+    if metric == "heartrate":
+        body["LTHR"] = thr
+        body["maxHR"] = extra.get("maximumHeartRate", group.get("maximumHeartRate"))
+        body["restingHR"] = extra.get("restingHeartRate", group.get("restingHeartRate"))
+    elif metric == "power":
+        body["LTPower"] = thr
+    elif metric == "speed":
+        body["speed"] = thr
+        if group.get("distance") is not None:
+            body["distance"] = group.get("distance")
+    else:
+        return None
+    resp = await client.post(
+        f"/trainingzones/v1/users/{uid}/{metric}/calculate/{method}", json=body)
+    if resp.is_error or not isinstance(resp.data, dict):
+        return None
+    raw = resp.data.get("zones")
+    if not isinstance(raw, list) or not raw:
+        return None
+    use_double = metric == "speed"
+    out: list[dict[str, Any]] = []
+    for z in raw:
+        if not isinstance(z, dict):
+            return None
+        mn = z.get("minimumAsDouble") if use_double else z.get("minimum")
+        mx = z.get("maximumAsDouble") if use_double else z.get("maximum")
+        # reject non-numeric / NaN (NaN != NaN) -> caller falls back
+        if not isinstance(mn, (int, float)) or not isinstance(mx, (int, float)) or mn != mn or mx != mx:
+            return None
+        out.append({"label": z.get("label"), "minimum": mn, "maximum": mx})
+    return out
+
+
 async def _put_zone_array(
     client: "TPClient", athlete_id: int, put_path: str, payload: list[Any],
 ) -> dict[str, Any] | None:
@@ -226,26 +289,41 @@ async def _update_single_zone_set(
         return {"isError": True, "error_code": "API_ERROR",
                 "message": f"No {settings_key} found in athlete settings."}
     idx, note = _select_group_index(groups, wtid)
-    new_group, err = _rescaled_group(groups[idx], new_threshold, integer=integer)
-    if err or new_group is None:
-        return {"isError": True, "error_code": "ZONE_RESCALE", "message": err or "rescale failed"}
-    if extra_fields:
-        for k, v in extra_fields.items():
-            if v is not None:
-                new_group[k] = v
+    metric = _CALC_METRIC.get(put_path, "")
+    calc_zones = await _calculated_zones(client, metric, groups[idx], new_threshold, extra_fields)
+    method_correct = calc_zones is not None
+    if method_correct:
+        new_group = copy.deepcopy(groups[idx])
+        if new_threshold is not None:
+            new_group["threshold"] = round(new_threshold) if integer else new_threshold
+        if extra_fields:
+            for k, v in extra_fields.items():
+                if v is not None:
+                    new_group[k] = v
+        new_group["zones"] = calc_zones
+    else:
+        new_group, err = _rescaled_group(groups[idx], new_threshold, integer=integer)
+        if err or new_group is None:
+            return {"isError": True, "error_code": "ZONE_RESCALE", "message": err or "rescale failed"}
+        if extra_fields:
+            for k, v in extra_fields.items():
+                if v is not None:
+                    new_group[k] = v
     payload = list(groups)
     payload[idx] = new_group
     put_err = await _put_zone_array(client, athlete_id, put_path, payload)
     if put_err:
         return put_err
     notes = [note] if note else []
-    if new_threshold is None:
-        notes.append("only anchors updated (max/resting); zone bands NOT recomputed — "
-                     "recompute in TP if this method derives bands from max/resting")
+    if not method_correct:
+        notes.append("zones rescaled proportionally (no server calculator for this method)")
+        if new_threshold is None:
+            notes.append("only anchors changed; bands unchanged — recompute in TP")
     result: dict[str, Any] = {
         "success": True,
         "workout_type_id": new_group.get("workoutTypeId"),
         "calculation_method": new_group.get("calculationMethod"),
+        "method_correct": method_correct,
         "threshold": new_group.get("threshold"),
         "zones": new_group.get("zones"),
     }
@@ -425,17 +503,27 @@ async def tp_update_speed_zones(
             except ValueError as e:
                 return {"isError": True, "error_code": "VALIDATION_ERROR", "message": str(e)}
             idx, note = _select_group_index(working, wtid)
-            new_group, err = _rescaled_group(working[idx], speed_ms, integer=False)
-            if err or new_group is None:
-                return {"isError": True, "error_code": "API_ERROR",
-                        "message": f"{sport}: {err or 'rescale failed'}"}
+            calc_zones = await _calculated_zones(client, "speed", working[idx], speed_ms, None)
+            method_correct = calc_zones is not None
+            if method_correct:
+                new_group = copy.deepcopy(working[idx])
+                new_group["threshold"] = speed_ms
+                new_group["zones"] = calc_zones
+            else:
+                new_group, err = _rescaled_group(working[idx], speed_ms, integer=False)
+                if err or new_group is None:
+                    return {"isError": True, "error_code": "API_ERROR",
+                            "message": f"{sport}: {err or 'rescale failed'}"}
             working[idx] = new_group
             if note:
                 notes.append(f"{sport}: {note}")
+            if not method_correct:
+                notes.append(f"{sport}: zones rescaled proportionally (no server calculator)")
             updated.append({
                 "sport": sport,
                 "workout_type_id": new_group.get("workoutTypeId"),
                 "calculation_method": new_group.get("calculationMethod"),
+                "method_correct": method_correct,
                 "distance": new_group.get("distance"),
                 "threshold_ms": speed_ms,
                 "zones": new_group.get("zones"),

--- a/src/tp_mcp/tools/settings.py
+++ b/src/tp_mcp/tools/settings.py
@@ -1,5 +1,6 @@
 """Athlete settings tools: zones, FTP, thresholds, nutrition."""
 
+import copy
 import logging
 import re
 from typing import Any
@@ -8,6 +9,7 @@ from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from tp_mcp.client import TPClient
 from tp_mcp.tools._validation import format_validation_error
+from tp_mcp.tools.workouts import SPORT_TYPE_MAP
 
 logger = logging.getLogger("tp-mcp")
 
@@ -21,11 +23,25 @@ POWER_ZONE_LABELS = [
 ]
 POWER_ZONE_MAXIMUM = 2000
 
+# Sport name (case-insensitive) -> zone workoutTypeId. Reuses the connector's
+# authoritative SPORT_TYPE_MAP, so a new TP sport needs no change here. 'default'
+# / 'general' target the Default (0) zone set (not a sport).
+_ZONE_WTID: dict[str, int] = {"default": 0, "general": 0}
+_ZONE_WTID.update({name.lower(): value_id for name, (_fam, value_id) in SPORT_TYPE_MAP.items()})
+
 
 class FTPInput(BaseModel):
     """Validates FTP input."""
 
     ftp: int = Field(gt=0, le=2000)
+    workout_type: str = Field(default="bike")
+
+    @field_validator("workout_type")
+    @classmethod
+    def check_ftp_type(cls, v: str) -> str:
+        if v.lower() not in _ZONE_WTID:
+            raise ValueError(f"workout_type must be one of {sorted(_ZONE_WTID)}")
+        return v
 
 
 class HRZonesInput(BaseModel):
@@ -39,8 +55,8 @@ class HRZonesInput(BaseModel):
     @field_validator("workout_type")
     @classmethod
     def check_type(cls, v: str) -> str:
-        if v not in ("general", "bike"):
-            raise ValueError("workout_type must be 'general' or 'bike'")
+        if v.lower() not in _ZONE_WTID:
+            raise ValueError(f"workout_type must be one of {sorted(_ZONE_WTID)}")
         return v
 
 
@@ -120,145 +136,194 @@ async def tp_get_athlete_settings() -> dict[str, Any]:
         return {"settings": response.data}
 
 
-async def tp_update_ftp(ftp: int) -> dict[str, Any]:
-    """Update FTP and recalculate the athlete's default power zones.
+# ── Zone-update helpers (method-agnostic, no hardcoded discovery results) ──────
+# workoutTypeId is TP's STABLE type identifier (0 default / 1 swim / 2 bike /
+# 3 run), used ONLY to locate the right zone group. The group's calculationMethod,
+# Distance-Time `distance`, zoneCalculatorId, band structure — and any field TP
+# adds in future — are read from the live payload and preserved verbatim; the
+# connector never assumes a calculation method or bakes in probed values.
+
+
+def _select_group_index(groups: list[Any], wtid: int) -> tuple[int, str | None]:
+    """Index of the zone group whose workoutTypeId == wtid; fall back to the
+    default (0) group, then the first. The note records any fallback."""
+    for i, g in enumerate(groups):
+        if isinstance(g, dict) and g.get("workoutTypeId") == wtid:
+            return i, None
+    for i, g in enumerate(groups):
+        if isinstance(g, dict) and g.get("workoutTypeId") == 0:
+            return i, f"no zone set for workoutTypeId={wtid}; updated the default (0) set"
+    return 0, f"no zone set for workoutTypeId={wtid} or default; updated the first set"
+
+
+def _rescaled_group(
+    group: dict[str, Any],
+    new_threshold: float | None,
+    *,
+    integer: bool,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Deep-copy `group`, set `threshold` (None = keep) and scale every zone band
+    by the new/old ratio. ALL other fields ride through untouched, so the
+    athlete's method / Distance-Time `distance` / calculator id are never
+    altered. TP does NOT recompute bands on save (verified live), so the
+    connector does — proportionally to the threshold (correct for
+    threshold-anchored methods); it never assumes a method formula.
+    Returns (new_group, error)."""
+    old = group.get("threshold")
+    if not isinstance(old, (int, float)) or old <= 0:
+        return None, "existing threshold is missing or zero"
+    zones = group.get("zones") or []
+    interior_maxima = [z.get("maximum") for z in zones[:-1] if isinstance(z, dict)]
+    if any(not isinstance(m, (int, float)) for m in interior_maxima):
+        return None, "existing zone bands are malformed"
+    target = float(old) if new_threshold is None else float(new_threshold)
+    ratio = target / float(old)
+    new_group = copy.deepcopy(group)
+    new_group["threshold"] = round(target) if integer else target
+    zlist = new_group.get("zones") or []
+    last = len(zlist) - 1
+    for i, z in enumerate(zlist):
+        if not isinstance(z, dict):
+            continue
+        for bound in ("minimum", "maximum"):
+            # Keep the final zone's artificial ceiling (e.g. 2000 W) unscaled.
+            if i == last and bound == "maximum":
+                continue
+            v = z.get(bound)
+            if isinstance(v, (int, float)):
+                z[bound] = round(v * ratio) if integer else v * ratio
+    return new_group, None
+
+
+async def _put_zone_array(
+    client: "TPClient", athlete_id: int, put_path: str, payload: list[Any],
+) -> dict[str, Any] | None:
+    """PUT the full zone-group array. Returns an error dict or None on success."""
+    pr = await client.put(f"/fitness/v2/athletes/{athlete_id}/{put_path}", json=payload)
+    if pr.is_error:
+        return {"isError": True,
+                "error_code": pr.error_code.value if pr.error_code else "API_ERROR",
+                "message": pr.message}
+    return None
+
+
+async def _update_single_zone_set(
+    client: "TPClient", athlete_id: int, settings_key: str, put_path: str,
+    wtid: int, new_threshold: float | None, *, integer: bool,
+    extra_fields: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """GET settings → locate the wtid group → rescale → PUT the full array (the
+    only shape TP accepts). `extra_fields` sets extra anchors verbatim (HR
+    maximumHeartRate/restingHeartRate)."""
+    sr = await client.get(f"/fitness/v1/athletes/{athlete_id}/settings")
+    if sr.is_error:
+        return {"isError": True,
+                "error_code": sr.error_code.value if sr.error_code else "API_ERROR",
+                "message": sr.message}
+    if not isinstance(sr.data, dict):
+        return {"isError": True, "error_code": "API_ERROR", "message": "No settings data returned."}
+    groups = sr.data.get(settings_key)
+    if not isinstance(groups, list) or not groups:
+        return {"isError": True, "error_code": "API_ERROR",
+                "message": f"No {settings_key} found in athlete settings."}
+    idx, note = _select_group_index(groups, wtid)
+    new_group, err = _rescaled_group(groups[idx], new_threshold, integer=integer)
+    if err or new_group is None:
+        return {"isError": True, "error_code": "ZONE_RESCALE", "message": err or "rescale failed"}
+    if extra_fields:
+        for k, v in extra_fields.items():
+            if v is not None:
+                new_group[k] = v
+    payload = list(groups)
+    payload[idx] = new_group
+    put_err = await _put_zone_array(client, athlete_id, put_path, payload)
+    if put_err:
+        return put_err
+    result: dict[str, Any] = {
+        "success": True,
+        "workout_type_id": new_group.get("workoutTypeId"),
+        "calculation_method": new_group.get("calculationMethod"),
+        "threshold": new_group.get("threshold"),
+        "zones": new_group.get("zones"),
+    }
+    if note:
+        result["note"] = note
+    return result
+
+
+async def tp_update_ftp(ftp: int, workout_type: str = "bike") -> dict[str, Any]:
+    """Update FTP (power threshold) and rescale the matching power-zone set.
 
     Args:
         ftp: Functional Threshold Power in watts.
+        workout_type: which power set to update — 'bike' (default; FTP is a
+            cycling concept), 'run' (running power) or 'default'. Falls back to
+            the default set if the athlete has no sport-specific one.
 
-    Returns:
-        Dict with updated zones or error.
+    The set's calculation method and structure are preserved; bands are rescaled
+    proportionally. A fresh athlete with no usable bands gets a Coggan model.
     """
     try:
-        params = FTPInput(ftp=ftp)
+        params = FTPInput(ftp=ftp, workout_type=workout_type)
     except (ValidationError, ValueError) as e:
         msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
-        return {
-            "isError": True,
-            "error_code": "VALIDATION_ERROR",
-            "message": msg,
-        }
+        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": msg}
 
     async with TPClient() as client:
         athlete_id = await client.ensure_athlete_id()
         if not athlete_id:
-            return {
-                "isError": True,
-                "error_code": "AUTH_INVALID",
-                "message": "Could not get athlete ID. Re-authenticate.",
-            }
+            return {"isError": True, "error_code": "AUTH_INVALID",
+                    "message": "Could not get athlete ID. Re-authenticate."}
+        wtid = _ZONE_WTID.get(params.workout_type.lower(), _ZONE_WTID["bike"])
+        result = await _update_single_zone_set(
+            client, athlete_id, "powerZones", "powerzones", wtid,
+            float(params.ftp), integer=True)
+        if result.get("error_code") == "ZONE_RESCALE":
+            result = await _ftp_coggan_fallback(client, athlete_id, params.ftp, wtid)
+        if result.get("success"):
+            result["ftp"] = params.ftp
+        return result
 
-        settings_endpoint = f"/fitness/v1/athletes/{athlete_id}/settings"
-        settings_response = await client.get(settings_endpoint)
-        if settings_response.is_error:
-            return {
-                "isError": True,
-                "error_code": settings_response.error_code.value if settings_response.error_code else "API_ERROR",
-                "message": settings_response.message,
-            }
 
-        if not settings_response.data or not isinstance(settings_response.data, dict):
-            return {
-                "isError": True,
-                "error_code": "API_ERROR",
-                "message": "No settings data returned.",
-            }
-
-        power_zones = settings_response.data.get("powerZones")
-        if not isinstance(power_zones, list) or not power_zones:
-            return {
-                "isError": True,
-                "error_code": "API_ERROR",
-                "message": "No power zones found in athlete settings.",
-            }
-
-        target_index = next(
-            (idx for idx, zone_group in enumerate(power_zones)
-             if isinstance(zone_group, dict) and zone_group.get("workoutTypeId") == 0),
-            0,
-        )
-        target_zone_group = power_zones[target_index]
-        if not isinstance(target_zone_group, dict):
-            return {
-                "isError": True,
-                "error_code": "API_ERROR",
-                "message": "Unexpected power zone format returned by TrainingPeaks.",
-            }
-
-        existing_labels = []
-        existing_zones = target_zone_group.get("zones")
-        if isinstance(existing_zones, list):
-            existing_labels = [
-                zone.get("label")
-                for zone in existing_zones
-                if isinstance(zone, dict) and zone.get("label")
-            ]
-        labels = existing_labels if len(existing_labels) == len(POWER_ZONE_LABELS) else POWER_ZONE_LABELS
-
-        current_threshold = target_zone_group.get("threshold")
-        zone_maxima: list[int] = []
-        if isinstance(current_threshold, (int, float)) and current_threshold > 0 and isinstance(existing_zones, list):
-            existing_maxima: list[int] = []
-            for zone in existing_zones[:-1]:
-                if not isinstance(zone, dict):
-                    existing_maxima = []
-                    break
-                maximum = zone.get("maximum")
-                if not isinstance(maximum, (int, float)):
-                    existing_maxima = []
-                    break
-                existing_maxima.append(int(maximum))
-            if len(existing_maxima) == len(labels) - 1:
-                zone_maxima = [round(params.ftp * (maximum / current_threshold)) for maximum in existing_maxima]
-
-        if not zone_maxima:
-            zone_maxima = [
-                round(params.ftp * ratio)
-                for ratio in (0.56, 0.76, 0.91, 1.06, 1.21)
-            ]
-        zones = []
-        lower_bound = 0
-        for label, upper_bound in zip(labels[:-1], zone_maxima, strict=False):
-            zones.append({
-                "label": label,
-                "minimum": lower_bound,
-                "maximum": upper_bound,
-            })
-            lower_bound = upper_bound + 1
-        zones.append({
-            "label": labels[-1],
-            "minimum": lower_bound,
-            "maximum": POWER_ZONE_MAXIMUM,
-        })
-
-        updated_zone_group = {
-            "threshold": params.ftp,
-            "calculationMethod": target_zone_group.get("calculationMethod"),
-            "workoutTypeId": target_zone_group.get("workoutTypeId"),
-            "zones": zones,
-        }
-        if "zoneCalculatorId" in target_zone_group:
-            updated_zone_group["zoneCalculatorId"] = target_zone_group.get("zoneCalculatorId")
-
-        payload = list(power_zones)
-        payload[target_index] = updated_zone_group
-
-        endpoint = f"/fitness/v2/athletes/{athlete_id}/powerzones"
-        response = await client.put(endpoint, json=payload)
-
-        if response.is_error:
-            return {
-                "isError": True,
-                "error_code": response.error_code.value if response.error_code else "API_ERROR",
-                "message": response.message,
-            }
-
-        return {
-            "success": True,
-            "ftp": params.ftp,
-            "workout_type_id": updated_zone_group["workoutTypeId"],
-            "zones": zones,
-        }
+async def _ftp_coggan_fallback(
+    client: "TPClient", athlete_id: int, ftp: int, wtid: int,
+) -> dict[str, Any]:
+    """Build a default Coggan power-zone set when there are no bands to rescale."""
+    sr = await client.get(f"/fitness/v1/athletes/{athlete_id}/settings")
+    if sr.is_error or not isinstance(sr.data, dict):
+        return {"isError": True, "error_code": "API_ERROR", "message": "No settings data returned."}
+    groups = sr.data.get("powerZones")
+    if not isinstance(groups, list) or not groups:
+        return {"isError": True, "error_code": "API_ERROR",
+                "message": "No power zones found in athlete settings."}
+    idx, note = _select_group_index(groups, wtid)
+    target = copy.deepcopy(groups[idx])
+    existing = target.get("zones") or []
+    labels = [z.get("label") for z in existing if isinstance(z, dict) and z.get("label")]
+    if len(labels) != len(POWER_ZONE_LABELS):
+        labels = list(POWER_ZONE_LABELS)
+    maxima = [round(ftp * r) for r in (0.56, 0.76, 0.91, 1.06, 1.21)]
+    zones: list[dict[str, Any]] = []
+    lo = 0
+    for label, hi in zip(labels[:-1], maxima, strict=False):
+        zones.append({"label": label, "minimum": lo, "maximum": hi})
+        lo = hi + 1
+    zones.append({"label": labels[-1], "minimum": lo, "maximum": POWER_ZONE_MAXIMUM})
+    target["threshold"] = ftp
+    target["zones"] = zones
+    payload = list(groups)
+    payload[idx] = target
+    put_err = await _put_zone_array(client, athlete_id, "powerzones", payload)
+    if put_err:
+        return put_err
+    res: dict[str, Any] = {
+        "success": True, "ftp": ftp, "workout_type_id": target.get("workoutTypeId"),
+        "calculation_method": target.get("calculationMethod"),
+        "threshold": ftp, "zones": zones,
+    }
+    if note:
+        res["note"] = note
+    return res
 
 
 async def tp_update_hr_zones(
@@ -267,154 +332,119 @@ async def tp_update_hr_zones(
     resting_hr: int | None = None,
     workout_type: str = "general",
 ) -> dict[str, Any]:
-    """Update heart rate zones.
+    """Update heart-rate zones for a specific sport, preserving the method.
 
     Args:
-        threshold_hr: Threshold heart rate (optional).
-        max_hr: Maximum heart rate (optional).
-        resting_hr: Resting heart rate (optional).
-        workout_type: 'general' or 'bike' (default 'general').
-
-    Returns:
-        Dict with updated zones or error.
+        threshold_hr: Threshold (LTHR). When given, bands rescale to it.
+        max_hr: Maximum HR (stored as an anchor; bands not auto-rescaled by it).
+        resting_hr: Resting HR (stored as an anchor).
+        workout_type: 'general' (default set), 'bike', 'run' or 'swim'.
     """
     try:
         params = HRZonesInput(
-            threshold_hr=threshold_hr,
-            max_hr=max_hr,
-            resting_hr=resting_hr,
-            workout_type=workout_type,
-        )
+            threshold_hr=threshold_hr, max_hr=max_hr,
+            resting_hr=resting_hr, workout_type=workout_type)
     except (ValidationError, ValueError) as e:
         msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
-        return {
-            "isError": True,
-            "error_code": "VALIDATION_ERROR",
-            "message": msg,
-        }
+        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": msg}
 
     if params.threshold_hr is None and params.max_hr is None and params.resting_hr is None:
-        return {
-            "isError": True,
-            "error_code": "VALIDATION_ERROR",
-            "message": "At least one of threshold_hr, max_hr, or resting_hr must be provided.",
-        }
+        return {"isError": True, "error_code": "VALIDATION_ERROR",
+                "message": "At least one of threshold_hr, max_hr, or resting_hr must be provided."}
 
     async with TPClient() as client:
         athlete_id = await client.ensure_athlete_id()
         if not athlete_id:
-            return {
-                "isError": True,
-                "error_code": "AUTH_INVALID",
-                "message": "Could not get athlete ID. Re-authenticate.",
-            }
-
-        payload: dict[str, Any] = {}
-        if params.threshold_hr is not None:
-            payload["threshold"] = params.threshold_hr
+            return {"isError": True, "error_code": "AUTH_INVALID",
+                    "message": "Could not get athlete ID. Re-authenticate."}
+        wtid = _ZONE_WTID.get(params.workout_type.lower(), 0)
+        extra: dict[str, Any] = {}
         if params.max_hr is not None:
-            payload["maximum"] = params.max_hr
+            extra["maximumHeartRate"] = params.max_hr
         if params.resting_hr is not None:
-            payload["resting"] = params.resting_hr
-
-        endpoint = f"/fitness/v2/athletes/{athlete_id}/heartratezones"
-        response = await client.put(endpoint, json=payload)
-
-        if response.is_error:
-            return {
-                "isError": True,
-                "error_code": response.error_code.value if response.error_code else "API_ERROR",
-                "message": response.message,
-            }
-
-        return {
-            "success": True,
-            "message": "Heart rate zones updated.",
-            "updates": payload,
-        }
+            extra["restingHeartRate"] = params.resting_hr
+        new_thr = float(params.threshold_hr) if params.threshold_hr is not None else None
+        return await _update_single_zone_set(
+            client, athlete_id, "heartRateZones", "heartratezones", wtid,
+            new_thr, integer=True, extra_fields=extra)
 
 
 async def tp_update_speed_zones(
     run_threshold_pace: str | None = None,
     swim_threshold_pace: str | None = None,
 ) -> dict[str, Any]:
-    """Update speed/pace zones.
+    """Update run/swim pace zones, preserving each set's method and (for swim
+    Distance/Time sets) its `distance` — only the threshold pace and bands move.
 
     Args:
-        run_threshold_pace: Run threshold pace (e.g. '4:30/km').
-        swim_threshold_pace: Swim threshold pace (e.g. '1:45/100m').
-
-    Returns:
-        Dict with updated zones or error.
+        run_threshold_pace: e.g. '4:30/km'.
+        swim_threshold_pace: e.g. '1:45/100m'.
     """
     try:
         params = SpeedZonesInput(
             run_threshold_pace=run_threshold_pace,
-            swim_threshold_pace=swim_threshold_pace,
-        )
+            swim_threshold_pace=swim_threshold_pace)
     except (ValidationError, ValueError) as e:
         msg = format_validation_error(e) if isinstance(e, ValidationError) else str(e)
-        return {
-            "isError": True,
-            "error_code": "VALIDATION_ERROR",
-            "message": msg,
-        }
+        return {"isError": True, "error_code": "VALIDATION_ERROR", "message": msg}
 
     if params.run_threshold_pace is None and params.swim_threshold_pace is None:
-        return {
-            "isError": True,
-            "error_code": "VALIDATION_ERROR",
-            "message": "At least one of run_threshold_pace or swim_threshold_pace must be provided.",
-        }
+        return {"isError": True, "error_code": "VALIDATION_ERROR",
+                "message": "At least one of run_threshold_pace or swim_threshold_pace must be provided."}
 
     async with TPClient() as client:
         athlete_id = await client.ensure_athlete_id()
         if not athlete_id:
-            return {
-                "isError": True,
-                "error_code": "AUTH_INVALID",
-                "message": "Could not get athlete ID. Re-authenticate.",
-            }
+            return {"isError": True, "error_code": "AUTH_INVALID",
+                    "message": "Could not get athlete ID. Re-authenticate."}
+        sr = await client.get(f"/fitness/v1/athletes/{athlete_id}/settings")
+        if sr.is_error:
+            return {"isError": True,
+                    "error_code": sr.error_code.value if sr.error_code else "API_ERROR",
+                    "message": sr.message}
+        if not isinstance(sr.data, dict):
+            return {"isError": True, "error_code": "API_ERROR", "message": "No settings data returned."}
+        groups = sr.data.get("speedZones")
+        if not isinstance(groups, list) or not groups:
+            return {"isError": True, "error_code": "API_ERROR",
+                    "message": "No speed zones found in athlete settings."}
 
-        payload: dict[str, Any] = {}
-
-        if params.run_threshold_pace is not None:
+        working = list(groups)
+        updated: list[dict[str, Any]] = []
+        notes: list[str] = []
+        plan = [("run", params.run_threshold_pace, False, 3),
+                ("swim", params.swim_threshold_pace, True, 1)]
+        for sport, pace, is_swim, wtid in plan:
+            if pace is None:
+                continue
             try:
-                speed_ms = _parse_pace_to_ms(params.run_threshold_pace)
-                payload["runThreshold"] = speed_ms
+                speed_ms = _parse_pace_to_ms(pace, is_swim=is_swim)
             except ValueError as e:
-                return {
-                    "isError": True,
-                    "error_code": "VALIDATION_ERROR",
-                    "message": str(e),
-                }
+                return {"isError": True, "error_code": "VALIDATION_ERROR", "message": str(e)}
+            idx, note = _select_group_index(working, wtid)
+            new_group, err = _rescaled_group(working[idx], speed_ms, integer=False)
+            if err or new_group is None:
+                return {"isError": True, "error_code": "API_ERROR",
+                        "message": f"{sport}: {err or 'rescale failed'}"}
+            working[idx] = new_group
+            if note:
+                notes.append(f"{sport}: {note}")
+            updated.append({
+                "sport": sport,
+                "workout_type_id": new_group.get("workoutTypeId"),
+                "calculation_method": new_group.get("calculationMethod"),
+                "distance": new_group.get("distance"),
+                "threshold_ms": speed_ms,
+                "zones": new_group.get("zones"),
+            })
 
-        if params.swim_threshold_pace is not None:
-            try:
-                speed_ms = _parse_pace_to_ms(params.swim_threshold_pace, is_swim=True)
-                payload["swimThreshold"] = speed_ms
-            except ValueError as e:
-                return {
-                    "isError": True,
-                    "error_code": "VALIDATION_ERROR",
-                    "message": str(e),
-                }
-
-        endpoint = f"/fitness/v2/athletes/{athlete_id}/speedzones"
-        response = await client.put(endpoint, json=payload)
-
-        if response.is_error:
-            return {
-                "isError": True,
-                "error_code": response.error_code.value if response.error_code else "API_ERROR",
-                "message": response.message,
-            }
-
-        return {
-            "success": True,
-            "message": "Speed zones updated.",
-            "updates": payload,
-        }
+        put_err = await _put_zone_array(client, athlete_id, "speedzones", working)
+        if put_err:
+            return put_err
+        result: dict[str, Any] = {"success": True, "updated": updated}
+        if notes:
+            result["note"] = "; ".join(notes)
+        return result
 
 
 async def tp_update_nutrition(planned_calories: int) -> dict[str, Any]:

--- a/src/tp_mcp/tools/settings.py
+++ b/src/tp_mcp/tools/settings.py
@@ -76,29 +76,28 @@ class SpeedZonesInput(BaseModel):
         return v
 
 
+_PACE_UNIT_METRES = {"km": 1000.0, "mi": 1609.344, "mile": 1609.344,
+                     "miles": 1609.344, "m": 1.0, "yd": 0.9144}
+
+
 def _parse_pace_to_ms(pace_str: str, is_swim: bool = False) -> float:
-    """Parse a pace string to metres per second.
-
-    Args:
-        pace_str: Pace like '4:30/km' or '1:45/100m'.
-        is_swim: Whether this is a swim pace (per 100m).
-
-    Returns:
-        Speed in metres per second.
+    """Parse a pace string ('M:SS[/unit]') to metres per second, HONOURING the
+    unit (km / mi / 100m / 100yd / …). Unknown units raise rather than being
+    silently treated as km/100m. Default unit: 100m for swim, km otherwise.
     """
-    # Strip unit suffix if present
-    pace_part = pace_str.split("/")[0]
-    parts = pace_part.split(":")
-    minutes = int(parts[0])
-    seconds = int(parts[1])
-    total_seconds = minutes * 60 + seconds
+    time_part, _, unit_part = pace_str.partition("/")
+    unit = unit_part.strip().lower() or ("100m" if is_swim else "km")
+    mo = re.fullmatch(r"(\d*)\s*(km|miles?|mi|yd|m)", unit)
+    if not mo:
+        raise ValueError(f"Unknown pace unit '/{unit_part.strip()}' in '{pace_str}'")
+    count = int(mo.group(1)) if mo.group(1) else 1
+    metres = count * _PACE_UNIT_METRES[mo.group(2)]
 
+    mm, _, ss = time_part.strip().partition(":")
+    total_seconds = int(mm) * 60 + int(ss)
     if total_seconds == 0:
         raise ValueError(f"Invalid pace: {pace_str}")
-
-    if is_swim:
-        return 100.0 / total_seconds
-    return 1000.0 / total_seconds
+    return metres / total_seconds
 
 
 async def tp_get_athlete_settings() -> dict[str, Any]:
@@ -239,6 +238,10 @@ async def _update_single_zone_set(
     put_err = await _put_zone_array(client, athlete_id, put_path, payload)
     if put_err:
         return put_err
+    notes = [note] if note else []
+    if new_threshold is None:
+        notes.append("only anchors updated (max/resting); zone bands NOT recomputed — "
+                     "recompute in TP if this method derives bands from max/resting")
     result: dict[str, Any] = {
         "success": True,
         "workout_type_id": new_group.get("workoutTypeId"),
@@ -246,8 +249,8 @@ async def _update_single_zone_set(
         "threshold": new_group.get("threshold"),
         "zones": new_group.get("zones"),
     }
-    if note:
-        result["note"] = note
+    if notes:
+        result["note"] = "; ".join(notes)
     return result
 
 

--- a/src/tp_mcp/tools/zone_methods.py
+++ b/src/tp_mcp/tools/zone_methods.py
@@ -1,0 +1,109 @@
+"""Discover TrainingPeaks zone-calculation methods.
+
+TP exposes no endpoint that lists zone-calculation methods, and athlete settings
+carry only the opaque ``calculationMethod`` integer (``zoneCalculatorId`` is
+null, no name). However, the zone calculator
+
+    POST /trainingzones/v1/users/{userId}/{metric}/calculate/{method}
+
+returns each zone with a ``label`` and echoes the ``calculationMethod``. The zone
+count and labels are method-intrinsic (stable across athletes; only the band
+boundaries depend on the input threshold), so probing the method-int range
+fingerprints every available method without hardcoding any names.
+
+This is read-only: the calculator only computes, it never saves.
+"""
+
+import logging
+from typing import Any
+
+from tp_mcp.client import TPClient
+
+logger = logging.getLogger("tp-mcp")
+
+METRICS = ("power", "heartrate", "speed")
+
+# Representative threshold body per metric. The values are arbitrary — only the
+# returned zone LABELS and COUNT are read (method-intrinsic); the boundaries
+# (which depend on these numbers) are intentionally ignored here.
+_PROBE_BODY: dict[str, dict[str, Any]] = {
+    "power": {"LTPower": 250},
+    "heartrate": {"LTHR": 160, "maxHR": 190, "restingHR": 50},
+    "speed": {"speed": 4.0, "distance": 3000},
+}
+_PROBE_THRESHOLD = {"power": 250.0, "heartrate": 160.0, "speed": 4.0}
+
+# Method ints to probe. Observed in the wild: power {1..7}, HR {1..5, 31},
+# speed {2, 5, 14}. A generous range is probed; unknown ints simply error and
+# are skipped, so this stays correct if TP adds methods.
+_PROBE_METHODS = list(range(0, 16)) + [31]
+
+
+async def _probe_metric(
+    client: TPClient, user_id: int, metric: str
+) -> list[dict[str, Any]]:
+    """Probe every candidate method int for one metric; return the ones that
+    resolve, each as {method, zone_count, labels, derives_threshold}."""
+    body = _PROBE_BODY[metric]
+    threshold = _PROBE_THRESHOLD[metric]
+    found: list[dict[str, Any]] = []
+    for method in _PROBE_METHODS:
+        endpoint = f"/trainingzones/v1/users/{user_id}/{metric}/calculate/{method}"
+        resp = await client.post(endpoint, json={**body, "zoneType": method})
+        if resp.is_error or not isinstance(resp.data, dict):
+            continue
+        zones = resp.data.get("zones")
+        if not isinstance(zones, list) or not zones:
+            continue
+        # A method whose returned threshold differs from the input derives it
+        # from a (field-)test — a direct threshold can't be set for it.
+        derived = resp.data.get("lactateThreshold")
+        if derived is None:
+            derived = resp.data.get("thresholdSpeed")
+        derives = (
+            isinstance(derived, (int, float))
+            and threshold > 0
+            and abs(float(derived) - threshold) / threshold > 0.02
+        )
+        found.append(
+            {
+                "method": method,
+                "zone_count": len(zones),
+                "labels": [z.get("label") for z in zones if isinstance(z, dict)],
+                "derives_threshold": bool(derives),
+            }
+        )
+    return found
+
+
+async def tp_get_zone_methods(metric: str | None = None) -> dict[str, Any]:
+    """List available zone-calculation methods, each with its zone count and
+    zone labels (the method's fingerprint).
+
+    Args:
+        metric: ``power``, ``heartrate``, or ``speed``. Omit to probe all three.
+
+    Returns:
+        ``{"methods": {metric: [{method, zone_count, labels,
+        derives_threshold}, ...]}}`` or an error envelope.
+    """
+    if metric is not None and metric not in METRICS:
+        return {
+            "isError": True,
+            "error_code": "VALIDATION_ERROR",
+            "message": f"metric must be one of {METRICS} or omitted.",
+        }
+    metrics = (metric,) if metric else METRICS
+
+    async with TPClient() as client:
+        user_data = await client._get_user_data()
+        user_id = (user_data or {}).get("userId")
+        if not isinstance(user_id, int):
+            return {
+                "isError": True,
+                "error_code": "AUTH_INVALID",
+                "message": "Could not get user id. Re-authenticate.",
+            }
+        methods = {m: await _probe_metric(client, user_id, m) for m in metrics}
+
+    return {"methods": methods}

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -62,6 +62,7 @@ class TestListTools:
             "tp_update_ftp",
             "tp_update_hr_zones",
             "tp_update_speed_zones",
+            "tp_create_zones",
             "tp_update_nutrition",
             "tp_get_pool_length_settings",
             "tp_log_metrics",

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -56,6 +56,7 @@ class TestListTools:
             "tp_add_workout_comment",
             "tp_validate_structure",
             "tp_get_workout_types",
+            "tp_get_zone_methods",
             "tp_get_atp",
             "tp_get_weekly_summary",
             "tp_get_athlete_settings",

--- a/tests/test_tools/test_settings.py
+++ b/tests/test_tools/test_settings.py
@@ -219,6 +219,7 @@ class TestUpdateHRZones:
         assert payload[0]["maximumHeartRate"] == 195           # updated anchor
         after = [(z["minimum"], z["maximum"]) for z in payload[0]["zones"]]
         assert after == before                                 # bands unchanged
+        assert "only anchors updated" in result.get("note", "")  # method-aware warning
 
     @pytest.mark.asyncio
     async def test_no_params_rejected(self):
@@ -244,6 +245,13 @@ class TestUpdateSpeedZones:
 
     def test_parse_swim_pace(self):
         assert abs(_parse_pace_to_ms("1:45/100m", is_swim=True) - 0.952) < 0.01
+
+    def test_parse_pace_honours_unit(self):
+        import pytest as _pytest
+        assert abs(_parse_pace_to_ms("5:00/mi") - 1609.344 / 300) < 0.01      # miles
+        assert abs(_parse_pace_to_ms("1:50/100yd", is_swim=True) - 91.44 / 110) < 0.01
+        with _pytest.raises(ValueError):
+            _parse_pace_to_ms("5:00/furlong")                                  # unknown unit
 
     @pytest.mark.asyncio
     async def test_run_preserves_method_and_distance(self):

--- a/tests/test_tools/test_settings.py
+++ b/tests/test_tools/test_settings.py
@@ -387,3 +387,68 @@ class TestCalculatePath:
             result = await tp_update_speed_zones(swim_threshold_pace="1:45/100m")
         assert result["error_code"] == "TEST_BASED_METHOD"
         mi.put.assert_not_called()                       # nothing written
+
+
+# ── tp_create_zones (new per-sport set) ──────────────────────────────────────
+
+import pytest as _pytest  # noqa: E402
+from tp_mcp.tools.settings import tp_create_zones  # noqa: E402
+
+_CALC7 = [{"label": str(i + 1), "minimum": i, "maximum": i + 1,
+           "minimumAsDouble": float(i), "maximumAsDouble": float(i + 1)} for i in range(7)]
+
+
+@_pytest.mark.asyncio
+async def test_create_zones_power_builds_new_group():
+    # athlete has only the default (wtid 0) power set → bike (wtid 2) is absent
+    settings = {"powerZones": [_pzones(250, 0, 1)]}
+    p, mi = _client(settings, calc_zones=_CALC7)
+    try:
+        out = await tp_create_zones(metric="power", workout_type="bike",
+                                    calculation_method=4, threshold=260)
+    finally:
+        p.stop()
+    assert out["success"] and out["created"]
+    assert out["workout_type_id"] == 2 and out["calculation_method"] == 4
+    # PUT received the full array INCLUDING the new wtid-2 group
+    put_body = mi.put.call_args[1]["json"] if mi.put.call_args[1] else mi.put.call_args[0][1]
+    assert {g["workoutTypeId"] for g in put_body} == {0, 2}
+    new = next(g for g in put_body if g["workoutTypeId"] == 2)
+    assert new["calculationMethod"] == 4 and new["threshold"] == 260 and len(new["zones"]) == 7
+
+
+@_pytest.mark.asyncio
+async def test_create_zones_refuses_when_set_exists():
+    settings = {"powerZones": [_pzones(250, 2, 4)]}   # bike set already present
+    p, _ = _client(settings, calc_zones=_CALC7)
+    try:
+        out = await tp_create_zones(metric="power", workout_type="bike",
+                                    calculation_method=4, threshold=260)
+    finally:
+        p.stop()
+    assert out["isError"] and out["error_code"] == "ZONES_EXIST"
+
+
+@_pytest.mark.asyncio
+async def test_create_zones_speed_needs_pace():
+    p, _ = _client({"speedZones": []}, calc_zones=_CALC7)
+    try:
+        out = await tp_create_zones(metric="speed", workout_type="run",
+                                    calculation_method=2)
+    finally:
+        p.stop()
+    assert out["isError"] and out["error_code"] == "VALIDATION_ERROR"
+
+
+@_pytest.mark.asyncio
+async def test_create_zones_speed_from_pace():
+    p, mi = _client({"speedZones": []}, calc_zones=_CALC7)
+    try:
+        out = await tp_create_zones(metric="speed", workout_type="run",
+                                    calculation_method=2, pace="4:00/km")
+    finally:
+        p.stop()
+    assert out["success"] and out["workout_type_id"] == 3
+    put_body = mi.put.call_args[1]["json"] if mi.put.call_args[1] else mi.put.call_args[0][1]
+    new = next(g for g in put_body if g["workoutTypeId"] == 3)
+    assert new["calculationMethod"] == 2 and len(new["zones"]) == 7

--- a/tests/test_tools/test_settings.py
+++ b/tests/test_tools/test_settings.py
@@ -19,15 +19,20 @@ from tp_mcp.tools.settings import (
 _OK = APIResponse(success=True, data=None)
 
 
-def _client(settings):
-    """Build a patched TPClient whose GET returns `settings` and PUT succeeds.
-    Returns (patcher, mock_instance)."""
+def _client(settings, calc_zones=None):
+    """Patched TPClient: GET returns `settings`, PUT succeeds. `calc_zones` (if
+    given) is returned by the zone-calculator POST (method-correct path);
+    otherwise the calculator returns no zones and the code falls back to the
+    proportional rescale. Returns (patcher, mock_instance)."""
     p = patch("tp_mcp.tools.settings.TPClient")
     mock_client = p.start()
     mi = AsyncMock()
     mi.ensure_athlete_id = AsyncMock(return_value=123)
+    mi._get_user_data = AsyncMock(return_value={"userId": 1135463})
     mi.get = AsyncMock(return_value=APIResponse(success=True, data=settings))
     mi.put = AsyncMock(return_value=_OK)
+    calc_data = {"zones": calc_zones} if calc_zones is not None else {}
+    mi.post = AsyncMock(return_value=APIResponse(success=True, data=calc_data))
     mock_client.return_value.__aenter__.return_value = mi
     return p, mi
 
@@ -106,7 +111,7 @@ class TestUpdateFTP:
         finally:
             p.stop()
         assert result["success"] and result["workout_type_id"] == 2
-        assert result["calculation_method"] == 1 and result.get("note") is None
+        assert result["calculation_method"] == 1 and result["method_correct"] is False
         payload = mi.put.call_args[1]["json"]
         assert payload[1]["threshold"] == 300 and payload[1]["workoutTypeId"] == 2
         assert payload[0] == settings["powerZones"][0]   # default set untouched
@@ -219,7 +224,7 @@ class TestUpdateHRZones:
         assert payload[0]["maximumHeartRate"] == 195           # updated anchor
         after = [(z["minimum"], z["maximum"]) for z in payload[0]["zones"]]
         assert after == before                                 # bands unchanged
-        assert "only anchors updated" in result.get("note", "")  # method-aware warning
+        assert "recompute in TP" in result.get("note", "")  # method-aware warning (fallback)
 
     @pytest.mark.asyncio
     async def test_no_params_rejected(self):
@@ -304,3 +309,59 @@ class TestUpdateSpeedZones:
     @pytest.mark.asyncio
     async def test_no_params_rejected(self):
         assert (await tp_update_speed_zones())["isError"] is True
+
+
+# ── Method-correct path: TP zone calculator ──────────────────────────────────
+
+class TestCalculatePath:
+    @pytest.mark.asyncio
+    async def test_ftp_uses_calculator_when_available(self):
+        settings = {"powerZones": [_pzones(280, 0, 5), _pzones(250, 2, 1)]}
+        calc = [{"label": str(i + 1), "minimum": i, "maximum": (i + 1) * 50} for i in range(6)]
+        p, mi = _client(settings, calc_zones=calc)
+        try:
+            result = await tp_update_ftp(ftp=300, workout_type="bike")
+        finally:
+            p.stop()
+        assert result["success"] and result["method_correct"] is True
+        # calculator output is used verbatim (mapped), NOT a proportional rescale
+        payload = mi.put.call_args[1]["json"]
+        assert payload[1]["zones"] == calc and payload[1]["threshold"] == 300
+        # calculator POST was hit with the set's method as zoneType
+        call = mi.post.call_args
+        assert "/power/calculate/1" in call[0][0]
+        assert call[1]["json"]["LTPower"] == 300 and call[1]["json"]["zoneType"] == 1
+
+    @pytest.mark.asyncio
+    async def test_hr_max_based_method_recomputed_by_calculator(self):
+        # The case proportional rescale gets WRONG: a max-based HR set. With the
+        # calculator, changing max_hr recomputes bands method-correctly.
+        settings = {"heartRateZones": [_hzones(160, 0, 3)]}
+        calc = [{"label": f"Z{i}", "minimum": i * 20, "maximum": (i + 1) * 20} for i in range(7)]
+        p, mi = _client(settings, calc_zones=calc)
+        try:
+            result = await tp_update_hr_zones(max_hr=195)   # no threshold change
+        finally:
+            p.stop()
+        assert result["method_correct"] is True
+        payload = mi.put.call_args[1]["json"]
+        assert payload[0]["zones"] == calc                  # bands recomputed, not stale
+        assert payload[0]["maximumHeartRate"] == 195
+        body = mi.post.call_args[1]["json"]
+        assert body["maxHR"] == 195 and body["LTHR"] == 160  # both anchors sent
+
+    @pytest.mark.asyncio
+    async def test_swim_distance_time_calculator_keeps_distance(self):
+        settings = {"speedZones": [_szones(0.83, 1, 3, 5)]}
+        calc = [{"label": f"Z{i}", "minimumAsDouble": i * 0.1, "maximumAsDouble": (i + 1) * 0.1}
+                for i in range(7)]
+        p, mi = _client(settings, calc_zones=calc)
+        try:
+            result = await tp_update_speed_zones(swim_threshold_pace="1:45/100m")
+        finally:
+            p.stop()
+        upd = result["updated"][0]
+        assert upd["method_correct"] is True and upd["distance"] == 5
+        body = mi.post.call_args[1]["json"]
+        assert body["zoneType"] == 3 and body["distance"] == 5   # Distance/Time preserved
+        assert "speed" in body

--- a/tests/test_tools/test_settings.py
+++ b/tests/test_tools/test_settings.py
@@ -365,3 +365,25 @@ class TestCalculatePath:
         body = mi.post.call_args[1]["json"]
         assert body["zoneType"] == 3 and body["distance"] == 5   # Distance/Time preserved
         assert "speed" in body
+
+    @pytest.mark.asyncio
+    async def test_test_based_method_is_refused_not_silently_wrong(self):
+        # Distance/Time: the calculator DERIVES a threshold from the input (as a
+        # test result), far from what was asked. The connector must REFUSE rather
+        # than silently store a threshold the coach didn't intend, and write nothing.
+        settings = {"speedZones": [_szones(0.83, 1, 3, 5)]}
+        with patch("tp_mcp.tools.settings.TPClient") as mc:
+            mi = AsyncMock()
+            mi.ensure_athlete_id = AsyncMock(return_value=123)
+            mi._get_user_data = AsyncMock(return_value={"userId": 1})
+            mi.get = AsyncMock(return_value=APIResponse(success=True, data=settings))
+            mi.put = AsyncMock(return_value=_OK)
+            calc = [{"label": f"Z{i}", "minimumAsDouble": i * 0.1, "maximumAsDouble": (i + 1) * 0.1}
+                    for i in range(7)]
+            # input 1:45/100m ≈ 0.952 m/s, but calculator derives 0.60 (test-based)
+            mi.post = AsyncMock(return_value=APIResponse(
+                success=True, data={"zones": calc, "thresholdSpeed": 0.60}))
+            mc.return_value.__aenter__.return_value = mi
+            result = await tp_update_speed_zones(swim_threshold_pace="1:45/100m")
+        assert result["error_code"] == "TEST_BASED_METHOD"
+        mi.put.assert_not_called()                       # nothing written

--- a/tests/test_tools/test_settings.py
+++ b/tests/test_tools/test_settings.py
@@ -1,4 +1,4 @@
-"""Tests for athlete settings tools."""
+"""Tests for athlete settings zone tools (method-agnostic, per-sport)."""
 
 from unittest.mock import AsyncMock, patch
 
@@ -7,6 +7,8 @@ import pytest
 from tp_mcp.client.http import APIResponse
 from tp_mcp.tools.settings import (
     _parse_pace_to_ms,
+    _rescaled_group,
+    _select_group_index,
     tp_get_athlete_settings,
     tp_update_ftp,
     tp_update_hr_zones,
@@ -14,252 +16,283 @@ from tp_mcp.tools.settings import (
     tp_update_speed_zones,
 )
 
+_OK = APIResponse(success=True, data=None)
+
+
+def _client(settings):
+    """Build a patched TPClient whose GET returns `settings` and PUT succeeds.
+    Returns (patcher, mock_instance)."""
+    p = patch("tp_mcp.tools.settings.TPClient")
+    mock_client = p.start()
+    mi = AsyncMock()
+    mi.ensure_athlete_id = AsyncMock(return_value=123)
+    mi.get = AsyncMock(return_value=APIResponse(success=True, data=settings))
+    mi.put = AsyncMock(return_value=_OK)
+    mock_client.return_value.__aenter__.return_value = mi
+    return p, mi
+
+
+def _pzones(thr, wtid, method, n=6, ceiling=2000):
+    step = thr // n
+    zones = [{"label": str(i + 1), "minimum": i * step, "maximum": (i + 1) * step} for i in range(n)]
+    zones[-1]["maximum"] = ceiling
+    return {"zoneCalculatorId": None, "threshold": thr, "calculationMethod": method,
+            "workoutTypeId": wtid, "zones": zones}
+
+
+# ── pure helpers ──────────────────────────────────────────────────────────────
+
+def test_select_group_index_exact_then_fallback():
+    groups = [{"workoutTypeId": 0}, {"workoutTypeId": 2}]
+    assert _select_group_index(groups, 2) == (1, None)
+    idx, note = _select_group_index(groups, 3)          # missing → default(0)
+    assert idx == 0 and "default" in note
+    idx2, note2 = _select_group_index([{"workoutTypeId": 5}], 3)  # no default → first
+    assert idx2 == 0 and note2
+
+
+def test_rescaled_group_preserves_all_fields_and_ceiling():
+    g = {"threshold": 200, "calculationMethod": 7, "distance": 5, "zoneCalculatorId": "x",
+         "workoutTypeId": 1, "zones": [{"label": "Z1", "minimum": 0, "maximum": 100},
+                                       {"label": "Z2", "minimum": 101, "maximum": 1000}]}
+    new, err = _rescaled_group(g, 220, integer=True)
+    assert err is None
+    assert new["calculationMethod"] == 7 and new["distance"] == 5 and new["zoneCalculatorId"] == "x"
+    assert new["threshold"] == 220
+    assert new["zones"][0]["maximum"] == 110          # 100 * 1.1
+    assert new["zones"][-1]["maximum"] == 1000        # ceiling preserved (not scaled)
+
+
+def test_rescaled_group_rejects_zero_and_malformed():
+    assert _rescaled_group({"threshold": 0, "zones": []}, 200, integer=True)[0] is None
+    bad = {"threshold": 200, "zones": [{"maximum": "x"}, {"maximum": 1000}]}
+    assert _rescaled_group(bad, 220, integer=True)[0] is None
+
+
+# ── get / nutrition (unchanged) ───────────────────────────────────────────────
 
 class TestGetAthleteSettings:
     @pytest.mark.asyncio
     async def test_success(self):
-        response = APIResponse(success=True, data={"threshold": 280, "zones": []})
-        with patch("tp_mcp.tools.settings.TPClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
-            mock_instance.get = AsyncMock(return_value=response)
-            mock_client.return_value.__aenter__.return_value = mock_instance
-
+        p, _ = _client({"threshold": 280, "zones": []})
+        try:
             result = await tp_get_athlete_settings()
+        finally:
+            p.stop()
         assert "settings" in result
-
-
-class TestUpdateFTP:
-    @pytest.mark.asyncio
-    async def test_coggan_zones_320w(self):
-        """FTP 320W should scale the existing default power zone model."""
-        response = APIResponse(success=True, data=None)
-        settings = {
-            "powerZones": [
-                {
-                    "zoneCalculatorId": None,
-                    "threshold": 280,
-                    "calculationMethod": 5,
-                    "workoutTypeId": 0,
-                    "zones": [
-                        {"label": "Recovery", "minimum": 0, "maximum": 156},
-                        {"label": "Endurance", "minimum": 157, "maximum": 212},
-                        {"label": "Tempo", "minimum": 213, "maximum": 254},
-                        {"label": "Threshold", "minimum": 255, "maximum": 296},
-                        {"label": "VO2 Max", "minimum": 297, "maximum": 338},
-                        {"label": "Anaerobic Capacity", "minimum": 339, "maximum": 2000},
-                    ],
-                },
-                {
-                    "zoneCalculatorId": None,
-                    "threshold": 300,
-                    "calculationMethod": 4,
-                    "workoutTypeId": 3,
-                    "zones": [{"label": str(i), "minimum": i, "maximum": i} for i in range(1, 7)],
-                },
-            ],
-        }
-        with patch("tp_mcp.tools.settings.TPClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
-            mock_instance.get = AsyncMock(return_value=APIResponse(success=True, data=settings))
-            mock_instance.put = AsyncMock(return_value=response)
-            mock_client.return_value.__aenter__.return_value = mock_instance
-
-            result = await tp_update_ftp(ftp=320)
-
-        assert result["success"] is True
-        assert result["ftp"] == 320
-        zones = result["zones"]
-        assert len(zones) == 6
-        # Existing maxima [156, 212, 254, 296, 338] are scaled from 280W to 320W
-        assert zones[0]["minimum"] == 0
-        assert zones[0]["maximum"] == 178
-        assert zones[1]["minimum"] == 179
-        assert zones[1]["maximum"] == 242
-        assert zones[3]["minimum"] == 291
-        assert zones[3]["maximum"] == 338
-        assert zones[5]["minimum"] == 387
-        assert zones[5]["maximum"] == 2000
-
-        payload = mock_instance.put.call_args[1]["json"]
-        assert len(payload) == 2
-        assert payload[0]["threshold"] == 320
-        assert payload[0]["workoutTypeId"] == 0
-        assert payload[0]["zones"] == zones
-        assert payload[1] == settings["powerZones"][1]
-
-    @pytest.mark.asyncio
-    async def test_ftp_fallback_when_threshold_is_zero(self):
-        """FTP update uses hardcoded ratios when current_threshold is 0."""
-        response = APIResponse(success=True, data=None)
-        settings = {
-            "powerZones": [
-                {
-                    "threshold": 0,
-                    "calculationMethod": 5,
-                    "workoutTypeId": 0,
-                    "zones": [
-                        {"label": "Recovery", "minimum": 0, "maximum": 156},
-                        {"label": "Endurance", "minimum": 157, "maximum": 212},
-                        {"label": "Tempo", "minimum": 213, "maximum": 254},
-                        {"label": "Threshold", "minimum": 255, "maximum": 296},
-                        {"label": "VO2 Max", "minimum": 297, "maximum": 338},
-                        {"label": "Anaerobic Capacity", "minimum": 339, "maximum": 2000},
-                    ],
-                }
-            ],
-        }
-        with patch("tp_mcp.tools.settings.TPClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
-            mock_instance.get = AsyncMock(return_value=APIResponse(success=True, data=settings))
-            mock_instance.put = AsyncMock(return_value=response)
-            mock_client.return_value.__aenter__.return_value = mock_instance
-
-            result = await tp_update_ftp(ftp=200)
-
-        assert result["success"] is True
-        assert result["ftp"] == 200
-        zones = result["zones"]
-        assert len(zones) == 6
-        # Hardcoded ratios: 0.56, 0.76, 0.91, 1.06, 1.21
-        assert zones[0]["maximum"] == round(200 * 0.56)
-        assert zones[1]["maximum"] == round(200 * 0.76)
-        assert zones[2]["maximum"] == round(200 * 0.91)
-        assert zones[3]["maximum"] == round(200 * 1.06)
-        assert zones[4]["maximum"] == round(200 * 1.21)
-        assert zones[5]["maximum"] == 2000
-
-    @pytest.mark.asyncio
-    async def test_ftp_fallback_when_zones_malformed(self):
-        """FTP update uses hardcoded ratios when existing zones have non-numeric maxima."""
-        response = APIResponse(success=True, data=None)
-        settings = {
-            "powerZones": [
-                {
-                    "threshold": 280,
-                    "calculationMethod": 5,
-                    "workoutTypeId": 0,
-                    "zones": [
-                        {"label": "Recovery", "minimum": 0, "maximum": "bad"},
-                        {"label": "Endurance", "minimum": 157, "maximum": 212},
-                        {"label": "Tempo", "minimum": 213, "maximum": 254},
-                        {"label": "Threshold", "minimum": 255, "maximum": 296},
-                        {"label": "VO2 Max", "minimum": 297, "maximum": 338},
-                        {"label": "Anaerobic Capacity", "minimum": 339, "maximum": 2000},
-                    ],
-                }
-            ],
-        }
-        with patch("tp_mcp.tools.settings.TPClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
-            mock_instance.get = AsyncMock(return_value=APIResponse(success=True, data=settings))
-            mock_instance.put = AsyncMock(return_value=response)
-            mock_client.return_value.__aenter__.return_value = mock_instance
-
-            result = await tp_update_ftp(ftp=300)
-
-        assert result["success"] is True
-        zones = result["zones"]
-        assert len(zones) == 6
-        # Falls back to hardcoded ratios: 0.56, 0.76, 0.91, 1.06, 1.21
-        assert zones[0]["maximum"] == round(300 * 0.56)
-        assert zones[1]["maximum"] == round(300 * 0.76)
-        assert zones[2]["maximum"] == round(300 * 0.91)
-        assert zones[3]["maximum"] == round(300 * 1.06)
-        assert zones[4]["maximum"] == round(300 * 1.21)
-        assert zones[5]["maximum"] == 2000
-
-    @pytest.mark.asyncio
-    async def test_ftp_validation(self):
-        result = await tp_update_ftp(ftp=0)
-        assert result["isError"] is True
-        assert result["error_code"] == "VALIDATION_ERROR"
-
-
-class TestUpdateHRZones:
-    @pytest.mark.asyncio
-    async def test_threshold_update(self):
-        response = APIResponse(success=True, data=None)
-        with patch("tp_mcp.tools.settings.TPClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
-            mock_instance.put = AsyncMock(return_value=response)
-            mock_client.return_value.__aenter__.return_value = mock_instance
-
-            result = await tp_update_hr_zones(threshold_hr=165)
-
-        assert result["success"] is True
-        payload = mock_instance.put.call_args[1]["json"]
-        assert payload["threshold"] == 165
-
-    @pytest.mark.asyncio
-    async def test_max_hr_only(self):
-        response = APIResponse(success=True, data=None)
-        with patch("tp_mcp.tools.settings.TPClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
-            mock_instance.put = AsyncMock(return_value=response)
-            mock_client.return_value.__aenter__.return_value = mock_instance
-
-            result = await tp_update_hr_zones(max_hr=195)
-
-        assert result["success"] is True
-
-    @pytest.mark.asyncio
-    async def test_no_params_rejected(self):
-        result = await tp_update_hr_zones()
-        assert result["isError"] is True
-
-
-class TestUpdateSpeedZones:
-    def test_parse_run_pace(self):
-        """4:30/km = 1000m / 270s = 3.704 m/s."""
-        speed = _parse_pace_to_ms("4:30/km")
-        assert abs(speed - 3.704) < 0.01
-
-    def test_parse_swim_pace(self):
-        """1:45/100m = 100m / 105s = 0.952 m/s."""
-        speed = _parse_pace_to_ms("1:45/100m", is_swim=True)
-        assert abs(speed - 0.952) < 0.01
-
-    @pytest.mark.asyncio
-    async def test_run_pace_update(self):
-        response = APIResponse(success=True, data=None)
-        with patch("tp_mcp.tools.settings.TPClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
-            mock_instance.put = AsyncMock(return_value=response)
-            mock_client.return_value.__aenter__.return_value = mock_instance
-
-            result = await tp_update_speed_zones(run_threshold_pace="4:30/km")
-
-        assert result["success"] is True
-
-    @pytest.mark.asyncio
-    async def test_invalid_pace_format(self):
-        result = await tp_update_speed_zones(run_threshold_pace="invalid")
-        assert result["isError"] is True
-
-    @pytest.mark.asyncio
-    async def test_no_params_rejected(self):
-        result = await tp_update_speed_zones()
-        assert result["isError"] is True
 
 
 class TestUpdateNutrition:
     @pytest.mark.asyncio
     async def test_success(self):
-        response = APIResponse(success=True, data=None)
         with patch("tp_mcp.tools.settings.TPClient") as mock_client:
-            mock_instance = AsyncMock()
-            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
-            mock_instance.post = AsyncMock(return_value=response)
-            mock_client.return_value.__aenter__.return_value = mock_instance
-
+            mi = AsyncMock()
+            mi.ensure_athlete_id = AsyncMock(return_value=123)
+            mi.post = AsyncMock(return_value=_OK)
+            mock_client.return_value.__aenter__.return_value = mi
             result = await tp_update_nutrition(planned_calories=2500)
+        assert result["success"] is True and result["planned_calories"] == 2500
 
-        assert result["success"] is True
-        assert result["planned_calories"] == 2500
+
+# ── FTP ───────────────────────────────────────────────────────────────────────
+
+class TestUpdateFTP:
+    @pytest.mark.asyncio
+    async def test_targets_bike_set_and_preserves_method(self):
+        settings = {"powerZones": [_pzones(280, 0, 5), _pzones(250, 2, 1)]}
+        p, mi = _client(settings)
+        try:
+            result = await tp_update_ftp(ftp=300, workout_type="bike")
+        finally:
+            p.stop()
+        assert result["success"] and result["workout_type_id"] == 2
+        assert result["calculation_method"] == 1 and result.get("note") is None
+        payload = mi.put.call_args[1]["json"]
+        assert payload[1]["threshold"] == 300 and payload[1]["workoutTypeId"] == 2
+        assert payload[0] == settings["powerZones"][0]   # default set untouched
+
+    @pytest.mark.asyncio
+    async def test_default_bike_falls_back_to_default_set(self):
+        settings = {"powerZones": [_pzones(280, 0, 5)]}   # no bike set
+        p, mi = _client(settings)
+        try:
+            result = await tp_update_ftp(ftp=320)          # default workout_type="bike"
+        finally:
+            p.stop()
+        assert result["success"] and result["workout_type_id"] == 0 and result.get("note")
+        zones = result["zones"]
+        assert zones[0]["maximum"] == round(settings["powerZones"][0]["zones"][0]["maximum"] * 320 / 280)
+        assert zones[-1]["maximum"] == 2000              # ceiling preserved
+
+    @pytest.mark.asyncio
+    async def test_coggan_fallback_on_zero_threshold(self):
+        settings = {"powerZones": [_pzones(0, 0, 5)]}
+        p, _ = _client(settings)
+        try:
+            result = await tp_update_ftp(ftp=200, workout_type="default")
+        finally:
+            p.stop()
+        assert result["success"]
+        assert result["zones"][0]["maximum"] == round(200 * 0.56)
+        assert result["zones"][-1]["maximum"] == 2000
+
+    @pytest.mark.asyncio
+    async def test_coggan_fallback_on_malformed(self):
+        s = _pzones(280, 0, 5)
+        s["zones"][0]["maximum"] = "bad"
+        p, _ = _client({"powerZones": [s]})
+        try:
+            result = await tp_update_ftp(ftp=300, workout_type="default")
+        finally:
+            p.stop()
+        assert result["success"] and result["zones"][0]["maximum"] == round(300 * 0.56)
+
+    @pytest.mark.asyncio
+    async def test_targets_xcski_power_set(self):
+        # wtid 11 = XCSki (from the connector's SPORT_TYPE_MAP) — power zones for
+        # skiing must be settable, not just bike/run.
+        settings = {"powerZones": [_pzones(280, 0, 5), _pzones(200, 11, 5)]}
+        p, mi = _client(settings)
+        try:
+            result = await tp_update_ftp(ftp=210, workout_type="xcski")
+        finally:
+            p.stop()
+        assert result["success"] and result["workout_type_id"] == 11
+        payload = mi.put.call_args[1]["json"]
+        assert payload[1]["threshold"] == 210 and payload[1]["workoutTypeId"] == 11
+        assert payload[0] == settings["powerZones"][0]   # default untouched
+
+    @pytest.mark.asyncio
+    async def test_validation(self):
+        assert (await tp_update_ftp(ftp=0))["error_code"] == "VALIDATION_ERROR"
+
+
+# ── HR ────────────────────────────────────────────────────────────────────────
+
+def _hzones(thr, wtid, method):
+    return {"zoneCalculatorId": None, "threshold": thr, "maximumHeartRate": 190,
+            "restingHeartRate": 50, "calculationMethod": method, "workoutTypeId": wtid,
+            "zones": [{"label": f"Z{i}", "minimum": 100 + i * 10, "maximum": 110 + i * 10}
+                      for i in range(7)]}
+
+
+class TestUpdateHRZones:
+    @pytest.mark.asyncio
+    async def test_threshold_preserves_method_and_anchors(self):
+        settings = {"heartRateZones": [_hzones(160, 0, 3)]}
+        p, mi = _client(settings)
+        try:
+            result = await tp_update_hr_zones(threshold_hr=170)   # general → wtid 0
+        finally:
+            p.stop()
+        assert result["success"] and result["calculation_method"] == 3
+        payload = mi.put.call_args[1]["json"]
+        assert isinstance(payload, list) and payload[0]["threshold"] == 170
+        assert payload[0]["calculationMethod"] == 3            # method preserved
+        assert payload[0]["maximumHeartRate"] == 190           # anchor preserved
+
+    @pytest.mark.asyncio
+    async def test_targets_run_set(self):
+        settings = {"heartRateZones": [_hzones(160, 0, 3), _hzones(165, 3, 2)]}
+        p, mi = _client(settings)
+        try:
+            result = await tp_update_hr_zones(threshold_hr=175, workout_type="run")
+        finally:
+            p.stop()
+        assert result["workout_type_id"] == 3 and result["calculation_method"] == 2
+        payload = mi.put.call_args[1]["json"]
+        assert payload[1]["threshold"] == 175
+        assert payload[0] == settings["heartRateZones"][0]     # default untouched
+
+    @pytest.mark.asyncio
+    async def test_max_only_keeps_threshold_and_bands(self):
+        settings = {"heartRateZones": [_hzones(160, 0, 3)]}
+        before = [(z["minimum"], z["maximum"]) for z in settings["heartRateZones"][0]["zones"]]
+        p, mi = _client(settings)
+        try:
+            result = await tp_update_hr_zones(max_hr=195)
+        finally:
+            p.stop()
+        assert result["success"]
+        payload = mi.put.call_args[1]["json"]
+        assert payload[0]["threshold"] == 160                  # unchanged
+        assert payload[0]["maximumHeartRate"] == 195           # updated anchor
+        after = [(z["minimum"], z["maximum"]) for z in payload[0]["zones"]]
+        assert after == before                                 # bands unchanged
+
+    @pytest.mark.asyncio
+    async def test_no_params_rejected(self):
+        assert (await tp_update_hr_zones())["isError"] is True
+
+    @pytest.mark.asyncio
+    async def test_invalid_workout_type_rejected(self):
+        assert (await tp_update_hr_zones(threshold_hr=160, workout_type="xc"))["error_code"] == "VALIDATION_ERROR"
+
+
+# ── Speed / pace (incl. Distance-Time preservation) ───────────────────────────
+
+def _szones(thr, wtid, method, distance):
+    return {"zoneCalculatorId": None, "threshold": thr, "calculationMethod": method,
+            "distance": distance, "workoutTypeId": wtid,
+            "zones": [{"label": f"Z{i}", "minimum": thr * (0.3 + 0.1 * i),
+                       "maximum": thr * (0.4 + 0.1 * i)} for i in range(7)]}
+
+
+class TestUpdateSpeedZones:
+    def test_parse_run_pace(self):
+        assert abs(_parse_pace_to_ms("4:30/km") - 3.704) < 0.01
+
+    def test_parse_swim_pace(self):
+        assert abs(_parse_pace_to_ms("1:45/100m", is_swim=True) - 0.952) < 0.01
+
+    @pytest.mark.asyncio
+    async def test_run_preserves_method_and_distance(self):
+        settings = {"speedZones": [_szones(3.7, 3, 2, 0)]}
+        p, mi = _client(settings)
+        try:
+            result = await tp_update_speed_zones(run_threshold_pace="4:30/km")
+        finally:
+            p.stop()
+        assert result["success"]
+        upd = result["updated"][0]
+        assert upd["sport"] == "run" and upd["workout_type_id"] == 3
+        assert upd["calculation_method"] == 2 and upd["distance"] == 0
+        payload = mi.put.call_args[1]["json"]
+        assert abs(payload[0]["threshold"] - 3.704) < 0.01
+
+    @pytest.mark.asyncio
+    async def test_swim_distance_time_set_is_preserved(self):
+        # The user's concern: a swim set on Distance/Time (method 3, distance>0)
+        # must keep its method AND distance when only the threshold pace changes.
+        settings = {"speedZones": [_szones(3.7, 3, 2, 0), _szones(0.83, 1, 3, 5)]}
+        p, mi = _client(settings)
+        try:
+            result = await tp_update_speed_zones(swim_threshold_pace="1:45/100m")
+        finally:
+            p.stop()
+        upd = result["updated"][0]
+        assert upd["sport"] == "swim" and upd["workout_type_id"] == 1
+        assert upd["calculation_method"] == 3 and upd["distance"] == 5   # Distance/Time intact
+        payload = mi.put.call_args[1]["json"]
+        assert payload[1]["calculationMethod"] == 3 and payload[1]["distance"] == 5
+        assert payload[0] == settings["speedZones"][0]                   # run set untouched
+
+    @pytest.mark.asyncio
+    async def test_run_and_swim_single_put(self):
+        settings = {"speedZones": [_szones(3.7, 3, 2, 0), _szones(0.83, 1, 3, 5)]}
+        p, mi = _client(settings)
+        try:
+            result = await tp_update_speed_zones(run_threshold_pace="4:30/km",
+                                                 swim_threshold_pace="1:45/100m")
+        finally:
+            p.stop()
+        assert len(result["updated"]) == 2
+        assert mi.put.await_count == 1                                   # both in ONE PUT
+
+    @pytest.mark.asyncio
+    async def test_invalid_pace_format(self):
+        assert (await tp_update_speed_zones(run_threshold_pace="invalid"))["isError"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_params_rejected(self):
+        assert (await tp_update_speed_zones())["isError"] is True

--- a/tests/test_tools/test_zone_methods.py
+++ b/tests/test_tools/test_zone_methods.py
@@ -1,0 +1,111 @@
+"""Tests for tp_get_zone_methods — method discovery via the zone calculator."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tp_mcp.client.http import APIResponse
+from tp_mcp.tools.zone_methods import tp_get_zone_methods
+
+
+def _zones(labels):
+    return [{"label": label, "minimum": 0, "maximum": 1} for label in labels]
+
+
+def _client(responses):
+    """Patch TPClient so calculate POSTs are answered from `responses`, keyed by
+    (metric, method) → data dict (or None for an error/skip). _get_user_data
+    returns a userId. Returns (patcher, mock_instance)."""
+    p = patch("tp_mcp.tools.zone_methods.TPClient")
+    mock_client = p.start()
+    mi = AsyncMock()
+    mi._get_user_data = AsyncMock(return_value={"userId": 1135463})
+
+    async def _post(endpoint, json=None):
+        parts = endpoint.split("/")
+        metric, method = parts[-3], int(parts[-1])
+        data = responses.get((metric, method))
+        if data is None:
+            return APIResponse(success=False, message="not found")
+        return APIResponse(success=True, data=data)
+
+    mi.post = AsyncMock(side_effect=_post)
+    mock_client.return_value.__aenter__.return_value = mi
+    return p, mi
+
+
+@pytest.mark.asyncio
+async def test_power_methods_fingerprinted_and_errors_skipped():
+    resp = {
+        # CTS: derives the threshold (225 != input 250) → derives_threshold True
+        ("power", 2): {"zones": _zones(["Recovery Miles", "Power Intervals"]),
+                       "lactateThreshold": 225},
+        # Coggan: threshold echoed (250) → derives_threshold False
+        ("power", 4): {"zones": _zones(["Zone 1 - Recovery/Walking",
+                                        "Zone 7 - Anaerobic Capacity"]),
+                       "lactateThreshold": 250},
+        # method 9 absent → POST errors → skipped
+    }
+    p, _ = _client(resp)
+    try:
+        out = await tp_get_zone_methods(metric="power")
+    finally:
+        p.stop()
+    methods = out["methods"]["power"]
+    by = {m["method"]: m for m in methods}
+    assert set(by) == {2, 4}                       # errored ints skipped
+    assert by[2]["derives_threshold"] is True
+    assert by[4]["derives_threshold"] is False
+    assert by[2]["zone_count"] == 2
+    assert "Power Intervals" in by[2]["labels"]
+    # probe order preserved (2 before 4)
+    assert [m["method"] for m in methods] == [2, 4]
+
+
+@pytest.mark.asyncio
+async def test_speed_uses_threshold_speed_field():
+    resp = {("speed", 3): {"zones": _zones(["Z1", "Z2"]), "thresholdSpeed": 3.2}}
+    p, _ = _client(resp)
+    try:
+        out = await tp_get_zone_methods(metric="speed")
+    finally:
+        p.stop()
+    m = out["methods"]["speed"][0]
+    assert m["method"] == 3
+    assert m["derives_threshold"] is True           # 3.2 != input 4.0
+
+
+@pytest.mark.asyncio
+async def test_all_metrics_when_metric_omitted():
+    resp = {
+        ("power", 1): {"zones": _zones(["1"]), "lactateThreshold": 250},
+        ("heartrate", 1): {"zones": _zones(["Z1"]), "lactateThreshold": 160},
+        ("speed", 2): {"zones": _zones(["Z1"]), "thresholdSpeed": 4.0},
+    }
+    p, _ = _client(resp)
+    try:
+        out = await tp_get_zone_methods()
+    finally:
+        p.stop()
+    assert set(out["methods"]) == {"power", "heartrate", "speed"}
+    assert out["methods"]["power"][0]["method"] == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_metric_rejected():
+    out = await tp_get_zone_methods(metric="cadence")
+    assert out["isError"] and out["error_code"] == "VALIDATION_ERROR"
+
+
+@pytest.mark.asyncio
+async def test_missing_user_id_is_auth_error():
+    p = patch("tp_mcp.tools.zone_methods.TPClient")
+    mock_client = p.start()
+    mi = AsyncMock()
+    mi._get_user_data = AsyncMock(return_value={})
+    mock_client.return_value.__aenter__.return_value = mi
+    try:
+        out = await tp_get_zone_methods(metric="power")
+    finally:
+        p.stop()
+    assert out["isError"] and out["error_code"] == "AUTH_INVALID"


### PR DESCRIPTION
## Per-sport zone management: update + create + method discovery

Single PR for the zone work discussed in #119 (supersedes #121, which is folded in here). Three parts, all method-correct via TrainingPeaks' own zone calculator, no hardcoded discovery:

### 1. Per-sport, method-correct updates — `tp_update_ftp` / `tp_update_hr_zones` / `tp_update_speed_zones`
Bugs fixed: `tp_update_ftp` wrote the default set (wtid 0) instead of the sport's; `tp_update_hr_zones` ignored `workout_type` (flat PUT → run-LTHR unreachable, method lost); `tp_update_speed_zones` dropped `distance`.
Approach: GET settings → locate the group by `workoutTypeId` (fallback to default with a note) → **deep-copy the whole group** so `calculationMethod`, `distance`, `zoneCalculatorId` ride through untouched → recompute bands with TP's calculator (`POST .../calculate/{method}`), proportional rescale as fallback (carries `method_correct`). Pace honours its unit (km/mi/100m/100yd). Any sport via the connector's `SPORT_TYPE_MAP`.

### 2. Create from scratch — `tp_create_zones`
For a sport that has **no** zone set yet (the updaters need an existing one). GET settings → ensure the set is absent (`ZONES_EXIST` otherwise) → compute bands for the **chosen** method (nothing to preserve when creating) → append the new group → PUT the full array. Verified live: TP's PUT accepts a brand-new group for a previously-absent `workoutTypeId` (byte-identical restore afterwards).

### 3. Method discovery — `tp_get_zone_methods`
TP has no endpoint listing zone-calculation methods, and settings store only the opaque `calculationMethod` int. But the calculator returns each zone's `label` and echoes the method → probing the int range fingerprints every method (count + labels) without hardcoding names. Returns `{method, zone_count, labels, derives_threshold}` per metric — also the natural source for choosing a method in (2).

### Shared: test-based methods
A method that **derives** its threshold from a test (Speed/Pace Distance/Time) can't be set/created from a plain threshold → `TEST_BASED_METHOD` (set up via a test in the TP UI). Detected uniformly (returned threshold ≠ input).

### Testing
`tests/test_tools/test_settings.py` (per-sport targeting, method preservation, calculate-first + proportional fallback, pace units, derived-threshold, `TEST_BASED_METHOD`, create + `ZONES_EXIST`), `tests/test_tools/test_zone_methods.py`. Gates green: `ruff check src/`, `mypy src/`, `pytest tests/`. The setters and create were verified live (incl. XCSki) with byte-identical restores.
