### PR TITLE
feat(profile): expose coached-athlete account type (Premium/Coach-Paid/Trial/Basic)

### DIFF
--- a/src/tp_mcp/tools/profile.py
+++ b/src/tp_mcp/tools/profile.py
@@ -1,12 +1,56 @@
 """TOOL-02: tp_get_profile / tp_list_athletes - Profile and coach tools."""
 
 import logging
+from datetime import datetime, timezone
 from typing import Any
 
 from tp_mcp.client import TPClient
 from tp_mcp.client.context import athlete_override
 
 logger = logging.getLogger("tp-mcp")
+
+
+def _account_fields(entry: dict[str, Any]) -> dict[str, Any]:
+    """Surface raw premium/account fields from a coach-roster ``athletes[]``
+    entry — passthrough, NOT interpreted.
+
+    /users/v3/user does NOT expose a clean ``isPremium`` for a coached athlete
+    (it belongs to the logged-in user). What it DOES carry on each roster entry
+    are several account-related fields whose exact semantics aren't documented
+    by TP — we hand them all through so callers can compare them across known
+    paid / coach-paid / free / trial athletes and learn the pattern. ``expired``
+    is the only derived bit: True when ``expireOn`` is in the past.
+
+    Known fields per entry (live-verified on a coach account):
+      • ``expireOn`` — ISO timestamp; some kind of expiration (likely premium /
+        coach-pairing). Many active athletes show past dates → semantics unclear.
+      • ``athleteType`` (int) / ``userType`` (int) — tier-ish codes, values vary
+        (0/2/4/5 and 1/4/6 in our sample).
+      • ``premiumTrial`` / ``premiumTrialDaysRemaining`` — trial state.
+      • ``downgradeAllowed`` / ``downgradeAllowedOn`` / ``lastUpgradeOn`` —
+        billing-action hints.
+    """
+    exp_raw = entry.get("expireOn")
+    expired: bool | None = None
+    if isinstance(exp_raw, str) and exp_raw:
+        try:
+            dt = datetime.fromisoformat(exp_raw.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            expired = dt < datetime.now(timezone.utc)
+        except ValueError:
+            expired = None
+    return {
+        "expire_on": exp_raw,
+        "expired": expired,
+        "athlete_type": entry.get("athleteType"),
+        "user_type": entry.get("userType"),
+        "premium_trial": entry.get("premiumTrial"),
+        "premium_trial_days_remaining": entry.get("premiumTrialDaysRemaining"),
+        "downgrade_allowed": entry.get("downgradeAllowed"),
+        "downgrade_allowed_on": entry.get("downgradeAllowedOn"),
+        "last_upgrade_on": entry.get("lastUpgradeOn"),
+    }
 
 
 async def _targeted_athlete_profile(client: TPClient) -> dict[str, Any]:
@@ -39,9 +83,12 @@ async def _targeted_athlete_profile(client: TPClient) -> dict[str, Any]:
         "athlete_id": athlete_id,
         "name": f"{first} {last}".strip(),
         "email": entry.get("email"),
-        # Premium status belongs to the logged-in account, not a coached
-        # athlete, so it is not available when targeting one.
+        # A clean «premium / basic» label isn't exposed for a coached athlete by
+        # /users/v3/user. Raw account-related fields ARE present on the roster
+        # entry, surfaced under `account` for caller-side analysis (see
+        # _account_fields docstring for the known shape and caveats).
         "account_type": None,
+        "account": _account_fields(entry),
     }
 
 
@@ -113,8 +160,14 @@ async def tp_get_profile() -> dict[str, Any]:
 async def tp_list_athletes() -> dict[str, Any]:
     """List athletes available to this account (coach accounts).
 
-    Returns:
-        Dict with athletes list, each containing athlete_id, name, and is_self flag.
+    Each entry carries ``athlete_id``, ``name``, ``is_self`` plus an ``account``
+    sub-dict with RAW premium / account fields from the coach roster
+    (``expire_on``, ``expired``, ``athlete_type``, ``user_type``,
+    ``premium_trial[_days_remaining]``, ``downgrade_allowed[_on]``,
+    ``last_upgrade_on``). Exact semantics aren't documented by TP — surfaced
+    passthrough so callers can correlate them against known coach-paid vs
+    self-paid vs free athletes. See ``_account_fields`` for the field catalogue
+    and caveats.
     """
     async with TPClient() as client:
         user_data = await client._get_user_data()
