### PR TITLE
fix(tests): stop encrypted-storage tests deleting the real credential

### DIFF
--- a/tests/test_auth/test_encrypted.py
+++ b/tests/test_auth/test_encrypted.py
@@ -6,8 +6,8 @@ import os
 import pytest
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+from tp_mcp.auth import encrypted
 from tp_mcp.auth.encrypted import (
-    CREDENTIALS_FILE,
     EncryptedCredentialStore,
     _derive_key,
     _derive_key_legacy,
@@ -15,11 +15,18 @@ from tp_mcp.auth.encrypted import (
 
 
 @pytest.fixture(autouse=True)
-def _clean_credentials():
-    """Remove credential file before and after each test."""
-    CREDENTIALS_FILE.unlink(missing_ok=True)
-    yield
-    CREDENTIALS_FILE.unlink(missing_ok=True)
+def _isolate_credentials(tmp_path, monkeypatch):
+    """Redirect the credential store to a per-test temp directory.
+
+    The store reads CONFIG_DIR/CREDENTIALS_FILE from module globals at call
+    time, so patching the module attributes is sufficient. Without this, a
+    plain test run operates on the developer's REAL
+    ~/.config/trainingpeaks-mcp/credentials.enc — and deletes their live
+    login (this actually happened).
+    """
+    config_dir = tmp_path / "trainingpeaks-mcp"
+    monkeypatch.setattr(encrypted, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(encrypted, "CREDENTIALS_FILE", config_dir / "credentials.enc")
 
 
 class TestDeriveKey:
@@ -73,8 +80,8 @@ class TestEncryptedCredentialStore:
         nonce = os.urandom(12)
         aesgcm = AESGCM(legacy_key)
         ciphertext = aesgcm.encrypt(nonce, b"legacy-cookie", None)
-        CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        CREDENTIALS_FILE.write_bytes(base64.b64encode(nonce + ciphertext))
+        encrypted.CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        encrypted.CREDENTIALS_FILE.write_bytes(base64.b64encode(nonce + ciphertext))
 
         # Retrieve via store (should fall back to legacy and migrate)
         store = EncryptedCredentialStore()
@@ -91,8 +98,8 @@ class TestEncryptedCredentialStore:
 
     def test_decryption_failure_returns_error(self):
         """Corrupted file should return a graceful error."""
-        CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        CREDENTIALS_FILE.write_bytes(base64.b64encode(b"corrupted-data-here!!"))
+        encrypted.CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        encrypted.CREDENTIALS_FILE.write_bytes(base64.b64encode(b"corrupted-data-here!!"))
 
         store = EncryptedCredentialStore()
         result = store.get()


### PR DESCRIPTION
`tests/test_auth/test_encrypted.py` operates directly on the developer's real `~/.config/trainingpeaks-mcp/credentials.enc`: an autouse fixture unlinks it before **and** after every test, so any full test run silently logs the developer out. (Discovered the hard way — a plain `pytest` run wiped a live credential mid-session.)

This PR replaces the delete-the-real-file fixture with an autouse `tmp_path` + `monkeypatch` fixture redirecting `encrypted.CONFIG_DIR` / `encrypted.CREDENTIALS_FILE` to a per-test temp directory (the store reads these module globals at call time, so patching the attributes suffices). Direct file references in the legacy-migration and corruption tests now go through the patched attributes.

Verified: full suite passes (493 tests) and a sentinel `credentials.enc` survives the run byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HayfGxiWZUH9XjsmgyNUR