### PR TITLE
fix(analyze): replace dead v1 endpoint with v2 summary/charts/laps

### DIFF
--- a/src/tp_mcp/tools/analyze.py
+++ b/src/tp_mcp/tools/analyze.py
@@ -1,8 +1,37 @@
-"""Tool for workout analysis via the Peaksware analysis API."""
+"""Tool for workout analysis via the Peaksware analysis API.
+
+TrainingPeaks retired the monolithic v1 endpoint
+(``POST /workout-analysis/v1/analyze``) — confirmed dead 2026-07 (every
+workout, every account, every age, 404 with an empty body from the real
+backend, not the gateway — auth was never the issue). Live browser-network
+tracing showed the current web app instead calls three narrower v2
+endpoints per workout:
+
+  * ``POST /workout-analysis/v2/analyze/summary`` — whole-workout totals
+    (TSS/IF/NP/EF/decoupling/...).
+  * ``POST /workout-analysis/v2/analyze/charts``  — per-second time-series
+    plus per-channel min/max/average/zones.
+  * ``POST /workout-analysis/v2/analyze/laps``    — device-recorded laps
+    (WorkoutStepIndex/Intensity/LapTrigger/AveragePace/...).
+
+All three take a body of just ``{"workoutId": <id>}`` — no
+``viewingPersonId`` needed even for a coach viewing an athlete's workout
+(verified live: the workout id alone is sufficient, confirmed with and
+without the field for a coach-owned athlete).
+
+The three responses are merged back into the same shape the rest of this
+codebase (and any downstream consumer) already expects from
+``parse_workout_analysis`` — so only this fetch layer needed to change.
+``summary`` is required (its absence means the workout genuinely isn't
+analyzable, mirroring the old v1 404 semantics); ``charts``/``laps`` degrade
+gracefully to empty on a 404 (some entries — e.g. manually logged, no device
+file — legitimately lack per-second/lap data while still having totals).
+"""
 
 import json
 import logging
 import tempfile
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -18,9 +47,13 @@ ANALYSIS_API_BASE = "https://api.peakswaresb.com"
 ANALYSIS_TIMEOUT = 60.0
 ANALYSIS_DATA_DIR = Path(tempfile.gettempdir()) / "tp-mcp" / "analysis"
 
+_SUMMARY_PATH = "/workout-analysis/v2/analyze/summary"
+_CHARTS_PATH = "/workout-analysis/v2/analyze/charts"
+_LAPS_PATH = "/workout-analysis/v2/analyze/laps"
+
 
 def _save_analysis_json(workout_id: int, data: dict[str, Any]) -> str:
-    """Save full analysis data to a JSON file.
+    """Save full analysis data (including time-series) to a JSON file.
 
     Returns:
         Absolute path to the saved file.
@@ -29,6 +62,88 @@ def _save_analysis_json(workout_id: int, data: dict[str, Any]) -> str:
     filepath = ANALYSIS_DATA_DIR / f"workout_{workout_id}.json"
     filepath.write_text(json.dumps(data, indent=2))
     return str(filepath)
