### PR TITLE
docs(workouts): keep rpe range at 0-10 in tp_create_workout docstring

### DIFF
--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -411,7 +411,7 @@ async def tp_create_workout(
         subtype_id: Optional workout subtype ID (e.g. Road Bike=3).
         tags: Optional comma-separated tags string.
         feeling: Optional TrainingPeaks feeling value (0-10).
-        rpe: Optional RPE score (1-10).
+        rpe: Optional RPE score (0-10).
         is_hidden: Optional to hide the workout to the athlete.
 
     Returns:


### PR DESCRIPTION
Follow-up to #88, which included an unrelated docstring edit changing the `rpe` range from `0-10` to `1-10`.

That contradicts:
- the validation `rpe: int | None = Field(default=None, ge=0, le=10)` (0 is valid)
- the shared `WORKOUT_RPE_DESCRIPTION` constant (still `0-10`)
- the `tp_update_workout` docstring (still `0-10`)

This restores `0-10` for consistency. Docstring-only, no functional change.