### PR TITLE
docs(auth): document TP_AUTH_COOKIE as supported headless auth (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,21 @@ tp-mcp auth --from-browser chrome  # Or: firefox, safari, edge, auto
 3. Find `Production_tpAuth` and copy its value
 4. Run `tp-mcp auth` and paste when prompted
 
+**Option C: Environment variable (headless servers, containers, CI)**
+
+Set the `TP_AUTH_COOKIE` environment variable to your `Production_tpAuth` cookie value (obtained as in Option B):
+
+```bash
+export TP_AUTH_COOKIE="<Production_tpAuth value>"
+tp-mcp serve
+```
+
+Or in your MCP client config, add it under the server's `env` block. This is a **supported, first-class auth method**, not a testing-only override - it is the recommended path wherever the keyring and encrypted-file backends don't work: headless Linux boxes without Secret Service, containers that are rebuilt (the encrypted file's key is derived from a machine-specific salt, so it doesn't survive a rebuild), and CI.
+
+Precedence: `TP_AUTH_COOKIE` is always checked **first**, before the system keyring, then the encrypted file, so setting it overrides any stored credential.
+
+> **Security note:** the cookie grants full access to your TrainingPeaks account, so treat `TP_AUTH_COOKIE` like a password. Inject it from a secrets manager or your orchestrator's secret mechanism - never hard-code it in Dockerfiles, compose files, or anything committed to git. Be aware that environment variables are readable by any process running as the same user, and via `docker inspect`. On desktop setups, the keyring/encrypted-file storage (Options A and B) remains the recommended default; `TP_AUTH_COOKIE` is for headless and container use.
+
 **Other auth commands:**
 ```bash
 tp-mcp auth-status  # Check if authenticated

--- a/src/tp_mcp/auth/storage.py
+++ b/src/tp_mcp/auth/storage.py
@@ -1,7 +1,9 @@
 """Unified credential storage with automatic backend selection.
 
 Uses system keyring when available, falls back to encrypted file storage.
-Environment variable override is also supported for CI/testing.
+The TP_AUTH_COOKIE environment variable is a supported first-class auth
+source for headless servers, containers, and CI, and takes precedence
+over both stored backends.
 """
 
 import os
@@ -72,14 +74,16 @@ def get_credential() -> CredentialResult:
     """Retrieve the TrainingPeaks auth cookie.
 
     Checks in order:
-    1. Environment variable (for CI/testing)
+    1. TP_AUTH_COOKIE environment variable (supported auth method for
+       headless servers, containers, and CI)
     2. System keyring
     3. Encrypted file
 
     Returns:
         CredentialResult with cookie if found.
     """
-    # Check environment variable first (CI/testing override)
+    # Check environment variable first (supported headless/container/CI
+    # auth path; takes precedence over stored credentials)
     env_cookie = os.environ.get(ENV_VAR_NAME)
     if env_cookie:
         return CredentialResult(


### PR DESCRIPTION
## Summary

Documents the `TP_AUTH_COOKIE` environment variable as a supported, first-class authentication method for headless servers, containers, and CI, rather than a CI/testing-only override. Docs-only change, no behaviour change.

- **README.md**: adds "Option C: Environment variable (headless servers, containers, CI)" under Step 2: Authenticate, covering what to set it to, precedence (checked before the system keyring and encrypted file, confirmed against `get_credential()` in `src/tp_mcp/auth/storage.py`), why it is the right path for containers (Secret Service unavailable, encrypted-file key derived from a machine-specific salt), and a security note on secret custody (inject from a secrets manager, never hard-code in Dockerfiles or committed files; env vars are readable by same-user processes and `docker inspect`; keyring/encrypted file remains the desktop default).
- **src/tp_mcp/auth/storage.py**: rewords the module docstring, `get_credential()` docstring, and inline comment so the env var reads as a supported headless auth path instead of a "CI/testing override".

## Testing

- `uv run --extra dev pytest -q` - 483 passed
- `uv run ruff check src/` - all checks passed
- `uv run mypy src` - no issues in 37 source files

Fixes #85