### PR TITLE
feat(library): bulk multi-athlete scheduling on tp_schedule_library_workout (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ honoured exactly. They update a **threshold** (FTP / LTHR / threshold pace).
 | `tp_delete_library` | Delete a library folder |
 | `tp_create_library_item` | Save a workout template |
 | `tp_update_library_item` | Edit a template |
-| `tp_schedule_library_workout` | Schedule a template to a calendar date |
+| `tp_schedule_library_workout` | Schedule a template to a calendar date, for one athlete or (coach accounts) several at once via `athletes` |
 
 ### Strength Workouts
 | Tool | Description |

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -1070,13 +1070,26 @@ TOOLS = [
     ),
     Tool(
         name="tp_schedule_library_workout",
-        description="Schedule a library template to a calendar date.",
+        description=(
+            "Schedule a library template to a calendar date, for yourself or "
+            "(coach accounts) for one or many athletes."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
                 "library_id": {"type": "string"},
                 "item_id": {"type": "string"},
                 "date": {"type": "string", "description": "YYYY-MM-DD"},
+                "athletes": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Bulk mode (coach accounts): athlete names or IDs to "
+                        "schedule the same template to, one workout each. "
+                        "Returns per-athlete results. Mutually exclusive with "
+                        "'athlete'."
+                    ),
+                },
             },
             "required": ["library_id", "item_id", "date"],
         },
@@ -1701,6 +1714,7 @@ async def _h_update_lib_item(args):
 async def _h_schedule_lib(args):
     return await tp_schedule_library_workout(
         library_id=args["library_id"], item_id=args["item_id"], date=args["date"],
+        athletes=args.get("athletes"),
     )
 
 

--- a/src/tp_mcp/tools/library.py
+++ b/src/tp_mcp/tools/library.py
@@ -7,6 +7,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from tp_mcp.client import TPClient
+from tp_mcp.client.context import athlete_override
 from tp_mcp.tools._validation import WorkoutIdInput, format_validation_error
 
 logger = logging.getLogger("tp-mcp")
@@ -548,10 +549,39 @@ async def tp_update_library_item(
         }
 
 
+def _template_workout_payload(
+    item: dict[str, Any], date: str, athlete_id: int
+) -> dict[str, Any]:
+    """Build the planned-workout payload that copies a library template."""
+    sport_id = item.get("workoutTypeId")
+    payload: dict[str, Any] = {
+        "athleteId": athlete_id,
+        "workoutDay": f"{date}T00:00:00",
+        "workoutTypeFamilyId": sport_id,
+        "workoutTypeValueId": sport_id,
+        "title": item.get("itemName"),
+        "totalTimePlanned": item.get("totalTimePlanned"),
+        "tssPlanned": item.get("tssPlanned"),
+        "ifPlanned": item.get("ifPlanned"),
+        "distancePlanned": item.get("distancePlanned"),
+        "elevationGainPlanned": item.get("elevationGainPlanned"),
+        "caloriesPlanned": item.get("caloriesPlanned"),
+        "description": item.get("description"),
+        "coachComments": item.get("coachComments"),
+    }
+    if item.get("workoutSubTypeId") is not None:
+        payload["workoutSubTypeId"] = item["workoutSubTypeId"]
+    if item.get("structure"):
+        # Calendar workouts carry structure as a JSON string
+        payload["structure"] = json.dumps(item["structure"])
+    return payload
+
+
 async def tp_schedule_library_workout(
     library_id: str,
     item_id: str,
     date: str,
+    athletes: list[str] | None = None,
 ) -> dict[str, Any]:
     """Schedule a library template to a calendar date.
 
@@ -565,9 +595,14 @@ async def tp_schedule_library_workout(
         library_id: Library ID.
         item_id: Library item ID.
         date: Target date (YYYY-MM-DD).
+        athletes: Optional list of athlete names or IDs (coach accounts) to
+            schedule the same template to several athletes in one call.
+            Mutually exclusive with the ``athlete`` targeting parameter.
 
     Returns:
-        Dict with confirmation (including new workout_id) or error.
+        Dict with confirmation (including new workout_id) or error. In bulk
+        mode, a ``scheduled`` list plus per-athlete ``errors``; ``isError``
+        is set only when EVERY athlete failed.
     """
     try:
         lib_validated = WorkoutIdInput(workout_id=library_id)
@@ -591,14 +626,37 @@ async def tp_schedule_library_workout(
             "message": f"Invalid date: {date}",
         }
 
