### PR TITLE
feat(security): opt-in least-privilege access policy (TP_MCP_MODE)

### DIFF
--- a/src/tp_mcp/access.py
+++ b/src/tp_mcp/access.py
@@ -1,0 +1,149 @@
+"""Least-privilege access policy for the TrainingPeaks MCP server.
+
+This module gates which tools the AI assistant can see and call, so a
+confused or prompt-injected model cannot modify or destroy TrainingPeaks
+data unless the human operator has explicitly opted in.
+
+Configuration is read from the process environment (set it in the
+`env` block of your Claude Desktop / MCP client config):
+
+- TP_MCP_MODE:
+    "read" / "readonly"  -> only read-only tools (+ auth refresh)
+    "write"              -> read + create/update tools, but NO deletes
+    "full"               -> everything (default; backwards compatible)
+
+- TP_MCP_DISABLED_TOOLS:
+    Comma-separated exact tool names to disable regardless of mode.
+    Example: "tp_upload_workout_file,tp_delete_workout"
+
+SECURITY DESIGN:
+- Fail safe: a tool that is not explicitly known is treated as WRITE
+  (hidden in read-only mode), and any unknown tool whose name implies
+  removal is treated as DELETE (hidden unless mode is "full").
+- Two enforcement points: tools are filtered out of `list_tools` (the
+  model never sees them) AND rejected in `call_tool` (defense in depth,
+  in case a name is called directly).
+"""
+
+import os
+from enum import Enum
+
+
+class AccessLevel(str, Enum):
+    """Capability tier of a tool."""
+
+    READ = "read"       # fetch/inspect only, no server-side mutation
+    WRITE = "write"     # create / update / log (reversible-ish mutation)
+    DELETE = "delete"   # destructive: permanently removes data
+    AUTH = "auth"       # local auth maintenance (no TP data mutation)
+
+
+MODE_ENV_VAR = "TP_MCP_MODE"
+DISABLED_ENV_VAR = "TP_MCP_DISABLED_TOOLS"
+
+# Explicit, audited classification. WRITE is intentionally the implicit
+# default (everything not listed here), so the maps below only need to
+# enumerate READ, DELETE, and AUTH.
+_READ_TOOLS: frozenset[str] = frozenset({
+    "tp_analyze_workout", "tp_auth_status", "tp_download_workout_file",
+    "tp_get_athlete_settings", "tp_get_atp", "tp_get_availability",
+    "tp_get_equipment", "tp_get_events", "tp_get_fitness", "tp_get_focus_event",
+    "tp_get_libraries", "tp_get_library_item", "tp_get_library_items",
+    "tp_get_metrics", "tp_get_next_event", "tp_get_note", "tp_get_note_comments",
+    "tp_get_nutrition", "tp_get_peaks", "tp_get_pool_length_settings",
+    "tp_get_profile", "tp_get_strength_summary", "tp_get_weekly_summary",
+    "tp_get_workout", "tp_get_workout_comments", "tp_get_workout_note",
+    "tp_get_workout_prs", "tp_get_workout_types", "tp_get_workouts",
+    "tp_get_zone_methods", "tp_list_athletes", "tp_list_athletes_in_group",
+    "tp_list_groups", "tp_list_notes", "tp_search_exercises",
+    "tp_validate_structure",
+})
+
+_DELETE_TOOLS: frozenset[str] = frozenset({
+    "tp_delete_availability", "tp_delete_equipment", "tp_delete_event",
+    "tp_delete_group", "tp_delete_library", "tp_delete_note",
+    "tp_delete_strength_workout", "tp_delete_workout", "tp_delete_workout_file",
+})
+
+_AUTH_TOOLS: frozenset[str] = frozenset({"tp_refresh_auth"})
+
+# Known tools whose name would otherwise trip the destructive-hint heuristic
+# below but are really reversible writes (e.g. group-membership management,
+# symmetric with tp_add_athletes_to_group).
+_WRITE_TOOLS: frozenset[str] = frozenset({"tp_remove_athletes_from_group"})
+
+# Substrings that force an *unknown* tool to the DELETE tier (fail safe).
+# Explicit classification above always wins over this heuristic.
+_DESTRUCTIVE_HINTS = ("delete", "remove", "clear", "purge", "destroy")
+
+_MODE_LEVELS: dict[str, frozenset[AccessLevel]] = {
+    "read": frozenset({AccessLevel.READ, AccessLevel.AUTH}),
+    "readonly": frozenset({AccessLevel.READ, AccessLevel.AUTH}),
+    "write": frozenset({AccessLevel.READ, AccessLevel.AUTH, AccessLevel.WRITE}),
+    "full": frozenset(
+        {AccessLevel.READ, AccessLevel.AUTH, AccessLevel.WRITE, AccessLevel.DELETE}
+    ),
+}
+
+DEFAULT_MODE = "full"  # backwards compatible; override with TP_MCP_MODE
+
+
+def classify(tool_name: str) -> AccessLevel:
+    """Return the capability tier for a tool name (fail safe)."""
+    if tool_name in _READ_TOOLS:
+        return AccessLevel.READ
+    if tool_name in _DELETE_TOOLS:
+        return AccessLevel.DELETE
+    if tool_name in _AUTH_TOOLS:
+        return AccessLevel.AUTH
+    if tool_name in _WRITE_TOOLS:
+        return AccessLevel.WRITE
+    # Unknown tool: fail safe. Treat removal-shaped names as destructive,
+    # everything else as a write (hidden in read-only mode).
+    if any(hint in tool_name for hint in _DESTRUCTIVE_HINTS):
+        return AccessLevel.DELETE
+    return AccessLevel.WRITE
+
+
+def current_mode() -> str:
+    """Resolved mode name from the environment (lowercased)."""
+    mode = os.environ.get(MODE_ENV_VAR, DEFAULT_MODE).strip().lower()
+    return mode if mode in _MODE_LEVELS else DEFAULT_MODE
+
+
+def _allowed_levels() -> frozenset[AccessLevel]:
+    return _MODE_LEVELS[current_mode()]
+
+
+def _disabled_tools() -> frozenset[str]:
+    raw = os.environ.get(DISABLED_ENV_VAR, "")
+    return frozenset(name.strip() for name in raw.split(",") if name.strip())
+
+
+def is_tool_allowed(tool_name: str) -> bool:
+    """Whether the tool may be exposed/called under the current policy."""
+    if tool_name in _disabled_tools():
+        return False
+    return classify(tool_name) in _allowed_levels()
+
+
+def denial_reason(tool_name: str) -> str:
+    """Human-readable reason a tool is blocked (safe to show the model)."""
+    if tool_name in _disabled_tools():
+        return (
+            f"Tool '{tool_name}' is disabled via {DISABLED_ENV_VAR}. "
+            "Ask the human operator to enable it if this is intended."
+        )
+    level = classify(tool_name)
+    return (
+        f"Tool '{tool_name}' requires a higher privilege ({level.value}) than the "
+        f"current {MODE_ENV_VAR}='{current_mode()}' allows. The human operator "
+        f"must raise {MODE_ENV_VAR} (read < write < full) to permit this."
+    )
+
+
+def policy_summary() -> str:
+    """One-line description for startup logging."""
+    disabled = _disabled_tools()
+    extra = f", {len(disabled)} tool(s) explicitly disabled" if disabled else ""
+    return f"access policy: {MODE_ENV_VAR}='{current_mode()}'{extra}"

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -13,7 +13,7 @@ from mcp.types import (
     Tool,
 )
 
