### PR TITLE
fix(events): correct tp_create_availability DTO — personId, type, availableSportTypes

### DIFF
--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -929,7 +929,11 @@ TOOLS = [
                 "sport_types": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Available sport types if limited",
+                    "description": "If limited, sports that REMAIN available — names (e.g. 'Run') or TP sport-type ids",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional short label shown on the calendar entry",
                 },
             },
             "required": ["start_date", "end_date"],
@@ -1661,6 +1665,7 @@ async def _h_create_avail(args):
     return await tp_create_availability(
         start_date=args["start_date"], end_date=args["end_date"],
         limited=args.get("limited", False), sport_types=args.get("sport_types"),
+        description=args.get("description"),
     )
 
 @_handler("tp_delete_availability")

--- a/src/tp_mcp/tools/events.py
+++ b/src/tp_mcp/tools/events.py
@@ -1035,6 +1035,8 @@ async def tp_create_availability(
             "startDate": f"{params.start_date.isoformat()}T00:00:00",
             "endDate": f"{params.end_date.isoformat()}T00:00:00",
             "type": 2 if limited else 1,
+            # "Other" is the only reason value verified against the live API;
+            # free-text context belongs in `description`.
             "reason": "Other",
         }
         if description:

--- a/src/tp_mcp/tools/events.py
+++ b/src/tp_mcp/tools/events.py
@@ -948,11 +948,38 @@ async def tp_get_availability(start_date: str, end_date: str) -> dict[str, Any]:
         }
 
 
+# Availability DTO verified live against TP (2026-07). The body identifies
+# the athlete via "personId" (numerically equal to the athlete id) — NOT
+# "athleteId": the server cross-checks it against the URL athlete id, and a
+# body where it fails to bind is rejected with 400 "AthleteId of request url
+# and AthleteId in body of request do not match". "type" is 1 = unavailable,
+# 2 = limited; limited entries list the sports that REMAIN available as TP
+# sport-type ids ("availableSportTypes", ids from /fitness/v6/workouttypes).
+_AVAILABILITY_SPORT_IDS = {
+    "swim": 1,
+    "bike": 2,
+    "run": 3,
+    "brick": 4,
+    "crosstrain": 5,
+    "race": 6,
+    "day off": 7,
+    "mountain bike": 8,
+    "mtb": 8,
+    "strength": 9,
+    "custom": 10,
+    "xc-ski": 11,
+    "rowing": 12,
+    "walk": 13,
+    "other": 100,
+}
+
+
 async def tp_create_availability(
     start_date: str,
     end_date: str,
     limited: bool = False,
     sport_types: list[str] | None = None,
+    description: str | None = None,
 ) -> dict[str, Any]:
     """Mark dates as unavailable or limited.
 
@@ -960,7 +987,9 @@ async def tp_create_availability(
         start_date: Start date (YYYY-MM-DD).
         end_date: End date (YYYY-MM-DD).
         limited: If True, mark as limited (not fully unavailable).
-        sport_types: If limited, list of available sport types.
+        sport_types: If limited, the sports that REMAIN available — names
+            (e.g. "Run") or TP sport-type ids.
+        description: Optional short label shown on the calendar entry.
 
     Returns:
         Dict with confirmation or error.
@@ -984,14 +1013,34 @@ async def tp_create_availability(
                 "message": "Could not get athlete ID. Re-authenticate.",
             }
 
+        sport_ids: list[int] = []
+        for s in sport_types or []:
+            if isinstance(s, int) or (isinstance(s, str) and s.isdigit()):
+                sport_ids.append(int(s))
+                continue
+            sid = _AVAILABILITY_SPORT_IDS.get(str(s).strip().lower())
+            if sid is None:
+                return {
+                    "isError": True,
+                    "error_code": "VALIDATION_ERROR",
+                    "message": (
+                        f"Unknown sport type '{s}'. Use a TP sport-type id or one of: "
+                        + ", ".join(sorted(_AVAILABILITY_SPORT_IDS))
+                    ),
+                }
+            sport_ids.append(sid)
+
         payload: dict[str, Any] = {
-            "athleteId": athlete_id,
+            "personId": athlete_id,
             "startDate": f"{params.start_date.isoformat()}T00:00:00",
             "endDate": f"{params.end_date.isoformat()}T00:00:00",
-            "limited": limited,
+            "type": 2 if limited else 1,
+            "reason": "Other",
         }
-        if limited and sport_types:
-            payload["sportTypes"] = sport_types
+        if description:
+            payload["description"] = description
+        if limited and sport_ids:
+            payload["availableSportTypes"] = sport_ids
 
         endpoint = f"/fitness/v1/athletes/{athlete_id}/availability"
         response = await client.post(endpoint, json=payload)

--- a/tests/test_tools/test_events.py
+++ b/tests/test_tools/test_events.py
@@ -294,13 +294,18 @@ class TestAvailability:
             result = await tp_create_availability(
                 start_date="2026-04-01", end_date="2026-04-07",
                 limited=True, sport_types=["Run", "Swim"],
+                description="Holiday",
             )
 
         assert result["success"] is True
         assert result["limited"] is True
         payload = mock_instance.post.call_args[1]["json"]
-        assert payload["limited"] is True
-        assert payload["sportTypes"] == ["Run", "Swim"]
+        assert payload["personId"] == 123
+        assert payload["type"] == 2
+        assert payload["availableSportTypes"] == [3, 1]
+        assert payload["description"] == "Holiday"
+        assert "athleteId" not in payload
+        assert "limited" not in payload
 
 
 class TestGetNote:


### PR DESCRIPTION
`tp_create_availability` has never worked against the live API — TP rejects every request with 400 *"AthleteId of request url and AthleteId in body of request do not match"*.

Verified live against `/fitness/v1/athletes/{id}/availability` (2026-07): the body identifies the athlete as **`personId`** (numerically equal to the athlete id), not `athleteId`; unavailable vs limited is **`type`** (1 / 2), not a `limited` boolean; and limited entries carry the sports that remain available as TP sport-type **ids** in `availableSportTypes` (ids per `/fitness/v6/workouttypes`), not name strings.

This PR maps sport names ("Run") to verified ids (ints pass through), adds an optional `description` (shown on the calendar entry), and updates the tool schema + tests to the real DTO. Round-trip verified live: POST both types → 200 with created entity, GET returns them, DELETE 200. Full detail in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HayfGxiWZUH9XjsmgyNUR