+
+
+def _error_for_status(status_code: int, workout_id: str) -> dict[str, Any] | None:
+    """Map a non-200 analysis-API status to our error envelope, or None for 200."""
+    if status_code == 401:
+        return {
+            "isError": True,
+            "error_code": "AUTH_EXPIRED",
+            "message": "Session expired. Run 'tp-mcp auth' to re-authenticate.",
+        }
+    if status_code == 404:
+        return {
+            "isError": True,
+            "error_code": "NOT_FOUND",
+            "message": f"Workout {workout_id} not found for analysis.",
+        }
+    if status_code != 200:
+        return {
+            "isError": True,
+            "error_code": "API_ERROR",
+            "message": f"Analysis API error: {status_code}",
+        }
+    return None
+
+
+async def _post_analysis(
+    http_client: httpx.AsyncClient,
+    path: str,
+    headers: dict[str, str],
+    workout_id: int,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """POST ``{"workoutId": workout_id}`` to a v2 analysis endpoint.
+
+    Returns:
+        ``(body, None)`` on success, or ``(None, error_envelope)``.
+    """
+    try:
+        response = await http_client.post(
+            f"{ANALYSIS_API_BASE}{path}",
+            headers=headers,
+            json={"workoutId": workout_id},
+        )
+    except httpx.TimeoutException:
+        return None, {
+            "isError": True,
+            "error_code": "NETWORK_ERROR",
+            "message": "Analysis request timed out.",
+        }
+    except httpx.RequestError:
+        logger.exception("Network error during workout analysis (%s)", path)
+        return None, {
+            "isError": True,
+            "error_code": "NETWORK_ERROR",
+            "message": "A network error occurred.",
+        }
+
+    err = _error_for_status(response.status_code, str(workout_id))
+    if err:
+        return None, err
+
+    try:
+        return response.json(), None
+    except Exception:
+        return None, {
+            "isError": True,
+            "error_code": "API_ERROR",
+            "message": "Failed to parse analysis response.",
+        }
+
+
+def _stop_timestamp(start_iso: str | None, elapsed_seconds: Any) -> str | None:
+    """v2's summary endpoint only gives ``startTimestamp`` — derive the stop
+    from ``TotalElapsedTime`` (wall-clock elapsed, includes any pauses), to
+    keep feeding the same start/stop pair the rest of the codebase expects
+    (multisport-day ordering, gap detection, local-time display)."""
+    if not start_iso or not isinstance(elapsed_seconds, (int, float)):
+        return None
+    try:
+        start_dt = datetime.fromisoformat(start_iso)
+    except ValueError:
+        return None
+    return (start_dt + timedelta(seconds=float(elapsed_seconds))).isoformat()
 
 
 async def tp_analyze_workout(workout_id: str) -> dict[str, Any]:
@@ -81,7 +196,7 @@ async def tp_analyze_workout(workout_id: str) -> dict[str, Any]:
             }
 
         # Analysis API is on a different domain than the main TP API,
-        # so we make a direct httpx call with the Bearer token.
+        # so we make direct httpx calls with the Bearer token.
         headers = {
             "Authorization": f"Bearer {access_token}",
             "Accept": "application/json, text/javascript, */*; q=0.01",
@@ -90,54 +205,71 @@ async def tp_analyze_workout(workout_id: str) -> dict[str, Any]:
             "Referer": "https://app.trainingpeaks.com/",
         }
 
-        try:
-            async with httpx.AsyncClient(timeout=ANALYSIS_TIMEOUT) as http_client:
-                response = await http_client.post(
-                    f"{ANALYSIS_API_BASE}/workout-analysis/v1/analyze",
-                    headers=headers,
-                    json={"workoutId": wid, "viewingPersonId": athlete_id},
-                )
-        except httpx.TimeoutException:
-            return {
-                "isError": True,
-                "error_code": "NETWORK_ERROR",
-                "message": "Analysis request timed out.",
-            }
-        except httpx.RequestError:
-            logger.exception("Network error during workout analysis")
-            return {
-                "isError": True,
-                "error_code": "NETWORK_ERROR",
-                "message": "A network error occurred.",
-            }
+        async with httpx.AsyncClient(timeout=ANALYSIS_TIMEOUT) as http_client:
+            summary, err = await _post_analysis(http_client, _SUMMARY_PATH, headers, wid)
+            if err:
+                return err
 
-        if response.status_code == 401:
-            return {
-                "isError": True,
-                "error_code": "AUTH_EXPIRED",
-                "message": "Session expired. Run 'tp-mcp auth' to re-authenticate.",
-            }
-        if response.status_code == 404:
-            return {
-                "isError": True,
-                "error_code": "NOT_FOUND",
-                "message": f"Workout {workout_id} not found for analysis.",
-            }
-        if response.status_code != 200:
-            return {
-                "isError": True,
-                "error_code": "API_ERROR",
-                "message": f"Analysis API error: {response.status_code}",
-            }
+            charts, charts_err = await _post_analysis(http_client, _CHARTS_PATH, headers, wid)
+            if charts_err:
+                if charts_err.get("error_code") == "NOT_FOUND":
+                    logger.info("workout %s: no chart/stream data available", wid)
+                    charts = None
+                else:
+                    return charts_err
 