-    async with TPClient() as client:
-        athlete_id = await client.ensure_athlete_id()
-        if not athlete_id:
+    if athletes is not None:
+        if athlete_override.get() is not None:
             return {
                 "isError": True,
-                "error_code": "AUTH_INVALID",
-                "message": "Could not get athlete ID. Re-authenticate.",
+                "error_code": "VALIDATION_ERROR",
+                "message": (
+                    "Pass either 'athlete' (single target) or 'athletes' "
+                    "(bulk), not both."
+                ),
             }
+        if (
+            not isinstance(athletes, (list, tuple))
+            or not athletes
+            or not all(isinstance(a, (str, int)) and str(a).strip() for a in athletes)
+        ):
+            return {
+                "isError": True,
+                "error_code": "VALIDATION_ERROR",
+                "message": "athletes must be a non-empty list of athlete names or IDs.",
+            }
+
+    async with TPClient() as client:
+        athlete_id: int | None = None
+        if athletes is None:
+            athlete_id = await client.ensure_athlete_id()
+            if not athlete_id:
+                return {
+                    "isError": True,
+                    "error_code": "AUTH_INVALID",
+                    "message": "Could not get athlete ID. Re-authenticate.",
+                }
 
         # Fetch the template to copy
         items_endpoint = f"/exerciselibrary/v2/libraries/{lib_validated.workout_id}/items"
@@ -632,30 +690,14 @@ async def tp_schedule_library_workout(
                 ),
             }
 
-        sport_id = item.get("workoutTypeId")
-        payload: dict[str, Any] = {
-            "athleteId": athlete_id,
-            "workoutDay": f"{date}T00:00:00",
-            "workoutTypeFamilyId": sport_id,
-            "workoutTypeValueId": sport_id,
-            "title": item.get("itemName"),
-            "totalTimePlanned": item.get("totalTimePlanned"),
-            "tssPlanned": item.get("tssPlanned"),
-            "ifPlanned": item.get("ifPlanned"),
-            "distancePlanned": item.get("distancePlanned"),
-            "elevationGainPlanned": item.get("elevationGainPlanned"),
-            "caloriesPlanned": item.get("caloriesPlanned"),
-            "description": item.get("description"),
-            "coachComments": item.get("coachComments"),
-        }
-        if item.get("workoutSubTypeId") is not None:
-            payload["workoutSubTypeId"] = item["workoutSubTypeId"]
-        if item.get("structure"):
-            # Calendar workouts carry structure as a JSON string
-            payload["structure"] = json.dumps(item["structure"])
+        if athletes is not None:
+            return await _schedule_item_bulk(client, item, date, athletes)
 
+        assert athlete_id is not None  # resolved above in the single-athlete path
         endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts"