@@ -149,6 +202,7 @@ async def tp_list_athletes() -> dict[str, Any]:
                 "athlete_id": a.get("athleteId"),
                 "name": f"{first} {last}".strip(),
                 "is_self": is_self,
+                "account": _account_fields(a),
             })
 
         return {"athletes": result}

--- a/src/tp_mcp/tools/profile.py
+++ b/src/tp_mcp/tools/profile.py
@@ -13,11 +13,9 @@ logger = logging.getLogger("tp-mcp")
 def _derive_tier(*, expired: bool | None, user_type: int | None,
                  trial_days: int | None) -> str | None:
     """Map raw account fields → TP-UI label («Account Type»). Verified against
-    the live UI on 10 athletes spanning all four states (Razuvaev / Kochetkov /
-    Khaldin / Kononova → coach_paid; Sokolov / Demenko / Кашлев / Korotkov →
-    basic; Toktogonov / Omorkanov / Chastushkin / Morozov → self_paid; Седых
-    → trial). Order matters — trial first, then active subscription, then
-    lapsed-but-tier-1 = coach-paid, default basic.
+    the live UI on a real coach roster spanning all four states (coach-paid,
+    basic, self-paid and trial athletes). Order matters — trial first, then
+    active subscription, then lapsed-but-tier-1 = coach-paid, default basic.
 
     Returns one of: ``premium_trial`` / ``premium_self`` / ``premium_coach`` /
     ``basic`` / ``None`` (when ``expired`` couldn't be parsed).
@@ -47,7 +45,8 @@ def _account_fields(entry: dict[str, Any]) -> dict[str, Any]:
       • ``expireOn`` — ISO timestamp; expiration of the athlete's PERSONAL
         subscription. A past date does NOT mean «no premium»: on a coach-paid
         athlete the coach's plan grants premium externally, the personal date
-        stays frozen on whenever the athlete last paid (Razuvaev: 2019-02-25).
+        stays frozen on whenever the athlete last paid (observed live: an
+        expireOn years in the past on an athlete with coach-granted premium).
       • ``athleteType`` (int) — varies (0/2/4/5), not used by the derivation.
       • ``userType`` (int) — 1 = was-ever-premium (paid tier code, persists
         even after personal expiry); 4 = active personal premium; 6 = basic.

--- a/src/tp_mcp/tools/profile.py
+++ b/src/tp_mcp/tools/profile.py
@@ -10,25 +10,52 @@ from tp_mcp.client.context import athlete_override
 logger = logging.getLogger("tp-mcp")
 
 
+def _derive_tier(*, expired: bool | None, user_type: int | None,
+                 trial_days: int | None) -> str | None:
+    """Map raw account fields → TP-UI label («Account Type»). Verified against
+    the live UI on 10 athletes spanning all four states (Razuvaev / Kochetkov /
+    Khaldin / Kononova → coach_paid; Sokolov / Demenko / Кашлев / Korotkov →
+    basic; Toktogonov / Omorkanov / Chastushkin / Morozov → self_paid; Седых
+    → trial). Order matters — trial first, then active subscription, then
+    lapsed-but-tier-1 = coach-paid, default basic.
+
+    Returns one of: ``premium_trial`` / ``premium_self`` / ``premium_coach`` /
+    ``basic`` / ``None`` (when ``expired`` couldn't be parsed).
+    """
+    if isinstance(trial_days, int) and trial_days > 0:
+        return "premium_trial"
+    if expired is False:
+        return "premium_self"            # active personal subscription
+    if expired is True and user_type == 1:
+        return "premium_coach"           # lapsed personal premium, coach pays
+    if expired is True:
+        return "basic"                   # no premium tier
+    return None                          # expireOn unparseable / missing
+
+
 def _account_fields(entry: dict[str, Any]) -> dict[str, Any]:
-    """Surface raw premium/account fields from a coach-roster ``athletes[]``
-    entry — passthrough, NOT interpreted.
+    """Premium / account fields from a coach-roster ``athletes[]`` entry, plus
+    a derived ``tier`` («Account Type» in the TP UI).
 
     /users/v3/user does NOT expose a clean ``isPremium`` for a coached athlete
-    (it belongs to the logged-in user). What it DOES carry on each roster entry
-    are several account-related fields whose exact semantics aren't documented
-    by TP — we hand them all through so callers can compare them across known
-    paid / coach-paid / free / trial athletes and learn the pattern. ``expired``
-    is the only derived bit: True when ``expireOn`` is in the past.
+    — that belongs to the logged-in user. The roster entry, though, carries
+    several account-related fields whose exact semantics aren't documented by
+    TP. We surface them raw AND derive a four-state tier label that matches the
+    TP UI (verified live on athletes from each state; see ``_derive_tier``).
 
     Known fields per entry (live-verified on a coach account):
-      • ``expireOn`` — ISO timestamp; some kind of expiration (likely premium /
-        coach-pairing). Many active athletes show past dates → semantics unclear.
-      • ``athleteType`` (int) / ``userType`` (int) — tier-ish codes, values vary
-        (0/2/4/5 and 1/4/6 in our sample).
-      • ``premiumTrial`` / ``premiumTrialDaysRemaining`` — trial state.
+      • ``expireOn`` — ISO timestamp; expiration of the athlete's PERSONAL
+        subscription. A past date does NOT mean «no premium»: on a coach-paid
+        athlete the coach's plan grants premium externally, the personal date
+        stays frozen on whenever the athlete last paid (Razuvaev: 2019-02-25).
+      • ``athleteType`` (int) — varies (0/2/4/5), not used by the derivation.
+      • ``userType`` (int) — 1 = was-ever-premium (paid tier code, persists
+        even after personal expiry); 4 = active personal premium; 6 = basic.
+        The derivation uses this to separate «coach-paid» from «basic».
+      • ``premiumTrial`` (bool) / ``premiumTrialDaysRemaining`` (int) — when
+        days>0 the athlete is on the free trial (premium-equivalent access).
       • ``downgradeAllowed`` / ``downgradeAllowedOn`` / ``lastUpgradeOn`` —
-        billing-action hints.
+        billing-action hints, not part of the derivation.
     """
     exp_raw = entry.get("expireOn")
     expired: bool | None = None
@@ -40,13 +67,17 @@ def _account_fields(entry: dict[str, Any]) -> dict[str, Any]:
             expired = dt < datetime.now(timezone.utc)
         except ValueError:
             expired = None
+    user_type = entry.get("userType")
+    trial_days = entry.get("premiumTrialDaysRemaining")
     return {
+        "tier": _derive_tier(expired=expired, user_type=user_type,
+                             trial_days=trial_days),
         "expire_on": exp_raw,
         "expired": expired,
         "athlete_type": entry.get("athleteType"),
-        "user_type": entry.get("userType"),
+        "user_type": user_type,
         "premium_trial": entry.get("premiumTrial"),
-        "premium_trial_days_remaining": entry.get("premiumTrialDaysRemaining"),
+        "premium_trial_days_remaining": trial_days,
         "downgrade_allowed": entry.get("downgradeAllowed"),
         "downgrade_allowed_on": entry.get("downgradeAllowedOn"),
         "last_upgrade_on": entry.get("lastUpgradeOn"),
@@ -161,13 +192,13 @@ async def tp_list_athletes() -> dict[str, Any]:
     """List athletes available to this account (coach accounts).
 
     Each entry carries ``athlete_id``, ``name``, ``is_self`` plus an ``account``
-    sub-dict with RAW premium / account fields from the coach roster
+    sub-dict. The most useful key there is ``tier`` — one of
+    ``premium_self`` / ``premium_coach`` / ``premium_trial`` / ``basic`` —
+    matching the «Account Type» label in the TP UI (derivation verified live
+    against athletes from each state). Raw underlying fields are kept alongside
     (``expire_on``, ``expired``, ``athlete_type``, ``user_type``,
     ``premium_trial[_days_remaining]``, ``downgrade_allowed[_on]``,
-    ``last_upgrade_on``). Exact semantics aren't documented by TP — surfaced
-    passthrough so callers can correlate them against known coach-paid vs
-    self-paid vs free athletes. See ``_account_fields`` for the field catalogue
-    and caveats.
+    ``last_upgrade_on``). See ``_account_fields`` / ``_derive_tier``.
     """
     async with TPClient() as client:
         user_data = await client._get_user_data()

--- a/tests/test_tools/test_profile.py
+++ b/tests/test_tools/test_profile.py
@@ -155,15 +155,15 @@ class TestDeriveTier:
     subscription > lapsed-tier-1 (coach-paid) > default basic."""
 
     def test_premium_self_paid_active_subscription(self):
-        # Toktogonov / Omorkanov / Chastushkin / Morozov pattern
+        # Active personal subscription: future expireOn.
         assert _derive_tier(expired=False, user_type=4, trial_days=0) == "premium_self"
 
     def test_premium_coach_paid_lapsed_personal_tier_1(self):
-        # Razuvaev / Kochetkov / Khaldin / Kononova pattern
+        # Coach-paid: personal premium lapsed, tier-1 user type persists.
         assert _derive_tier(expired=True, user_type=1, trial_days=0) == "premium_coach"
 
     def test_basic_lapsed_non_premium_tier(self):
-        # Sokolov / Demenko / Кашлев / Korotkov pattern (user_type=6)
+        # Basic: lapsed with non-premium user_type (6).
         assert _derive_tier(expired=True, user_type=6, trial_days=0) == "basic"
 
     def test_basic_with_other_non_premium_user_type(self):
@@ -171,7 +171,7 @@ class TestDeriveTier:
         assert _derive_tier(expired=True, user_type=4, trial_days=0) == "basic"
 
     def test_premium_trial_wins_over_other_signals(self):
-        # Седых pattern: trial active even though expireOn just lapsed.
+        # Trial stays active even though expireOn just lapsed.
         assert _derive_tier(expired=True, user_type=4, trial_days=4) == "premium_trial"
         assert _derive_tier(expired=False, user_type=4, trial_days=7) == "premium_trial"
 

--- a/tests/test_tools/test_profile.py
+++ b/tests/test_tools/test_profile.py
@@ -7,7 +7,10 @@ import pytest
 from tp_mcp.client.context import athlete_override
 from tp_mcp.client.http import APIResponse
 from tp_mcp.tools.profile import (
-    _account_fields, _derive_tier, tp_get_profile, tp_list_athletes,
+    _account_fields,
+    _derive_tier,
+    tp_get_profile,
+    tp_list_athletes,
 )
 
 OWN_USER_RESPONSE = {

--- a/tests/test_tools/test_profile.py
+++ b/tests/test_tools/test_profile.py
@@ -6,7 +6,9 @@ import pytest
 
 from tp_mcp.client.context import athlete_override
 from tp_mcp.client.http import APIResponse
-from tp_mcp.tools.profile import _account_fields, tp_get_profile, tp_list_athletes
+from tp_mcp.tools.profile import (
+    _account_fields, _derive_tier, tp_get_profile, tp_list_athletes,
+)
 
 OWN_USER_RESPONSE = {
     "user": {
@@ -103,6 +105,8 @@ class TestGetProfileTargetedAthlete:
         assert result["account"]["expired"] is True
         assert result["account"]["athlete_type"] == 4
         assert result["account"]["user_type"] == 6
+        # …plus the derived tier («Account Type» label in TP UI).
+        assert result["account"]["tier"] == "basic"
         # The logged-in user's profile endpoint must not be the source here.
         instance.get.assert_not_awaited()
 
@@ -140,6 +144,36 @@ class TestGetProfileTargetedAthlete:
 
         assert result["isError"] is True
         assert result["error_code"] == "NOT_FOUND"
+
+
+class TestDeriveTier:
+    """Verified live against the TP UI «Account Type» label on 10 athletes
+    spanning all four states (2026-06-28 sync). Order matters: trial > active
+    subscription > lapsed-tier-1 (coach-paid) > default basic."""
+
+    def test_premium_self_paid_active_subscription(self):
+        # Toktogonov / Omorkanov / Chastushkin / Morozov pattern
+        assert _derive_tier(expired=False, user_type=4, trial_days=0) == "premium_self"
+
+    def test_premium_coach_paid_lapsed_personal_tier_1(self):
+        # Razuvaev / Kochetkov / Khaldin / Kononova pattern
+        assert _derive_tier(expired=True, user_type=1, trial_days=0) == "premium_coach"
+
+    def test_basic_lapsed_non_premium_tier(self):
+        # Sokolov / Demenko / Кашлев / Korotkov pattern (user_type=6)
+        assert _derive_tier(expired=True, user_type=6, trial_days=0) == "basic"
+
+    def test_basic_with_other_non_premium_user_type(self):
+        # Anything not 1 is basic when expired (saw 6/4/2 etc. in the wild).
+        assert _derive_tier(expired=True, user_type=4, trial_days=0) == "basic"
+
+    def test_premium_trial_wins_over_other_signals(self):
+        # Седых pattern: trial active even though expireOn just lapsed.
+        assert _derive_tier(expired=True, user_type=4, trial_days=4) == "premium_trial"
+        assert _derive_tier(expired=False, user_type=4, trial_days=7) == "premium_trial"
+
+    def test_none_when_expired_unknown(self):
+        assert _derive_tier(expired=None, user_type=6, trial_days=0) is None
 
 
 class TestAccountFields:
@@ -190,8 +224,10 @@ class TestListAthletesShape:
         assert len(result["athletes"]) == 2
         coach, charlotte = result["athletes"]
         assert coach["is_self"] is True and coach["athlete_id"] == 100
-        # account block carries the raw fields
+        # account block carries the raw fields + the derived tier
         assert coach["account"]["athlete_type"] == 1
         assert coach["account"]["expired"] is False     # future expireOn
+        assert coach["account"]["tier"] == "premium_self"
         assert charlotte["account"]["athlete_type"] == 4
         assert charlotte["account"]["expired"] is True   # 2017
+        assert charlotte["account"]["tier"] == "basic"

--- a/tests/test_tools/test_profile.py
+++ b/tests/test_tools/test_profile.py
@@ -6,7 +6,7 @@ import pytest
 
 from tp_mcp.client.context import athlete_override
 from tp_mcp.client.http import APIResponse
-from tp_mcp.tools.profile import tp_get_profile
+from tp_mcp.tools.profile import _account_fields, tp_get_profile, tp_list_athletes
 
 OWN_USER_RESPONSE = {
     "user": {
@@ -25,6 +25,15 @@ ROSTER = [
         "lastName": "Coach",
         "email": "stevan@example.com",
         "coachedBy": 100,
+        # Premium-ish fields (passthrough). Active premium = future expireOn.
+        "expireOn": "2099-01-01T00:00:00",
+        "athleteType": 1,
+        "userType": 1,
+        "premiumTrial": None,
+        "premiumTrialDaysRemaining": 0,
+        "downgradeAllowed": True,
+        "downgradeAllowedOn": "2099-01-01T00:00:00",
+        "lastUpgradeOn": "2025-01-01T00:00:00",
     },
     {
         "athleteId": 201,
@@ -32,6 +41,12 @@ ROSTER = [
         "lastName": "Horton",
         "email": "charlotte@example.com",
         "coachedBy": 100,
+        "expireOn": "2017-01-28T03:17:00",   # expired
+        "athleteType": 4,
+        "userType": 6,
+        "premiumTrial": None,
+        "premiumTrialDaysRemaining": 0,
+        "downgradeAllowed": False,
     },
 ]
 
@@ -83,6 +98,11 @@ class TestGetProfileTargetedAthlete:
         assert result["email"] == "charlotte@example.com"
         # Premium status is not knowable for a coached athlete.
         assert result["account_type"] is None
+        # Raw account fields ARE surfaced under `account` for caller analysis.
+        assert result["account"]["expire_on"] == "2017-01-28T03:17:00"
+        assert result["account"]["expired"] is True
+        assert result["account"]["athlete_type"] == 4
+        assert result["account"]["user_type"] == 6
         # The logged-in user's profile endpoint must not be the source here.
         instance.get.assert_not_awaited()
 
@@ -120,3 +140,58 @@ class TestGetProfileTargetedAthlete:
 
         assert result["isError"] is True
         assert result["error_code"] == "NOT_FOUND"
+
+
+class TestAccountFields:
+    """`_account_fields` is a passthrough surface for premium/account flags
+    whose semantics aren't documented by TP — these only pin the SHAPE so the
+    keys don't drift, plus the ONE derived bit (`expired`)."""
+
+    def test_passes_through_known_fields(self):
+        out = _account_fields({
+            "expireOn": "2099-01-01T00:00:00",
+            "athleteType": 1, "userType": 1,
+            "premiumTrial": "trial", "premiumTrialDaysRemaining": 5,
+            "downgradeAllowed": True, "downgradeAllowedOn": "2099-01-01",
+            "lastUpgradeOn": "2025-01-01",
+        })
+        assert out["expire_on"] == "2099-01-01T00:00:00"
+        assert out["athlete_type"] == 1 and out["user_type"] == 1
+        assert out["premium_trial"] == "trial"
+        assert out["premium_trial_days_remaining"] == 5
+        assert out["downgrade_allowed"] is True
+        assert out["downgrade_allowed_on"] == "2099-01-01"
+        assert out["last_upgrade_on"] == "2025-01-01"
+
+    def test_expired_derived_from_expireon(self):
+        assert _account_fields({"expireOn": "2017-01-28T03:17:00"})["expired"] is True
+        assert _account_fields({"expireOn": "2099-12-31T23:59:00"})["expired"] is False
+
+    def test_missing_or_bad_expireon_keeps_expired_none(self):
+        assert _account_fields({})["expired"] is None
+        assert _account_fields({"expireOn": ""})["expired"] is None
+        assert _account_fields({"expireOn": "not-a-date"})["expired"] is None
+
+
+class TestListAthletesShape:
+    @pytest.mark.asyncio
+    async def test_list_athletes_surfaces_account_block(self):
+        """tp_list_athletes now carries an `account` sub-dict per entry — raw
+        passthrough so a caller can correlate fields against known coach-paid
+        vs self-paid vs free athletes."""
+        instance = _mock_client(
+            _get_user_data={"personId": 100, "email": "stevan@example.com",
+                            "athletes": ROSTER},
+        )
+        with patch("tp_mcp.tools.profile.TPClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value = instance
+            result = await tp_list_athletes()
+
+        assert len(result["athletes"]) == 2
+        coach, charlotte = result["athletes"]
+        assert coach["is_self"] is True and coach["athlete_id"] == 100
+        # account block carries the raw fields
+        assert coach["account"]["athlete_type"] == 1
+        assert coach["account"]["expired"] is False     # future expireOn
+        assert charlotte["account"]["athlete_type"] == 4
+        assert charlotte["account"]["expired"] is True   # 2017


### PR DESCRIPTION
Closes #125.

`tp_get_profile(athlete=…)` previously returned `account_type: null` for any coached
athlete (`Premium status belongs to the logged-in account, not a coached athlete`).
That's true for `/users/v3/user.settings.account.isPremium`, but the coach roster
(`athletes[]` from the user-data endpoint) carries per-athlete account fields that
let us reconstruct the TP-UI "Account Type" label.

- Surfaces the raw premium/account fields on roster entries (`tp_list_athletes`).
- Derives a `tier` (`premium_self` / `premium_coach` / `premium_trial` / `basic`) on both
  `tp_list_athletes` and `tp_get_profile`.

Rebased onto current `main` (post v2.1.0 merge batch); ruff/mypy/pytest green (501 passed).
