### PR TITLE
fix(events): add normalised distance_km to event tools (#71)

### DIFF
--- a/src/tp_mcp/tools/events.py
+++ b/src/tp_mcp/tools/events.py
@@ -103,6 +103,41 @@ class CreateEventInput(BaseModel):
         return v
 
 
+def _distance_km(distance: Any, distance_units: Any) -> float | None:
+    """Compute a canonical distance in km from TP's raw distance + distanceUnits.
+
+    TP is inconsistent across athletes for the same event: the same race may come
+    back as (50000, "Meters"), (50, "Kilometers"), (50000, "") or (50, None).
+    Unit strings are matched case-insensitively; miles convert at 1.609344 km/mi.
+    When units are blank/missing, a value >= 1000 is assumed to be metres and
+    divided by 1000 — a best-effort heuristic (no real-world event is >= 1000 km),
+    otherwise the value is treated as already being in km.
+    """
+    if isinstance(distance, bool) or not isinstance(distance, (int, float)):
+        return None
+    value = float(distance)
+    units = str(distance_units or "").strip().lower()
+    if units in ("meters", "metres", "meter", "metre", "m"):
+        return value / 1000.0
+    if units in ("miles", "mile", "mi"):
+        return value * 1.609344
+    if units in ("kilometers", "kilometres", "kilometer", "kilometre", "km"):
+        return value
+    if not units and value >= 1000:
+        # Blank units with a large value: assume metres (best-effort guess).
+        return value / 1000.0
+    return value
+
+
+def _with_distance_km(event: Any) -> Any:
+    """Return the event with a normalised `distance_km` field added (raw fields kept)."""
+    if not isinstance(event, dict):
+        return event
+    event = dict(event)
+    event["distance_km"] = _distance_km(event.get("distance"), event.get("distanceUnits"))
+    return event
+
+
 async def tp_get_focus_event() -> dict[str, Any]:
     """Get the A-priority focus event with goals and results."""
     async with TPClient() as client:
@@ -127,7 +162,7 @@ async def tp_get_focus_event() -> dict[str, Any]:
         if not response.data:
             return {"event": None, "message": "No focus event set."}
 
-        return {"event": response.data}
+        return {"event": _with_distance_km(response.data)}
 
 
 async def tp_get_next_event() -> dict[str, Any]:
@@ -154,7 +189,7 @@ async def tp_get_next_event() -> dict[str, Any]:
         if not response.data:
             return {"event": None, "message": "No upcoming events."}
 
-        return {"event": response.data}
+        return {"event": _with_distance_km(response.data)}
 
 
 async def tp_get_events(start_date: str, end_date: str) -> dict[str, Any]:
@@ -199,9 +234,10 @@ async def tp_get_events(start_date: str, end_date: str) -> dict[str, Any]:
             }
 
         data = response.data if isinstance(response.data, list) else []
+        events = [_with_distance_km(evt) for evt in data]
         return {
-            "events": data,
-            "count": len(data),
+            "events": events,
+            "count": len(events),
             "date_range": {"start": start_date, "end": end_date},
         }
 

--- a/tests/test_tools/test_events.py
+++ b/tests/test_tools/test_events.py
@@ -66,6 +66,104 @@ class TestGetNextEvent:
         assert result["event"]["name"] == "Local 10K"
 
 
+class TestEventDistanceNormalisation:
+    """Event tools inject a canonical distance_km alongside TP's raw
+    distance/distanceUnits, which vary per athlete for the same race (#71)."""
+
+    @staticmethod
+    async def _next_event_result(data):
+        response = APIResponse(success=True, data=data)
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+            return await tp_get_next_event()
+
+    @pytest.mark.asyncio
+    async def test_meters_units(self):
+        result = await self._next_event_result(
+            {"name": "50K", "distance": 50000, "distanceUnits": "Meters"}
+        )
+        assert result["event"]["distance_km"] == 50.0
+        # Raw fields untouched
+        assert result["event"]["distance"] == 50000
+        assert result["event"]["distanceUnits"] == "Meters"
+
+    @pytest.mark.asyncio
+    async def test_kilometers_units(self):
+        result = await self._next_event_result(
+            {"name": "50K", "distance": 50, "distanceUnits": "Kilometers"}
+        )
+        assert result["event"]["distance_km"] == 50.0
+
+    @pytest.mark.asyncio
+    async def test_blank_units_large_value_assumed_meters(self):
+        result = await self._next_event_result(
+            {"name": "50K", "distance": 50000, "distanceUnits": ""}
+        )
+        assert result["event"]["distance_km"] == 50.0
+
+    @pytest.mark.asyncio
+    async def test_null_units_small_value_assumed_km(self):
+        result = await self._next_event_result(
+            {"name": "50K", "distance": 50, "distanceUnits": None}
+        )
+        assert result["event"]["distance_km"] == 50.0
+
+    @pytest.mark.asyncio
+    async def test_missing_distance(self):
+        result = await self._next_event_result({"name": "No distance"})
+        assert result["event"]["distance_km"] is None
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_distance(self):
+        result = await self._next_event_result(
+            {"name": "Bad data", "distance": "n/a", "distanceUnits": "Kilometers"}
+        )
+        assert result["event"]["distance_km"] is None
+
+    @pytest.mark.asyncio
+    async def test_miles_units(self):
+        result = await self._next_event_result(
+            {"name": "Marathon", "distance": 26.2, "distanceUnits": "Miles"}
+        )
+        assert result["event"]["distance_km"] == pytest.approx(42.164813, rel=1e-6)
+
+    @pytest.mark.asyncio
+    async def test_focus_event_gets_distance_km(self):
+        response = APIResponse(
+            success=True,
+            data={"name": "IM World Champs", "distance": 226000, "distanceUnits": "Meters"},
+        )
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_get_focus_event()
+
+        assert result["event"]["distance_km"] == 226.0
+
+    @pytest.mark.asyncio
+    async def test_get_events_list_gets_distance_km(self):
+        events = [
+            {"name": "Race A", "distance": 10000, "distanceUnits": "Meters"},
+            {"name": "Race B", "distance": 21.1, "distanceUnits": "Kilometers"},
+        ]
+        response = APIResponse(success=True, data=events)
+        with patch("tp_mcp.tools.events.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_get_events("2026-01-01", "2026-03-01")
+
+        assert [e["distance_km"] for e in result["events"]] == [10.0, 21.1]
+
+
 class TestGetEvents:
     @pytest.mark.asyncio
     async def test_list_events(self):


### PR DESCRIPTION
## Summary

TP returns `distance`/`distanceUnits` inconsistently across athletes for the same event - e.g. `(50000, "Meters")`, `(50, "Kilometers")`, `(50000, "")` or `(50, null)` - so downstream consumers cannot trust either raw field on its own.

This adds a canonical `distance_km: float | None` field, computed server-side, to every event returned by:

- `tp_get_focus_event`
- `tp_get_next_event`
- `tp_get_events`

All raw fields are kept untouched.

## Normalisation rules

- Units saying meters/metres/m (case-insensitive) → divide by 1000
- Units saying miles/mi → multiply by 1.609344
- Units saying kilometers/km → value as-is
- Blank/missing units with value >= 1000 → assume metres, divide by 1000 (best-effort heuristic; no real-world event is >= 1000 km)
- Blank/missing units with value < 1000 → treat as km
- Missing or non-numeric distance → `distance_km: None`

## Tests

New `TestEventDistanceNormalisation` class covering metres, km, blank units >= 1000, null units < 1000, missing distance, non-numeric distance, miles, plus coverage that all three tools inject the field. Full suite: 481 passed; ruff and mypy clean.

Fixes #71