-        response = await client.post(endpoint, json=payload)
+        response = await client.post(
+            endpoint, json=_template_workout_payload(item, date, athlete_id)
+        )
 
         if response.is_error:
             return {
@@ -675,3 +717,74 @@ async def tp_schedule_library_workout(
             "workout_id": workout_id,
             "title": item.get("itemName"),
         }
+
+
+async def _schedule_item_bulk(
+    client: TPClient, item: dict[str, Any], date: str, athletes: list[str]
+) -> dict[str, Any]:
+    """Schedule one library template to several athletes, sequentially.
+
+    Each entry is resolved exactly as the single ``athlete`` targeting
+    parameter would be (name or ID, via the athlete_override context var).
+    Follows the groups-tools partial-failure pattern: per-athlete ``errors``,
+    ``isError`` only when EVERY athlete failed.
+    """
+    scheduled: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+
+    for entry in athletes:
+        target = str(entry).strip()
+        token = athlete_override.set(target)
+        try:
+            athlete_id = await client.ensure_athlete_id()
+        except ValueError as e:
+            # Ambiguous athlete name — ensure_athlete_id lists the matches.
+            errors.append({"athlete": target, "message": str(e)})
+            continue
+        finally:
+            athlete_override.reset(token)
+
+        if not athlete_id:
+            errors.append({
+                "athlete": target,
+                "message": f"Could not resolve athlete {target!r} in your roster.",
+            })
+            continue
+
+        endpoint = f"/fitness/v6/athletes/{athlete_id}/workouts"
+        response = await client.post(
+            endpoint, json=_template_workout_payload(item, date, athlete_id)
+        )
+        if response.is_error:
+            errors.append({
+                "athlete": target,
+                "athlete_id": athlete_id,
+                "message": response.message,
+            })
+        else:
+            workout_id = None
+            if isinstance(response.data, dict):
+                workout_id = response.data.get("workoutId")
+            scheduled.append({
+                "athlete": target,
+                "athlete_id": athlete_id,
+                "workout_id": workout_id,
+            })
+
+    result: dict[str, Any] = {
+        "date": date,
+        "title": item.get("itemName"),
+        "scheduled": scheduled,
+        "errors": errors,
+        "message": (
+            f"Scheduled for {len(scheduled)} of {len(athletes)} athlete(s) on {date}."
+        ),
+    }
+    if errors and not scheduled:
+        result["isError"] = True
+        result["error_code"] = "API_ERROR"
+        result["message"] = (
+            f"None of the {len(errors)} athlete(s) could be scheduled; "
+            "see errors for per-athlete detail."
+        )
+    return result

--- a/tests/test_tools/test_library.py
+++ b/tests/test_tools/test_library.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from tp_mcp.client.context import athlete_override
 from tp_mcp.client.http import APIResponse
 from tp_mcp.tools.library import (
     tp_create_library,
@@ -341,6 +342,24 @@ class TestScheduleLibraryWorkout:
         assert isinstance(payload["structure"], str)
 
     @pytest.mark.asyncio
+    async def test_single_athlete_ignores_bulk_shape(self):
+        """Omitting athletes keeps the original single-athlete result shape."""
+        items_response = APIResponse(success=True, data=[self.TEMPLATE])
+        create_response = APIResponse(success=True, data={"workoutId": 999})
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=items_response)
+            mock_instance.post = AsyncMock(return_value=create_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_schedule_library_workout("1", "10", "2026-04-01")
+
+        assert result["success"] is True
+        assert "scheduled" not in result
+        assert "errors" not in result
+
+    @pytest.mark.asyncio
     async def test_schedule_unknown_item_returns_not_found(self):
         items_response = APIResponse(success=True, data=[self.TEMPLATE])
         with patch("tp_mcp.tools.library.TPClient") as mock_client:
@@ -355,3 +374,162 @@ class TestScheduleLibraryWorkout:
         assert result.get("isError") is True
         assert result["error_code"] == "NOT_FOUND"
         mock_instance.post.assert_not_called()
+
+
+class TestScheduleLibraryWorkoutBulk:
+    TEMPLATE = TestScheduleLibraryWorkout.TEMPLATE
+
+    def _mock(self, mock_client, athlete_ids, post_responses):
+        items_response = APIResponse(success=True, data=[self.TEMPLATE])
+        mock_instance = AsyncMock()
+        mock_instance.ensure_athlete_id = AsyncMock(side_effect=athlete_ids)
+        mock_instance.get = AsyncMock(return_value=items_response)
+        mock_instance.post = AsyncMock(side_effect=post_responses)
+        mock_client.return_value.__aenter__.return_value = mock_instance
+        return mock_instance
+
+    @pytest.mark.asyncio
+    async def test_bulk_schedules_each_athlete(self):
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = self._mock(
+                mock_client,
+                athlete_ids=[111, 222],
+                post_responses=[
+                    APIResponse(success=True, data={"workoutId": 1001}),
+                    APIResponse(success=True, data={"workoutId": 1002}),
+                ],
+            )
+
+            result = await tp_schedule_library_workout(
+                "1", "10", "2026-04-01", athletes=["Alice", "222"],
+            )
+
+        assert result.get("isError") is not True
+        assert [s["athlete_id"] for s in result["scheduled"]] == [111, 222]
+        assert [s["workout_id"] for s in result["scheduled"]] == [1001, 1002]
+        assert result["errors"] == []
+        endpoints = [c[0][0] for c in mock_instance.post.call_args_list]
+        assert endpoints == [
+            "/fitness/v6/athletes/111/workouts",
+            "/fitness/v6/athletes/222/workouts",
+        ]
+        # Each payload targets its own athlete
+        payloads = [c[1]["json"] for c in mock_instance.post.call_args_list]
+        assert [p["athleteId"] for p in payloads] == [111, 222]
+        assert all(p["title"] == "Sweet Spot" for p in payloads)
+
+    @pytest.mark.asyncio
+    async def test_bulk_partial_failure_is_not_error(self):
+        """One athlete failing is reported in errors, without isError."""
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            self._mock(
+                mock_client,
+                athlete_ids=[111, 222],
+                post_responses=[
+                    APIResponse(success=True, data={"workoutId": 1001}),
+                    APIResponse(success=False, message="boom"),
+                ],
+            )
+
+            result = await tp_schedule_library_workout(
+                "1", "10", "2026-04-01", athletes=["Alice", "Bob"],
+            )
+
+        assert result.get("isError") is not True
+        assert len(result["scheduled"]) == 1
+        assert result["errors"] == [
+            {"athlete": "Bob", "athlete_id": 222, "message": "boom"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_bulk_unresolvable_athlete_reported(self):
+        """An athlete not in the roster (ensure_athlete_id -> None) is a
+        per-athlete error; the rest still get scheduled."""
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            mock_instance = self._mock(
+                mock_client,
+                athlete_ids=[None, 222],
+                post_responses=[
+                    APIResponse(success=True, data={"workoutId": 1002}),
+                ],
+            )
+
+            result = await tp_schedule_library_workout(
+                "1", "10", "2026-04-01", athletes=["Nobody", "222"],
+            )
+
+        assert result.get("isError") is not True
+        assert [s["athlete_id"] for s in result["scheduled"]] == [222]
+        assert result["errors"][0]["athlete"] == "Nobody"
+        assert mock_instance.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_bulk_ambiguous_name_reported(self):
+        """ensure_athlete_id raising ValueError (ambiguous name) becomes a
+        per-athlete error rather than blowing up the whole call."""
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            self._mock(
+                mock_client,
+                athlete_ids=[ValueError("Ambiguous athlete name 'Alex'"), 222],
+                post_responses=[
+                    APIResponse(success=True, data={"workoutId": 1002}),
+                ],
+            )
+
+            result = await tp_schedule_library_workout(
+                "1", "10", "2026-04-01", athletes=["Alex", "222"],
+            )
+
+        assert result.get("isError") is not True
+        assert "Ambiguous" in result["errors"][0]["message"]
+        assert [s["athlete_id"] for s in result["scheduled"]] == [222]
+
+    @pytest.mark.asyncio
+    async def test_bulk_total_failure_sets_is_error(self):
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            self._mock(
+                mock_client,
+                athlete_ids=[111, 222],
+                post_responses=[
+                    APIResponse(success=False, message="boom"),
+                    APIResponse(success=False, message="boom"),
+                ],
+            )
+
+            result = await tp_schedule_library_workout(
+                "1", "10", "2026-04-01", athletes=["Alice", "Bob"],
+            )
+
+        assert result["isError"] is True
+        assert result["error_code"] == "API_ERROR"
+        assert result["scheduled"] == []
+        assert len(result["errors"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_both_athlete_and_athletes_rejected(self):
+        """Passing the single 'athlete' target alongside 'athletes' is a
+        validation error before any API call."""
+        token = athlete_override.set("Alice")
+        try:
+            with patch("tp_mcp.tools.library.TPClient") as mock_client:
+                result = await tp_schedule_library_workout(
+                    "1", "10", "2026-04-01", athletes=["Bob"],
+                )
+        finally:
+            athlete_override.reset(token)
+
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+        assert "not both" in result["message"]
+        mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_athletes_list_rejected(self):
+        with patch("tp_mcp.tools.library.TPClient") as mock_client:
+            result = await tp_schedule_library_workout(
+                "1", "10", "2026-04-01", athletes=[],
+            )
+
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+        mock_client.assert_not_called()


### PR DESCRIPTION
## What

Extends the existing `tp_schedule_library_workout` tool with an optional `athletes` array parameter so a coach can schedule one library template to multiple athletes in a single call, per the design discussion on the issue (extend the existing tool rather than add a sibling).

## How

- New optional `athletes` parameter (list of athlete names or IDs). When provided, the template is fetched once and scheduled for each athlete sequentially (no parallelism, per the issue's v1 scope).
- Each entry is resolved exactly as the single `athlete` targeting parameter would be, via the `athlete_override` context var and `ensure_athlete_id` (numeric ID or name lookup, with the existing ambiguous-name detection surfaced as a per-athlete error).
- Per-athlete results follow the established groups-tools partial-failure pattern: a `scheduled` list plus an `errors` list, with `isError` set only when every athlete failed.
- Passing both `athlete` and `athletes` returns a `VALIDATION_ERROR` telling the caller to use one or the other; an empty `athletes` list is also rejected.
- When `athletes` is omitted, behaviour is byte-for-byte what it was before (single-athlete path unchanged; the payload build is simply factored into a shared helper).
- Tool `inputSchema` and README row updated accordingly.

## Tests

Seven new tests in `tests/test_tools/test_library.py`: single-athlete shape unchanged, bulk success (correct per-athlete endpoints and payloads), partial failure (no `isError`), unresolvable athlete, ambiguous name, total failure (`isError` true), both-params validation error, and empty-list validation error.

`uv run --extra dev pytest -q` (491 passed), `uv run ruff check src/` and `uv run mypy src` all pass.

Fixes #72