-        try:
-            raw_data = response.json()
-        except Exception:
-            return {
-                "isError": True,
-                "error_code": "API_ERROR",
-                "message": "Failed to parse analysis response.",
-            }
+            laps, laps_err = await _post_analysis(http_client, _LAPS_PATH, headers, wid)
+            if laps_err:
+                if laps_err.get("error_code") == "NOT_FOUND":
+                    logger.info("workout %s: no lap data available", wid)
+                    laps = None
+                else:
+                    return laps_err
+
+    summary_data = (summary or {}).get("data") or {}
+    totals = [
+        {"name": name, "value": meta.get("value"), "unit": meta.get("unit")}
+        for name, meta in summary_data.items()
+        if isinstance(meta, dict)
+    ]
+    start_ts = (summary or {}).get("startTimestamp")
+    elapsed = (summary_data.get("TotalElapsedTime") or {}).get("value")
+    stop_ts = _stop_timestamp(start_ts, elapsed)
+
+    charts_metadata = (charts or {}).get("metadata") or {}
+    data_elements = [
+        {
+            "identifier": ident,
+            "name": meta.get("friendlyName"),
+            "unit": meta.get("unit"),
+            "min": meta.get("minimum"),
+            "max": meta.get("maximum"),
+            "average": meta.get("average"),
+            "zones": meta.get("zones"),
+        }
+        for ident, meta in charts_metadata.items()
+        if isinstance(meta, dict)
+    ]
+    time_series = (charts or {}).get("data") or []
+
+    lap_column_meta = (laps or {}).get("columnMetadata") or {}
+    lap_columns = [
+        {"identifier": ident, **meta}
+        for ident, meta in lap_column_meta.items()
+        if isinstance(meta, dict)
+    ]
+    lap_data = (laps or {}).get("data") or []
+
+    raw_data: dict[str, Any] = {
+        "workoutId": wid,
+        "startTimestamp": start_ts,
+        "stopTimestamp": stop_ts,
+        "totals": totals,
+        "dataElements": data_elements,
+        "data": time_series,
+        "lapData": lap_data,
+        "lapColumns": lap_columns,
+    }
 
     try:
         analysis = parse_workout_analysis(raw_data)
@@ -153,7 +285,7 @@ async def tp_analyze_workout(workout_id: str) -> dict[str, Any]:
     data_file = _save_analysis_json(wid, raw_data)
 
     # Return summary inline, point to file for full data