-from tp_mcp.access import is_tool_allowed, denial_reason, policy_summary
+from tp_mcp.access import denial_reason, is_tool_allowed, policy_summary
 from tp_mcp.auth import get_credential, validate_auth
 from tp_mcp.client.context import athlete_override
 from tp_mcp.tools import (

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -13,6 +13,7 @@ from mcp.types import (
     Tool,
 )
 
+from tp_mcp.access import is_tool_allowed, denial_reason, policy_summary
 from tp_mcp.auth import get_credential, validate_auth
 from tp_mcp.client.context import athlete_override
 from tp_mcp.tools import (
@@ -1294,8 +1295,13 @@ for _tool in TOOLS:
 
 @server.list_tools()
 async def list_tools() -> list[Tool]:
-    """List available tools."""
-    return TOOLS
+    """List available tools, filtered by the active access policy.
+
+    Tools above the configured privilege (TP_MCP_MODE) or explicitly
+    disabled (TP_MCP_DISABLED_TOOLS) are hidden, so the model never sees
+    capabilities the human operator has not granted.
+    """
+    return [tool for tool in TOOLS if is_tool_allowed(tool.name)]
 
 
 # ---------------------------------------------------------------------------
@@ -1723,6 +1729,17 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     """Handle tool calls."""
     logger.info("Tool call: %s", name)
 
+    # Enforce the access policy (defense in depth: list_tools already hides
+    # disallowed tools, but reject here too in case one is called by name).
+    if not is_tool_allowed(name):
+        logger.warning("Blocked tool call by access policy: %s", name)
+        blocked = {
+            "isError": True,
+            "error_code": "TOOL_NOT_ALLOWED",
+            "message": denial_reason(name),
+        }
+        return [TextContent(type="text", text=json.dumps(blocked, indent=2))]
+
     # Extract athlete targeting for coach accounts and set context var
     athlete_target = arguments.pop("athlete", None)
     token = athlete_override.set(athlete_target)
@@ -1770,6 +1787,7 @@ async def _validate_auth_on_startup() -> bool:
 async def run_server_async() -> None:
     """Run the MCP server (async)."""
     logger.info("Starting TrainingPeaks MCP Server")
+    logger.info(policy_summary())
     await _validate_auth_on_startup()
 
     async with stdio_server() as (read_stream, write_stream):

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -1,0 +1,70 @@
+"""Tests for the least-privilege access policy."""
+
+import pytest
+
+from tp_mcp import access
+from tp_mcp.access import AccessLevel, classify, is_tool_allowed
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(access.MODE_ENV_VAR, raising=False)
+    monkeypatch.delenv(access.DISABLED_ENV_VAR, raising=False)
+
+
+def test_default_mode_is_full_backwards_compatible():
+    assert access.current_mode() == "full"
+    assert is_tool_allowed("tp_delete_workout")
+    assert is_tool_allowed("tp_create_workout")
+    assert is_tool_allowed("tp_get_workouts")
+
+
+def test_read_mode_blocks_all_writes_and_deletes(monkeypatch):
+    monkeypatch.setenv(access.MODE_ENV_VAR, "read")
+    assert is_tool_allowed("tp_get_workouts")            # read ok
+    assert is_tool_allowed("tp_refresh_auth")            # auth ok
+    assert not is_tool_allowed("tp_create_workout")      # write blocked
+    assert not is_tool_allowed("tp_update_ftp")          # write blocked
+    assert not is_tool_allowed("tp_delete_workout")      # delete blocked
+    assert not is_tool_allowed("tp_upload_workout_file")  # write blocked
+
+
+def test_write_mode_allows_writes_but_not_deletes(monkeypatch):
+    monkeypatch.setenv(access.MODE_ENV_VAR, "write")
+    assert is_tool_allowed("tp_create_workout")
+    assert is_tool_allowed("tp_update_ftp")
+    assert not is_tool_allowed("tp_delete_workout")
+    assert not is_tool_allowed("tp_delete_group")
+
+
+def test_disabled_list_overrides_mode(monkeypatch):
+    monkeypatch.setenv(access.MODE_ENV_VAR, "full")
+    monkeypatch.setenv(access.DISABLED_ENV_VAR, "tp_upload_workout_file, tp_delete_workout")
+    assert not is_tool_allowed("tp_upload_workout_file")
+    assert not is_tool_allowed("tp_delete_workout")
+    assert is_tool_allowed("tp_create_workout")  # not in the disabled list
+
+
+def test_unknown_tool_fails_safe(monkeypatch):
+    # Unknown non-destructive name -> WRITE (hidden in read mode)
+    monkeypatch.setenv(access.MODE_ENV_VAR, "read")
+    assert classify("tp_frobnicate_thing") == AccessLevel.WRITE
+    assert not is_tool_allowed("tp_frobnicate_thing")
+    # Unknown removal-shaped name -> DELETE (hidden unless full)
+    assert classify("tp_purge_everything") == AccessLevel.DELETE
+    monkeypatch.setenv(access.MODE_ENV_VAR, "write")
+    assert not is_tool_allowed("tp_purge_everything")
+
+
+def test_invalid_mode_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(access.MODE_ENV_VAR, "banana")
+    assert access.current_mode() == "full"
+
+
+def test_classification_partitions_all_known_tools():
+    # Every delete tool classifies as DELETE; sanity on the read set too.
+    for name in access._DELETE_TOOLS:
+        assert classify(name) == AccessLevel.DELETE
+    for name in access._READ_TOOLS:
+        assert classify(name) == AccessLevel.READ
+    assert classify("tp_refresh_auth") == AccessLevel.AUTH


### PR DESCRIPTION
## Summary

Adds an **opt-in least-privilege access policy** so operators can restrict which tools the AI assistant is able to see and call. This lets people run the server in read-only or write-only (no-delete) modes, which is valuable because a session cookie grants full account access and the model drives 9 destructive `tp_delete_*` tools plus file upload.

Fully backwards compatible: with no configuration the behavior is unchanged (`full` mode).

## Motivation

The server exposes 78 tools, including 9 that permanently delete data (`tp_delete_workout`, `tp_delete_event`, `tp_delete_group`, …) and `tp_upload_workout_file` which reads an arbitrary local path. A confused or prompt-injected model could therefore modify or destroy TrainingPeaks data. Today the only mitigation is the MCP client's per-call approval prompt. This PR adds server-side least-privilege as defense in depth, configured entirely from the client's `env` block.

## What changed

- **New `src/tp_mcp/access.py`** — self-contained policy module (only depends on `os`/`enum`). Classifies every tool as `read` / `write` / `delete` / `auth` and decides what the active mode permits.
- **`server.py`** — `list_tools()` now hides tools above the active privilege, and `call_tool()` rejects them as defense in depth. Startup logs the active policy.
- **Tests** — `tests/test_access.py` covers the modes, the disable-list, and fail-safe classification.

## Configuration

```jsonc
"env": {
  "TP_MCP_MODE": "read",   // read | write | full (default: full)
  "TP_MCP_DISABLED_TOOLS": "tp_upload_workout_file"  // optional, comma-separated
}
```

| Mode | Exposes | Blocks |
|------|---------|--------|
| `read` | 37 read/auth tools | all writes and deletes |
| `write` | + create/update tools | the 9 destructive deletes |
| `full` (default) | all 78 | nothing |

## Design notes

- **Fail safe:** an unknown/future tool is treated as `write` (hidden in read-only), and any unknown name matching a destructive hint (`delete`/`remove`/`purge`/…) is treated as `delete`, so new tools can't silently leak into a restricted mode.
- **Two enforcement points:** filtered in `list_tools` (model never sees them) and rejected in `call_tool` (in case a name is called directly).
- Classification is an explicit, audited allow-list — no heuristic can promote a destructive tool into a lower tier.

## Testing

`pytest tests/test_access.py` — modes, disable-list, and fail-safe classification. Verified the partition against the live tool list: 36 read / 32 write / 9 delete / 1 auth, and that no `delete` tool is ever exposed in `read` or `write` mode.
