### PR TITLE
Fall back to encrypted file when keyring write fails (Windows blob-size limit)

### DIFF
--- a/src/tp_mcp/auth/storage.py
+++ b/src/tp_mcp/auth/storage.py
@@ -48,14 +48,22 @@ def store_credential(cookie: str) -> CredentialResult:
     # Always store in encrypted file first (reliable fallback)
     encrypted_result = store_credential_encrypted(cookie)
 
-    # Also try keyring if available (may fail due to app permissions)
+    # Also try keyring if available (may fail due to app permissions on macOS,
+    # or the Windows Credential Manager blob-size limit for large cookies).
     if is_keyring_available():
-        keyring_result = store_credential_keyring(cookie)
-        if keyring_result.success:
-            return CredentialResult(
-                success=True,
-                message="Credential stored in keyring and encrypted file",
-            )
+        try:
+            keyring_result = store_credential_keyring(cookie)
+            if keyring_result.success:
+                return CredentialResult(
+                    success=True,
+                    message="Credential stored in keyring and encrypted file",
+                )
+        except Exception:
+            # Keyring write raised (e.g. WinError 1783 "The stub received bad
+            # data" when the cookie exceeds the Windows Credential Manager
+            # blob-size limit). The encrypted file write above already
+            # succeeded, so fall back to it instead of crashing.
+            pass
 
     return encrypted_result
 


### PR DESCRIPTION
## Problem

On Windows, `tp-mcp auth` crashes with an uncaught traceback when storing the cookie:

```
win32ctypes.pywin32.pywintypes.error: (1783, 'CredWrite', 'The stub received bad data')
```

`store_credential()` writes the encrypted file first (the documented "reliable fallback") and **then** also tries the system keyring. The Windows Credential Manager rejects `CredWrite` with `WinError 1783` when the credential exceeds its blob-size limit (~2560 bytes). A TrainingPeaks `Production_tpAuth` token is ~1.8 KB, which becomes ~3.6 KB once keyring encodes it as a UTF-16 wide string — well over the limit.

Because the keyring call isn't wrapped, the exception propagates and crashes the process **after** the credential has already been stored in the encrypted file. The cookie is actually saved (so `serve` works), but the user sees an alarming traceback, the command exits non-zero, and the same crash recurs on every re-auth and on `tp_refresh_auth`.

## Fix

Wrap the keyring write in `try/except` so it falls back to the already-successful encrypted-file result instead of crashing. This matches the existing comment, which notes keyring "may fail due to app permissions."

## Testing

- Reproduced the crash on Windows 11 with a real ~1.8 KB cookie.
- After the fix, `store_credential()` returns success (`Credential stored in encrypted file`) with no traceback, and `tp-mcp auth-status` reports the account as authenticated.
- No behavior change on platforms where the keyring write succeeds (the success path is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)