-    totals = {t.name: {"value": t.value, "unit": t.unit} for t in analysis.totals}
+    totals_out = {t.name: {"value": t.value, "unit": t.unit} for t in analysis.totals}
 
     channels = [
         {
@@ -176,7 +308,7 @@ async def tp_analyze_workout(workout_id: str) -> dict[str, Any]:
         "workoutId": analysis.workout_id,
         "startTimestamp": analysis.start_timestamp,
         "stopTimestamp": analysis.stop_timestamp,
-        "totals": totals,
+        "totals": totals_out,
         "dataChannels": channels,
         "lapData": analysis.lap_data,
         "lapColumns": analysis.lap_columns,

--- a/src/tp_mcp/tools/analyze.py
+++ b/src/tp_mcp/tools/analyze.py
@@ -227,8 +227,12 @@ async def tp_analyze_workout(workout_id: str) -> dict[str, Any]:
                     return laps_err
 
     summary_data = (summary or {}).get("data") or {}
+    # Key totals by ``friendlyName`` (e.g. "NP", "Distance") rather than the v2
+    # identifier (e.g. "NormalizedPower", "TotalDistance") to preserve the same
+    # total names the old v1 endpoint returned; fall back to the identifier when
+    # a channel has no friendlyName.
     totals = [
-        {"name": name, "value": meta.get("value"), "unit": meta.get("unit")}
+        {"name": meta.get("friendlyName") or name, "value": meta.get("value"), "unit": meta.get("unit")}
         for name, meta in summary_data.items()
         if isinstance(meta, dict)
     ]

--- a/tests/test_tools/test_analyze.py
+++ b/tests/test_tools/test_analyze.py
@@ -231,6 +231,12 @@ class TestTpAnalyzeWorkout:
         assert "totals" in result
         assert "TSS" in result["totals"]
         assert result["totals"]["TSS"]["value"] == 75.2
+        # Totals keyed by friendlyName ("NP"/"Distance"), not the v2 identifier
+        # ("NormalizedPower"/"TotalDistance") — preserves the old v1 total names.
+        assert "NP" in result["totals"]
+        assert result["totals"]["NP"]["value"] == 220
+        assert "Distance" in result["totals"]
+        assert result["totals"]["Distance"]["value"] == 40.5
         assert len(result["dataChannels"]) == 2
         assert result["dataChannels"][0]["identifier"] == "Power"
         assert result["time_series_points"] == 3

--- a/tests/test_tools/test_analyze.py
+++ b/tests/test_tools/test_analyze.py
@@ -1,4 +1,4 @@
-"""Tests for workout analysis tool."""
+"""Tests for workout analysis tool (v2 endpoints: summary/charts/laps)."""
 
 import json
 from pathlib import Path
@@ -30,73 +30,124 @@ def _mock_tp_client(athlete_id=TEST_ATHLETE_ID):
     return mock_client
 
 
-def _sample_analysis_response():
-    """Minimal analysis API response for testing (matches real API structure)."""
+def _sample_summary_response():
+    """Minimal v2 summary response (shape confirmed live 2026-07)."""
     return {
-        "workoutId": 3553733903,
         "startTimestamp": "2025-01-08T12:00:00",
-        "stopTimestamp": "2025-01-08T13:00:00",
-        "totals": [
-            {"name": "TSS", "value": "75.2"},
-            {"name": "NP", "value": "220", "unit": "W"},
-            {"name": "Distance", "value": "40.5", "unit": "km"},
-        ],
-        "dataElements": [
-            {
-                "identifier": "Power",
-                "name": "Power",
-                "unit": "watts",
-                "min": 0,
-                "max": 800,
-                "average": 200,
-                "sequence": 1,
-                "enabled": True,
+        "data": {
+            "TotalElapsedTime": {"friendlyName": "Elapsed time", "value": 3600, "unit": "h:m:s"},
+            "TSS": {"friendlyName": "TSS", "value": 75.2},
+            "NormalizedPower": {"friendlyName": "NP", "value": 220, "unit": "W"},
+            "TotalDistance": {"friendlyName": "Distance", "value": 40.5, "unit": "km"},
+        },
+    }
+
+
+def _sample_charts_response():
+    """Minimal v2 charts response (shape confirmed live 2026-07)."""
+    return {
+        "metadata": {
+            "Power": {
+                "friendlyName": "Power", "unit": "watts",
+                "minimum": 0, "maximum": 800, "average": 200,
                 "zones": [
                     {"label": "1", "min": 0, "max": 150},
                     {"label": "2", "min": 151, "max": 200},
                 ],
-                "zonesVisible": True,
             },
-            {
-                "identifier": "HeartRate",
-                "name": "Heart Rate",
-                "unit": "bpm",
-                "min": 80,
-                "max": 185,
-                "average": 145,
-                "sequence": 2,
-                "enabled": True,
-                "zonesVisible": True,
+            "HeartRate": {
+                "friendlyName": "Heart Rate", "unit": "bpm",
+                "minimum": 80, "maximum": 185, "average": 145,
             },
-        ],
+        },
         "data": [
             {"time": 0, "Power": 150, "HeartRate": 120},
             {"time": 4, "Power": 200, "HeartRate": 135},
             {"time": 8, "Power": 220, "HeartRate": 145},
         ],
-        "lapData": [
-            {
-                "id": "1",
-                "Name": "Lap 1",
-                "TotalElapsedTime": "00:20:00",
-                "AveragePower": "210",
-                "AverageHeartRate": "142",
-            },
-        ],
-        "lapColumns": [
-            {"field": "Name", "headerName": "Name", "type": "string", "hidden": False},
-            {"field": "AveragePower", "headerName": "Avg power (W)", "type": "number", "hidden": False},
-        ],
-        "lapsGridSettings": {"pinned": [], "detectIntervals": False},
-        "state": {"intervalsDetected": False, "detectedIntervalCount": 0},
     }
 
 
+def _sample_laps_response():
+    """Minimal v2 laps response (shape confirmed live 2026-07)."""
+    return {
+        "columnMetadata": {
+            "Name": {"friendlyName": "Name", "type": "string"},
+            "AveragePower": {"friendlyName": "Avg power", "unit": "W", "type": "number"},
+        },
+        "data": [
+            {
+                "id": 0, "Name": "Lap 1", "TotalElapsedTime": 1200,
+                "AveragePower": 210, "AverageHeartRate": 142,
+                "WorkoutStepIndex": 0, "Intensity": "Active", "LapTrigger": "Distance",
+            },
+        ],
+        "lapDetectionState": {"powerIntervalsDetected": False},
+        "lapSources": {"Device": 1},
+    }
+
+
+def _mock_post_sequence(status_summary=200, status_charts=200, status_laps=200):
+    """Build an httpx.AsyncClient mock whose .post() side_effects the three
+    v2 calls in call order (summary, charts, laps)."""
+    def _resp(status, body):
+        m = MagicMock()
+        m.status_code = status
+        m.json.return_value = body
+        return m
+
+    responses = [
+        _resp(status_summary, _sample_summary_response()),
+        _resp(status_charts, _sample_charts_response()),
+        _resp(status_laps, _sample_laps_response()),
+    ]
+    mock_http_client = AsyncMock()
+    mock_http_client.post.side_effect = responses
+    return mock_http_client
+
+
 class TestWorkoutAnalysisModel:
-    """Tests for WorkoutAnalysis model."""
+    """Tests for WorkoutAnalysis model (unchanged — merged v2 output still
+    validates against the same shape)."""
 
     def test_parse_workout_analysis(self):
-        data = _sample_analysis_response()
+        data = {
+            "workoutId": 3553733903,
+            "startTimestamp": "2025-01-08T12:00:00",
+            "stopTimestamp": "2025-01-08T13:00:00",
+            "totals": [
+                {"name": "TSS", "value": "75.2"},
+                {"name": "NP", "value": "220", "unit": "W"},
+                {"name": "Distance", "value": "40.5", "unit": "km"},
+            ],
+            "dataElements": [
+                {
+                    "identifier": "Power", "name": "Power", "unit": "watts",
+                    "min": 0, "max": 800, "average": 200,
+                    "zones": [
+                        {"label": "1", "min": 0, "max": 150},
+                        {"label": "2", "min": 151, "max": 200},
+                    ],
+                },
+                {
+                    "identifier": "HeartRate", "name": "Heart Rate", "unit": "bpm",
+                    "min": 80, "max": 185, "average": 145,
+                },
+            ],
+            "data": [
+                {"time": 0, "Power": 150, "HeartRate": 120},
+                {"time": 4, "Power": 200, "HeartRate": 135},
+                {"time": 8, "Power": 220, "HeartRate": 145},
+            ],
+            "lapData": [
+                {"id": "1", "Name": "Lap 1", "TotalElapsedTime": "00:20:00",
+                 "AveragePower": "210", "AverageHeartRate": "142"},
+            ],
+            "lapColumns": [
+                {"identifier": "Name", "friendlyName": "Name", "type": "string"},
+                {"identifier": "AveragePower", "friendlyName": "Avg power (W)", "type": "number"},
+            ],
+        }
         result = parse_workout_analysis(data)
         assert result.workout_id == 3553733903
         assert len(result.totals) == 3
@@ -108,7 +159,7 @@ class TestWorkoutAnalysisModel:
         assert len(result.lap_data) == 1
         assert result.lap_data[0]["Name"] == "Lap 1"
         assert len(result.lap_columns) == 2
-        assert result.lap_columns[0]["field"] == "Name"
+        assert result.lap_columns[0]["identifier"] == "Name"
 
     def test_parse_minimal_analysis(self):
         data = {"workoutId": 123}
@@ -120,7 +171,7 @@ class TestWorkoutAnalysisModel:
 
 
 class TestTpAnalyzeWorkout:
-    """Tests for tp_analyze_workout tool."""
+    """Tests for tp_analyze_workout tool (v2: summary + charts + laps)."""
 
     @pytest.mark.asyncio
     async def test_invalid_workout_id(self):
@@ -162,49 +213,93 @@ class TestTpAnalyzeWorkout:
     @pytest.mark.asyncio
     async def test_success(self):
         mock_client = _mock_tp_client()
-        analysis_data = _sample_analysis_response()
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = analysis_data
 
         with patch("tp_mcp.tools.analyze.TPClient") as mock_tp:
             mock_tp.return_value.__aenter__.return_value = mock_client
             with patch("tp_mcp.tools.analyze.httpx.AsyncClient") as mock_httpx:
-                mock_http_client = AsyncMock()
-                mock_http_client.post.return_value = mock_response
+                mock_http_client = _mock_post_sequence()
                 mock_httpx.return_value.__aenter__.return_value = mock_http_client
 
                 result = await tp_analyze_workout("3553733903")
 
         assert "isError" not in result or not result.get("isError")
         assert result["workoutId"] == 3553733903
+        assert result["startTimestamp"] == "2025-01-08T12:00:00"
+        # stopTimestamp derived from TotalElapsedTime=3600s (1h) — v2 summary
+        # doesn't return it directly.
+        assert result["stopTimestamp"] == "2025-01-08T13:00:00"
         assert "totals" in result
         assert "TSS" in result["totals"]
-        assert result["totals"]["TSS"]["value"] == "75.2"
+        assert result["totals"]["TSS"]["value"] == 75.2
         assert len(result["dataChannels"]) == 2
         assert result["dataChannels"][0]["identifier"] == "Power"
         assert result["time_series_points"] == 3
+        assert len(result["lapData"]) == 1
+        assert result["lapData"][0]["Name"] == "Lap 1"
         assert "data_file" in result
         assert result["data_file"].endswith(".json")
 
-        # Verify full data was saved to file
+        # Verify full merged data was saved to file
         saved = json.loads(Path(result["data_file"]).read_text())
-        assert saved["data"] == analysis_data["data"]
         assert saved["data"][0]["Power"] == 150
+        assert saved["lapData"][0]["Name"] == "Lap 1"
+
+        # All three v2 endpoints were called, in order, with {"workoutId": ...}
+        calls = mock_http_client.post.call_args_list
+        assert len(calls) == 3
+        assert calls[0].args[0].endswith("/workout-analysis/v2/analyze/summary")
+        assert calls[1].args[0].endswith("/workout-analysis/v2/analyze/charts")
+        assert calls[2].args[0].endswith("/workout-analysis/v2/analyze/laps")
+        for c in calls:
+            assert c.kwargs["json"] == {"workoutId": 3553733903}
 
     @pytest.mark.asyncio
-    async def test_401_expired_auth(self):
+    async def test_charts_and_laps_404_degrade_gracefully(self):
+        """A workout with totals but no device file (e.g. manual entry) still
+        returns a usable result — charts/laps 404 is soft, summary 404 is not."""
         mock_client = _mock_tp_client()
-
-        mock_response = MagicMock()
-        mock_response.status_code = 401
 
         with patch("tp_mcp.tools.analyze.TPClient") as mock_tp:
             mock_tp.return_value.__aenter__.return_value = mock_client
             with patch("tp_mcp.tools.analyze.httpx.AsyncClient") as mock_httpx:
-                mock_http_client = AsyncMock()
-                mock_http_client.post.return_value = mock_response
+                mock_http_client = _mock_post_sequence(status_charts=404, status_laps=404)
+                mock_httpx.return_value.__aenter__.return_value = mock_http_client
+
+                result = await tp_analyze_workout("3553733903")
+
+        assert "isError" not in result or not result.get("isError")
+        assert result["totals"]["TSS"]["value"] == 75.2
+        assert result["dataChannels"] == []
+        assert result["lapData"] == []
+        assert result["time_series_points"] == 0
+
+    @pytest.mark.asyncio
+    async def test_401_expired_auth_on_summary(self):
+        mock_client = _mock_tp_client()
+
+        with patch("tp_mcp.tools.analyze.TPClient") as mock_tp:
+            mock_tp.return_value.__aenter__.return_value = mock_client
+            with patch("tp_mcp.tools.analyze.httpx.AsyncClient") as mock_httpx:
+                mock_http_client = _mock_post_sequence(status_summary=401)
+                mock_httpx.return_value.__aenter__.return_value = mock_http_client
+
+                result = await tp_analyze_workout("12345")
+
+        assert result["isError"] is True
+        assert result["error_code"] == "AUTH_EXPIRED"
+        # Auth failure short-circuits — charts/laps never called.
+        assert mock_http_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_401_on_charts_is_hard_failure(self):
+        """Unlike NOT_FOUND, an auth failure mid-sequence still propagates —
+        it's a systemic problem, not a data-availability gap."""
+        mock_client = _mock_tp_client()
+
+        with patch("tp_mcp.tools.analyze.TPClient") as mock_tp:
+            mock_tp.return_value.__aenter__.return_value = mock_client
+            with patch("tp_mcp.tools.analyze.httpx.AsyncClient") as mock_httpx:
+                mock_http_client = _mock_post_sequence(status_charts=401)
                 mock_httpx.return_value.__aenter__.return_value = mock_http_client
 
                 result = await tp_analyze_workout("12345")
@@ -213,23 +308,21 @@ class TestTpAnalyzeWorkout:
         assert result["error_code"] == "AUTH_EXPIRED"
 
     @pytest.mark.asyncio
-    async def test_404_not_found(self):
+    async def test_404_not_found_on_summary(self):
         mock_client = _mock_tp_client()
-
-        mock_response = MagicMock()
-        mock_response.status_code = 404
 
         with patch("tp_mcp.tools.analyze.TPClient") as mock_tp:
             mock_tp.return_value.__aenter__.return_value = mock_client
             with patch("tp_mcp.tools.analyze.httpx.AsyncClient") as mock_httpx:
-                mock_http_client = AsyncMock()
-                mock_http_client.post.return_value = mock_response
+                mock_http_client = _mock_post_sequence(status_summary=404)
                 mock_httpx.return_value.__aenter__.return_value = mock_http_client
 
                 result = await tp_analyze_workout("9999")
 
         assert result["isError"] is True
         assert result["error_code"] == "NOT_FOUND"
+        # summary is required — charts/laps never called.
+        assert mock_http_client.post.call_count == 1
 
     @pytest.mark.asyncio
     async def test_timeout(self):
@@ -265,27 +358,21 @@ class TestTpAnalyzeWorkout:
 
     @pytest.mark.asyncio
     async def test_sends_bearer_token_not_cookie(self):
-        """Verify the analysis API gets Bearer auth, not cookie auth."""
+        """Verify the analysis API gets Bearer auth, not cookie auth, and no
+        viewingPersonId (confirmed live: workoutId alone suffices, even for a
+        coach viewing an athlete's workout)."""
         mock_client = _mock_tp_client()
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = _sample_analysis_response()
 
         with patch("tp_mcp.tools.analyze.TPClient") as mock_tp:
             mock_tp.return_value.__aenter__.return_value = mock_client
             with patch("tp_mcp.tools.analyze.httpx.AsyncClient") as mock_httpx:
-                mock_http_client = AsyncMock()
-                mock_http_client.post.return_value = mock_response
+                mock_http_client = _mock_post_sequence()
                 mock_httpx.return_value.__aenter__.return_value = mock_http_client
 
                 await tp_analyze_workout("3553733903")
 
-                call_kwargs = mock_http_client.post.call_args
+                call_kwargs = mock_http_client.post.call_args_list[0]
                 headers = call_kwargs.kwargs["headers"]
                 assert headers["Authorization"] == f"Bearer {TEST_ACCESS_TOKEN}"
                 assert "Cookie" not in headers
-                assert call_kwargs.kwargs["json"] == {
-                    "workoutId": 3553733903,
-                    "viewingPersonId": TEST_ATHLETE_ID,
-                }
+                assert call_kwargs.kwargs["json"] == {"workoutId": 3553733903}


### PR DESCRIPTION
## Summary

Closes #136.

`POST /workout-analysis/v1/analyze` is dead — confirmed via live probing (not a data-freshness issue: tested workouts from the last week, ~2.5 months ago, and ~6 months ago across Run/Bike/Swim, 100% 404, including workouts that were successfully analyzed through this exact tool weeks earlier). Auth wasn't the problem either: an authenticated call reaches the real backend (`server: Kestrel` in the response headers) and gets a bodyless 404 from *it*, not from the API gateway (an unauthenticated call gets a clean gateway-level 401 instead).

A live browser network trace (captured by the repo owner while viewing an analyzed workout on trainingpeaks.com) showed the current web app instead calls three narrower v2 endpoints per workout, all with body `{"workoutId": id}`:

- `POST /workout-analysis/v2/analyze/summary` — whole-workout totals (TSS/IF/NP/EF/decoupling/...)
- `POST /workout-analysis/v2/analyze/charts` — per-second time-series + per-channel min/max/average/zones
- `POST /workout-analysis/v2/analyze/laps` — device-recorded laps (WorkoutStepIndex/Intensity/LapTrigger/AveragePace/...)

No `viewingPersonId` needed — confirmed live with and without it, and confirmed it works for a coach account viewing an athlete's workout (not just the logged-in user's own data), so cross-athlete access is unaffected.

## What changed

`tp_analyze_workout` now calls all three v2 endpoints and merges the result back into the exact same `WorkoutAnalysis` shape as before (`totals`/`dataElements`/`data`/`lapData`/`lapColumns`), so nothing downstream needs to change — same tool signature, same output contract, same `data_file` behavior.

- `summary` is required — a 404 there means the workout genuinely isn't analyzable, matching the old v1 semantics.
- `charts`/`laps` degrade gracefully on 404 (e.g. a manually-logged entry can legitimately lack a device file/laps while still having totals) — logged and returned as empty rather than failing the whole call.
- Any other error (401/network/parse failure) on any of the three still propagates as a hard failure, same as before.
- v2's summary doesn't return `stopTimestamp` directly (only `startTimestamp`) — derived from `TotalElapsedTime` to keep feeding the same start/stop pair consumers already expect.

Verified live end-to-end against a workout that 404'd repeatedly under v1 — now returns full totals, 19 laps, and a 900+ point time-series.

## Test plan

- [x] `ruff check src/` clean
- [x] `mypy src/` clean
- [x] `pytest tests/` — 493 passed (rewrote `test_analyze.py` for the 3-call sequence: success, charts/laps-404-degrades-gracefully, 401-on-summary short-circuits, 401-on-charts-is-still-a-hard-failure, 404-on-summary, timeout, network error, bearer-not-cookie + no viewingPersonId)
- [x] Live smoke test against a real, previously-404ing workout (see PR description above)

cc @JamsusMaximus