### PR TITLE
feat(plans): multi-week training plan tools (list / read / apply)

### DIFF
--- a/src/tp_mcp/client/http.py
+++ b/src/tp_mcp/client/http.py
@@ -1,6 +1,7 @@
 """HTTP client wrapper for TrainingPeaks API."""
 
 import asyncio
+import logging
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -9,6 +10,8 @@ from typing import Any
 import httpx
 
 from tp_mcp.auth import get_credential
+
+logger = logging.getLogger("tp-mcp")
 
 TP_API_BASE = "https://tpapi.trainingpeaks.com"
 DEFAULT_TIMEOUT = 30.0
@@ -52,6 +55,24 @@ class ErrorCode(Enum):
     VALIDATION_ERROR = "VALIDATION_ERROR"
     API_ERROR = "API_ERROR"
     NETWORK_ERROR = "NETWORK_ERROR"
+    FORBIDDEN_ENDPOINT = "FORBIDDEN_ENDPOINT"
+
+
+# Hard-blocked endpoints — destructive operations the connector must NEVER issue,
+# regardless of caller (tool, probe, or future code). DEFENSE-IN-DEPTH safeguard.
+#
+# /plans/v1/commands/applyplan — the NATIVE training-plan apply command. Live
+# incident 2026-06-17: applying a published plan via this command produced a
+# degenerate application that associated the SOURCE plan-template's own workouts
+# with the application; a subsequent Unapply ("remove all associated workouts")
+# then DELETED the template's 139 workouts, emptying a published Plan-Store plan.
+# The connector applies plans with a SYNTHETIC copy (tp_apply_training_plan), which
+# never calls this command, so blocking it loses no functionality.
+_FORBIDDEN_ENDPOINTS: tuple[str, ...] = ("/plans/v1/commands/applyplan",)
+
+
+def _is_forbidden(endpoint: str) -> bool:
+    return any(bad in endpoint for bad in _FORBIDDEN_ENDPOINTS)
 
 
 @dataclass
@@ -307,6 +328,16 @@ class TPClient:
         Returns:
             APIResponse with data or error.
         """
+        if _is_forbidden(endpoint):
+            logger.error("BLOCKED forbidden endpoint: %s %s", method, endpoint)
+            return APIResponse(
+                success=False,
+                error_code=ErrorCode.FORBIDDEN_ENDPOINT,
+                message=(f"Endpoint {endpoint} is disabled in this connector "
+                         "(destructive plan operation — has emptied a published plan). "
+                         "Use the synthetic tp_apply_training_plan instead."),
+            )
+
         await self._ensure_client()
         assert self._client is not None
 
@@ -471,6 +502,13 @@ class TPClient:
         Returns:
             RawResponse with binary content and headers, or error.
         """
+        if _is_forbidden(endpoint):
+            logger.error("BLOCKED forbidden endpoint: GET %s", endpoint)
+            return RawResponse(
+                success=False,
+                error_code=ErrorCode.FORBIDDEN_ENDPOINT,
+                message=f"Endpoint {endpoint} is disabled in this connector.",
+            )
         await self._ensure_client()
         assert self._client is not None
 

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -20,6 +20,7 @@ from tp_mcp.tools import (
     tp_add_note_comment,
     tp_add_workout_comment,
     tp_analyze_workout,
+    tp_apply_training_plan,
     tp_auth_status,
     tp_copy_workout,
     tp_create_availability,
@@ -63,6 +64,8 @@ from tp_mcp.tools import (
     tp_get_strength_summary,
     tp_get_strength_workout,
     tp_get_strength_workouts,
+    tp_get_training_plan,
+    tp_get_training_plan_workouts,
     tp_get_weekly_summary,
     tp_get_workout,
     tp_get_workout_comments,
@@ -75,6 +78,7 @@ from tp_mcp.tools import (
     tp_list_athletes_in_group,
     tp_list_groups,
     tp_list_notes,
+    tp_list_training_plans,
     tp_log_metrics,
     tp_pair_workout,
     tp_refresh_auth,
@@ -553,6 +557,53 @@ TOOLS = [
                 "end_date": {"type": "string", "description": "YYYY-MM-DD"},
             },
             "required": ["start_date", "end_date"],
+        },
+    ),
+    # --- Training Plans (multi-week Plan Store / "My Plans" — distinct from
+    #     workout libraries and the ATP) ---
+    Tool(
+        name="tp_list_training_plans",
+        description="List the coach's authored multi-week training plans (id, title, "
+                    "weeks, workout count, total hours, category, price).",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+    ),
+    Tool(
+        name="tp_get_training_plan",
+        description="Summary of one training plan: weeks, per-week duration/distance, "
+                    "sport breakdown, description.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "plan_id": {"type": "integer", "description": "Plan id (from tp_list_training_plans)"},
+            },
+            "required": ["plan_id"],
+        },
+    ),
+    Tool(
+        name="tp_get_training_plan_workouts",
+        description="All workouts of a training plan laid out by week/day "
+                    "(sport, title, description, duration, TSS, has_structure).",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "plan_id": {"type": "integer", "description": "Plan id"},
+            },
+            "required": ["plan_id"],
+        },
+    ),
+    Tool(
+        name="tp_apply_training_plan",
+        description="Apply a training plan to an athlete's calendar from a start date "
+                    "by copying each plan workout (with structure) to start_date + its "
+                    "relative day. Targets the athlete given via the athlete parameter.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "plan_id": {"type": "integer", "description": "Plan id"},
+                "start_date": {"type": "string", "description": "Calendar date for plan day 1 (YYYY-MM-DD)"},
+                "athlete": {"type": "string", "description": "Target athlete name or ID (coach accounts)"},
+            },
+            "required": ["plan_id", "start_date"],
         },
     ),
     # --- Athlete Settings ---
@@ -1553,6 +1604,19 @@ async def _h_weekly_summary(args): return await tp_get_weekly_summary(week_of=ar
 
 @_handler("tp_get_atp")
 async def _h_get_atp(args): return await tp_get_atp(start_date=args["start_date"], end_date=args["end_date"])
+
+@_handler("tp_list_training_plans")
+async def _h_list_training_plans(args): return await tp_list_training_plans()
+
+@_handler("tp_get_training_plan")
+async def _h_get_training_plan(args): return await tp_get_training_plan(plan_id=args["plan_id"])
+
+@_handler("tp_get_training_plan_workouts")
+async def _h_get_training_plan_workouts(args): return await tp_get_training_plan_workouts(plan_id=args["plan_id"])
+
+@_handler("tp_apply_training_plan")
+async def _h_apply_training_plan(args):
+    return await tp_apply_training_plan(plan_id=args["plan_id"], start_date=args["start_date"])
 
 # --- Athlete Settings ---
 @_handler("tp_get_athlete_settings")

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -49,6 +49,12 @@ from tp_mcp.tools.library import (
 )
 from tp_mcp.tools.metrics import tp_get_metrics, tp_get_nutrition, tp_log_metrics
 from tp_mcp.tools.peaks import tp_get_peaks, tp_get_workout_prs
+from tp_mcp.tools.plans import (
+    tp_apply_training_plan,
+    tp_get_training_plan,
+    tp_get_training_plan_workouts,
+    tp_list_training_plans,
+)
 from tp_mcp.tools.profile import tp_get_profile, tp_list_athletes
 from tp_mcp.tools.refresh_auth import tp_refresh_auth
 from tp_mcp.tools.settings import (
@@ -116,6 +122,10 @@ __all__ = [
     "tp_download_workout_file",
     "tp_get_athlete_settings",
     "tp_get_atp",
+    "tp_list_training_plans",
+    "tp_get_training_plan",
+    "tp_get_training_plan_workouts",
+    "tp_apply_training_plan",
     "tp_get_availability",
     "tp_get_equipment",
     "tp_get_events",

--- a/src/tp_mcp/tools/plans.py
+++ b/src/tp_mcp/tools/plans.py
@@ -191,15 +191,22 @@ async def tp_get_training_plan_workouts(plan_id: int | str) -> dict[str, Any]:
         return {"plan_id": v.plan_id, "workouts": out, "count": len(out)}
 
 
-# NB on the NATIVE apply command (reverse-engineered from the web app, NOT used):
-# POST /plans/v1/commands/applyplan with [{athleteId(str), planId, planTitle,
-# startType:1, targetDate}] registers an applied-plan record (returns appliedPlanId)
-# but does NOT materialise the workouts by itself — the web client then DRIVES an
-# async job by repeatedly polling POST /plans/v1/appliedplans/applyPlanStatus until
-# done. That status call's exact body shape isn't pinned (it rejects
-# {"AppliedPlanIds":[...]} with 400) and the protocol is a fragile poll-loop, so we
-# use the SYNTHETIC copy below instead: deterministic, one-shot, fully verified.
-# (Revisit native only with a full HAR of the applyPlanStatus request + its polling.)
+# NB on the NATIVE apply command — fully reverse-engineered (Claude-in-Chrome HAR +
+# live probes) but NOT used, because every server-side replication produced a
+# DEGENERATE apply (an applied-plan record with endDate == startDate-ish and ZERO
+# workouts materialised), and the body that makes the web's apply actually populate
+# the calendar could not be reproduced:
+#   1. POST /plans/v1/commands/applyplan  body=[{athleteId(str), planId, planTitle,
+#      startType, targetDate}] → [{appliedPlanId, startDate, endDate, ...}].
+#   2. Async job; drive it by polling POST /plans/v1/appliedplans/applyPlanStatus
+#      with a BARE array body [appliedPlanId] (NOT {"AppliedPlanIds":[...]} — that
+#      400s), response {"batchStatus": N}, 2 = complete.
+# Live result: with startType 1 AND 2 the command returns batchStatus 2 (="done")
+# yet creates NO workouts on the calendar (verified across several far-date applies
+# on two athletes); startType 0 is rejected. The only captured web payload was a
+# startType:1 apply that was itself degenerate, so the working-apply body is unknown.
+# → We use the SYNTHETIC copy below: deterministic, one-shot, fully verified live.
+# (Revisit native only with a HAR of a CONFIRMED-WORKING web apply's request body.)
 
 
 async def tp_apply_training_plan(plan_id: int | str, start_date: str) -> dict[str, Any]:

--- a/src/tp_mcp/tools/plans.py
+++ b/src/tp_mcp/tools/plans.py
@@ -1,0 +1,269 @@
+"""Training Plan tools — list/read authored multi-week plans + apply to an athlete.
+
+TrainingPeaks training plans (Plan Store / "My Plans") are a separate entity from
+workout libraries (exerciselibrary) and the ATP. Endpoints (tpapi):
+  GET  /plans/v1/plans                                  → authored plans
+  GET  /plans/v1/plans/{id}                             → plan summary
+  GET  /plans/v1/plans/{id}/workouts/{start}/{end}      → all plan workouts (w/ structure)
+
+Workouts are anchored at the plan's startDate; ``workoutDay`` gives the relative
+day (day 1 = startDate). ``tp_apply_training_plan`` materialises the plan on an
+athlete's calendar by COPYING each workout to ``start_date + relative_offset``
+via the proven create endpoint (POST /fitness/v6/athletes/{id}/workouts) — there
+is no black-box-discoverable native "apply" endpoint, so this is a faithful
+client-side copy (structure/description/TSS preserved; TP does not record it as a
+linked plan application).
+"""
+
+import json
+import logging
+from datetime import date as date_type
+from datetime import timedelta
+from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+from tp_mcp.client import TPClient
+from tp_mcp.tools._validation import format_validation_error
+
+logger = logging.getLogger("tp-mcp")
+
+# workoutTypeValueId → sport label (mirrors SPORT_TYPE_MAP in workouts.py; for all
+# standard sports the family id equals the value id, so family = value on create).
+_SPORT_BY_TYPE: dict[int, str] = {
+    1: "Swim", 2: "Bike", 3: "Run", 4: "Brick", 5: "Crosstrain", 6: "Race",
+    7: "DayOff", 8: "MtnBike", 9: "Strength", 11: "XCSki", 12: "Rowing", 13: "Walk",
+    100: "Other",
+}
+
+# workoutTypeValueId 100 ("Other") is used by plans for training-PERIOD annotations
+# (e.g. «Период: базовый») — calendar banners, not trainable sessions. They can't
+# be replicated as workouts on apply (TP renders them as period bands), so apply
+# skips them rather than creating junk calendar entries.
+_PERIOD_TYPE_ID = 100
+
+
+def _err(code: str, msg: str | None) -> dict[str, Any]:
+    return {"isError": True, "error_code": code, "message": msg or "error"}
+
+
+def _api_err(response: Any) -> dict[str, Any]:
+    return _err(response.error_code.value if response.error_code else "API_ERROR",
+                response.message)
+
+
+class _PlanIdInput(BaseModel):
+    plan_id: int = Field(gt=0)
+
+    @field_validator("plan_id", mode="before")
+    @classmethod
+    def _coerce(cls, v: object) -> object:
+        return int(v) if isinstance(v, str) else v
+
+
+class _ApplyInput(BaseModel):
+    plan_id: int = Field(gt=0)
+    start_date: date_type
+
+    @field_validator("plan_id", mode="before")
+    @classmethod
+    def _coerce_id(cls, v: object) -> object:
+        return int(v) if isinstance(v, str) else v
+
+    @field_validator("start_date", mode="before")
+    @classmethod
+    def _coerce_date(cls, v: object) -> object:
+        return date_type.fromisoformat(v) if isinstance(v, str) else v
+
+
+async def tp_list_training_plans() -> dict[str, Any]:
+    """List the coach's authored training plans (slim)."""
+    async with TPClient() as client:
+        r = await client.get("/plans/v1/plans")
+        if r.is_error:
+            return _api_err(r)
+        out = []
+        for p in r.data or []:
+            dur = p.get("trainingDurationByWeek") or []
+            out.append({
+                "plan_id": p.get("planId"),
+                "title": (p.get("title") or "").strip(),
+                "weeks": p.get("weekCount"),
+                "workouts": p.get("workoutCount"),
+                "total_hours": round(sum(dur), 1) if dur else None,
+                "category": p.get("planCategory"),
+                "price": p.get("price"),
+                "is_public": p.get("isPublic"),
+                "event_date": p.get("eventDate"),
+            })
+        return {"plans": out, "count": len(out)}
+
+
+async def tp_get_training_plan(plan_id: int | str) -> dict[str, Any]:
+    """Summary of one plan: weeks, per-week duration/distance, sport breakdown."""
+    try:
+        v = _PlanIdInput(plan_id=plan_id)  # type: ignore[arg-type]
+    except (ValidationError, ValueError) as e:
+        return _err("VALIDATION_ERROR",
+                    format_validation_error(e) if isinstance(e, ValidationError) else str(e))
+    async with TPClient() as client:
+        r = await client.get(f"/plans/v1/plans/{v.plan_id}")
+        if r.is_error:
+            return _api_err(r)
+        d = r.data or {}
+        dur = d.get("trainingDurationByWeek") or []
+        dist = d.get("trainingDistanceByWeek") or []
+        by_sport = []
+        for t in d.get("plannedWorkoutTypeDurations") or []:
+            if (t.get("duration") or 0) or (t.get("distance") or 0):
+                by_sport.append({
+                    "sport": _SPORT_BY_TYPE.get(t.get("workoutTypeId"), str(t.get("workoutTypeId"))),
+                    "hours": round(t.get("duration") or 0, 1),
+                    "km": round((t.get("distance") or 0) / 1000, 1),
+                })
+        return {
+            "plan_id": d.get("planId"),
+            "title": (d.get("title") or "").strip(),
+            "weeks": d.get("weekCount"),
+            "day_count": d.get("dayCount"),
+            "workouts": d.get("workoutCount"),
+            "description": d.get("description"),
+            "duration_by_week_h": [round(x, 2) for x in dur],
+            "distance_by_week_km": [round(x / 1000, 1) for x in dist],
+            "by_sport": by_sport,
+            "start_date": (d.get("startDate") or "")[:10] or None,
+        }
+
+
+async def _fetch_plan_workouts(
+    client: TPClient, plan_id: int,
+) -> tuple[date_type | None, Any]:
+    """(plan startDate, [workouts]) or (None, error_dict). The plan-workouts range
+    endpoint is NOT 90-day-capped (verified on a 112-day plan)."""
+    det = await client.get(f"/plans/v1/plans/{plan_id}")
+    if det.is_error:
+        return None, _api_err(det)
+    d = det.data or {}
+    start = (d.get("startDate") or "")[:10]
+    days = d.get("dayCount") or (d.get("weekCount") or 0) * 7
+    if not start or not days:
+        return None, _err("API_ERROR", "Plan has no startDate/dayCount.")
+    sd = date_type.fromisoformat(start)
+    ed = sd + timedelta(days=int(days) + 1)
+    wr = await client.get(f"/plans/v1/plans/{plan_id}/workouts/{sd.isoformat()}/{ed.isoformat()}")
+    if wr.is_error:
+        return None, _api_err(wr)
+    return sd, (wr.data or [])
+
+
+async def tp_get_training_plan_workouts(plan_id: int | str) -> dict[str, Any]:
+    """All workouts of a plan, laid out by week/day (slim — title/description/
+    duration/TSS/has_structure; full structure is omitted to keep the payload
+    small, but is used internally by tp_apply_training_plan)."""
+    try:
+        v = _PlanIdInput(plan_id=plan_id)  # type: ignore[arg-type]
+    except (ValidationError, ValueError) as e:
+        return _err("VALIDATION_ERROR",
+                    format_validation_error(e) if isinstance(e, ValidationError) else str(e))
+    async with TPClient() as client:
+        sd, ws = await _fetch_plan_workouts(client, v.plan_id)
+        if sd is None:
+            return ws  # error dict
+        out = []
+        for w in ws:
+            wd = (w.get("workoutDay") or "")[:10]
+            try:
+                rel = (date_type.fromisoformat(wd) - sd).days + 1 if wd else None
+            except ValueError:
+                rel = None
+            out.append({
+                "week": ((rel - 1) // 7 + 1) if rel else None,
+                "day": rel,
+                "sport": _SPORT_BY_TYPE.get(w.get("workoutTypeValueId"), str(w.get("workoutTypeValueId"))),
+                "title": (w.get("title") or "").strip(),
+                "description": w.get("description"),
+                "duration_min": round((w.get("totalTimePlanned") or 0) * 60) or None,
+                "distance_km": round((w.get("distancePlanned") or 0) / 1000, 2) or None,
+                "tss": w.get("tssPlanned"),
+                "has_structure": w.get("structure") is not None,
+            })
+        out.sort(key=lambda x: (x["day"] or 0))
+        return {"plan_id": v.plan_id, "workouts": out, "count": len(out)}
+
+
+async def tp_apply_training_plan(plan_id: int | str, start_date: str) -> dict[str, Any]:
+    """Apply a plan to the athlete's calendar from ``start_date`` by copying each
+    plan workout to ``start_date + relative_day`` (structure/description/TSS kept).
+    Athlete is resolved from the coach's athlete_override context (the ``athlete``
+    arg, handled by the server dispatch)."""
+    try:
+        v = _ApplyInput(plan_id=plan_id, start_date=start_date)  # type: ignore[arg-type]
+    except (ValidationError, ValueError) as e:
+        return _err("VALIDATION_ERROR",
+                    format_validation_error(e) if isinstance(e, ValidationError) else str(e))
+    async with TPClient() as client:
+        athlete_id = await client.ensure_athlete_id()
+        if not athlete_id:
+            return _err("AUTH_INVALID", "Could not get athlete ID. Re-authenticate.")
+        sd, ws = await _fetch_plan_workouts(client, v.plan_id)
+        if sd is None:
+            return ws  # error dict
+
+        created = failed = skipped = 0
+        first_error: str | None = None
+        for w in ws:
+            tid = w.get("workoutTypeValueId")
+            if tid == _PERIOD_TYPE_ID:
+                skipped += 1   # training-period annotation, not a session
+                continue
+            wd = (w.get("workoutDay") or "")[:10]
+            try:
+                rel = (date_type.fromisoformat(wd) - sd).days if wd else None
+            except ValueError:
+                rel = None
+            if rel is None:
+                failed += 1
+                continue
+            day = v.start_date + timedelta(days=rel)
+            payload: dict[str, Any] = {
+                "athleteId": athlete_id,
+                "workoutDay": f"{day.isoformat()}T00:00:00",
+                "workoutTypeFamilyId": tid,   # family == value for standard sports
+                "workoutTypeValueId": tid,
+                "title": (w.get("title") or "Workout").strip(),
+            }
+            if w.get("totalTimePlanned") is not None:
+                payload["totalTimePlanned"] = w["totalTimePlanned"]
+            if w.get("description"):
+                payload["description"] = w["description"]
+            if w.get("distancePlanned") is not None:
+                payload["distancePlanned"] = w["distancePlanned"]
+            if w.get("tssPlanned") is not None:
+                payload["tssPlanned"] = w["tssPlanned"]
+            if w.get("ifPlanned") is not None:
+                payload["ifPlanned"] = w["ifPlanned"]
+            st = w.get("structure")
+            if isinstance(st, dict):
+                payload["structure"] = json.dumps(st)
+
+            resp = await client.post(f"/fitness/v6/athletes/{athlete_id}/workouts", json=payload)
+            if resp.is_error:
+                failed += 1
+                if first_error is None:
+                    first_error = resp.message
+            else:
+                created += 1
+
+        result: dict[str, Any] = {
+            "success": failed == 0 and created > 0,
+            "plan_id": v.plan_id,
+            "athlete_id": athlete_id,
+            "start_date": v.start_date.isoformat(),
+            "created": created,
+            "failed": failed,
+            "skipped_periods": skipped,
+            "total": len(ws),
+        }
+        if first_error:
+            result["first_error"] = first_error[:160]
+        return result

--- a/src/tp_mcp/tools/plans.py
+++ b/src/tp_mcp/tools/plans.py
@@ -191,11 +191,23 @@ async def tp_get_training_plan_workouts(plan_id: int | str) -> dict[str, Any]:
         return {"plan_id": v.plan_id, "workouts": out, "count": len(out)}
 
 
+# NB on the NATIVE apply command (reverse-engineered from the web app, NOT used):
+# POST /plans/v1/commands/applyplan with [{athleteId(str), planId, planTitle,
+# startType:1, targetDate}] registers an applied-plan record (returns appliedPlanId)
+# but does NOT materialise the workouts by itself — the web client then DRIVES an
+# async job by repeatedly polling POST /plans/v1/appliedplans/applyPlanStatus until
+# done. That status call's exact body shape isn't pinned (it rejects
+# {"AppliedPlanIds":[...]} with 400) and the protocol is a fragile poll-loop, so we
+# use the SYNTHETIC copy below instead: deterministic, one-shot, fully verified.
+# (Revisit native only with a full HAR of the applyPlanStatus request + its polling.)
+
+
 async def tp_apply_training_plan(plan_id: int | str, start_date: str) -> dict[str, Any]:
     """Apply a plan to the athlete's calendar from ``start_date`` by copying each
-    plan workout to ``start_date + relative_day`` (structure/description/TSS kept).
-    Athlete is resolved from the coach's athlete_override context (the ``athlete``
-    arg, handled by the server dispatch)."""
+    plan workout to ``start_date + relative_day`` (structure/description/TSS
+    preserved); training-period annotation markers are skipped. Athlete is resolved
+    from the coach's athlete_override context (the ``athlete`` arg, handled by the
+    server dispatch)."""
     try:
         v = _ApplyInput(plan_id=plan_id, start_date=start_date)  # type: ignore[arg-type]
     except (ValidationError, ValueError) as e:
@@ -205,6 +217,7 @@ async def tp_apply_training_plan(plan_id: int | str, start_date: str) -> dict[st
         athlete_id = await client.ensure_athlete_id()
         if not athlete_id:
             return _err("AUTH_INVALID", "Could not get athlete ID. Re-authenticate.")
+
         sd, ws = await _fetch_plan_workouts(client, v.plan_id)
         if sd is None:
             return ws  # error dict
@@ -256,6 +269,7 @@ async def tp_apply_training_plan(plan_id: int | str, start_date: str) -> dict[st
 
         result: dict[str, Any] = {
             "success": failed == 0 and created > 0,
+            "method": "synthetic",
             "plan_id": v.plan_id,
             "athlete_id": athlete_id,
             "start_date": v.start_date.isoformat(),

--- a/tests/test_client/test_http.py
+++ b/tests/test_client/test_http.py
@@ -201,3 +201,28 @@ class TestHandleResponse:
 
         assert result.success is True
         assert result.data is None
+
+
+class TestForbiddenEndpoints:
+    """Safeguard: destructive plan commands are hard-blocked at the client (the
+    native applyplan + unapply emptied a published plan's template, 2026-06-17)."""
+
+    def test_helper_matches_applyplan_only(self):
+        from tp_mcp.client.http import _is_forbidden
+        assert _is_forbidden("/plans/v1/commands/applyplan")
+        assert _is_forbidden("/plans/v1/commands/applyplan?x=1")
+        # the synthetic-apply read paths + status poll stay allowed
+        assert not _is_forbidden("/plans/v1/plans/163992/workouts/2018-12-17/2019-04-10")
+        assert not _is_forbidden("/plans/v1/appliedplans/applyPlanStatus")
+        assert not _is_forbidden("/fitness/v6/athletes/123/workouts")
+
+    @pytest.mark.asyncio
+    async def test_applyplan_blocked_with_no_network_call(self):
+        from tp_mcp.client.http import ErrorCode
+        client = TPClient()
+        # Sent via post() → _request(): blocked before any auth/HTTP happens.
+        r = await client.post("/plans/v1/commands/applyplan", json=[{"planId": 1}])
+        assert r.is_error and r.error_code == ErrorCode.FORBIDDEN_ENDPOINT
+        # get_raw() is guarded too.
+        rr = await client.get_raw("/plans/v1/commands/applyplan")
+        assert rr.is_error and rr.error_code == ErrorCode.FORBIDDEN_ENDPOINT

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -118,6 +118,10 @@ class TestListTools:
             "tp_get_strength_workouts",
             "tp_get_strength_workout",
             "tp_delete_strength_workout",
+            "tp_list_training_plans",
+            "tp_get_training_plan",
+            "tp_get_training_plan_workouts",
+            "tp_apply_training_plan",
         }
         assert v2_tools.issubset(names)
         assert len(names) == len(core_tools) + len(v2_tools)

--- a/tests/test_tools/test_plans.py
+++ b/tests/test_tools/test_plans.py
@@ -32,11 +32,14 @@ _WORKOUTS = [
 ]
 
 
-def _client_with(get_side_effect, post=None, athlete_id=123):
+def _client_with(get_side_effect, post=None, post_side_effect=None, athlete_id=123):
     inst = AsyncMock()
     inst.ensure_athlete_id = AsyncMock(return_value=athlete_id)
     inst.get = AsyncMock(side_effect=get_side_effect)
-    inst.post = AsyncMock(return_value=post or APIResponse(success=True, data={"workoutId": 1}))
+    if post_side_effect is not None:
+        inst.post = AsyncMock(side_effect=post_side_effect)
+    else:
+        inst.post = AsyncMock(return_value=post or APIResponse(success=True, data={"workoutId": 1}))
     return inst
 
 
@@ -108,6 +111,8 @@ async def test_get_workouts_lays_out_by_week_day():
 
 @pytest.mark.asyncio
 async def test_apply_copies_workouts_skips_period_markers():
+    """Synthetic apply: each plan workout is recreated at start_date + relative
+    day (structure preserved as a JSON string); type-100 period markers skipped."""
     post = APIResponse(success=True, data={"workoutId": 999})
     inst = _client_with(_get_router, post=post)
     p = _patch(inst)
@@ -115,13 +120,13 @@ async def test_apply_copies_workouts_skips_period_markers():
         r = await tp_apply_training_plan(163992, "2027-09-01")
     finally:
         p.stop()
-    assert r["success"] is True
+    assert r["success"] is True and r["method"] == "synthetic"
     assert r["created"] == 2          # run + day-off
     assert r["skipped_periods"] == 1  # the type-100 annotation
     assert r["failed"] == 0
-    # the run workout was POSTed with its structure as a JSON string at day+1
-    posted = [c.kwargs["json"] for c in inst.post.call_args_list]
-    run_post = next(b for b in posted if b["workoutTypeValueId"] == 3)
+    creates = [c.kwargs["json"] for c in inst.post.call_args_list
+               if "/fitness/v6/" in c.args[0]]
+    run_post = next(b for b in creates if b["workoutTypeValueId"] == 3)
     assert run_post["workoutDay"] == "2027-09-02T00:00:00"  # start_date + rel day 1
     assert run_post["workoutTypeFamilyId"] == 3
     assert isinstance(run_post["structure"], str) and "primaryLengthMetric" in run_post["structure"]

--- a/tests/test_tools/test_plans.py
+++ b/tests/test_tools/test_plans.py
@@ -1,0 +1,133 @@
+"""Tests for training-plan tools (list/get/workouts/apply)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tp_mcp.client.http import APIResponse
+from tp_mcp.tools.plans import (
+    tp_apply_training_plan,
+    tp_get_training_plan,
+    tp_get_training_plan_workouts,
+    tp_list_training_plans,
+)
+
+_DETAIL = {
+    "planId": 163992, "title": "Plan 10k  ", "weekCount": 2, "dayCount": 14,
+    "workoutCount": 3, "description": "desc", "startDate": "2018-12-17T00:00:00",
+    "trainingDurationByWeek": [2.0, 3.0], "trainingDistanceByWeek": [10000.0, 20000.0],
+    "plannedWorkoutTypeDurations": [
+        {"workoutTypeId": 3, "duration": 5.0, "distance": 40000.0},
+        {"workoutTypeId": 7, "duration": 0.0, "distance": 0.0},
+    ],
+}
+# day 1 = period annotation (type 100, skipped on apply), day 2 = structured run,
+# day 3 = day off.
+_WORKOUTS = [
+    {"workoutDay": "2018-12-17T00:00:00", "workoutTypeValueId": 100, "title": "Период: базовый"},
+    {"workoutDay": "2018-12-18T00:00:00", "workoutTypeValueId": 3, "title": "Run",
+     "description": "easy", "totalTimePlanned": 0.5, "tssPlanned": 26.0,
+     "structure": {"structure": [{"x": 1}], "primaryLengthMetric": "duration"}},
+    {"workoutDay": "2018-12-19T00:00:00", "workoutTypeValueId": 7, "title": "Выходной"},
+]
+
+
+def _client_with(get_side_effect, post=None, athlete_id=123):
+    inst = AsyncMock()
+    inst.ensure_athlete_id = AsyncMock(return_value=athlete_id)
+    inst.get = AsyncMock(side_effect=get_side_effect)
+    inst.post = AsyncMock(return_value=post or APIResponse(success=True, data={"workoutId": 1}))
+    return inst
+
+
+def _patch(inst):
+    p = patch("tp_mcp.tools.plans.TPClient")
+    m = p.start()
+    m.return_value.__aenter__.return_value = inst
+    return p
+
+
+@pytest.mark.asyncio
+async def test_list_slims_records():
+    resp = APIResponse(success=True, data=[{
+        "planId": 163992, "title": "Plan 10k", "weekCount": 16, "workoutCount": 139,
+        "planCategory": 2, "price": 10.0, "isPublic": True, "eventDate": None,
+        "trainingDurationByWeek": [2.0, 3.0],
+    }])
+    inst = _client_with(lambda ep, **k: resp)
+    p = _patch(inst)
+    try:
+        r = await tp_list_training_plans()
+    finally:
+        p.stop()
+    assert r["count"] == 1
+    plan = r["plans"][0]
+    assert plan["plan_id"] == 163992 and plan["weeks"] == 16 and plan["workouts"] == 139
+    assert plan["total_hours"] == 5.0 and plan["price"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_get_summary_maps_sport_and_weeks():
+    inst = _client_with(lambda ep, **k: APIResponse(success=True, data=_DETAIL))
+    p = _patch(inst)
+    try:
+        r = await tp_get_training_plan(163992)
+    finally:
+        p.stop()
+    assert r["title"] == "Plan 10k" and r["weeks"] == 2 and r["day_count"] == 14
+    assert r["duration_by_week_h"] == [2.0, 3.0]
+    assert r["distance_by_week_km"] == [10.0, 20.0]
+    assert {"sport": "Run", "hours": 5.0, "km": 40.0} in r["by_sport"]
+    # zero-duration sport (DayOff) is dropped from the breakdown
+    assert all(s["sport"] != "DayOff" for s in r["by_sport"])
+
+
+def _get_router(ep, **k):
+    if ep.endswith("/workouts/2018-12-17/2018-12-31"):
+        return APIResponse(success=True, data=_WORKOUTS)
+    if "/workouts/" in ep:
+        return APIResponse(success=True, data=_WORKOUTS)
+    return APIResponse(success=True, data=_DETAIL)
+
+
+@pytest.mark.asyncio
+async def test_get_workouts_lays_out_by_week_day():
+    inst = _client_with(_get_router)
+    p = _patch(inst)
+    try:
+        r = await tp_get_training_plan_workouts(163992)
+    finally:
+        p.stop()
+    assert r["count"] == 3
+    run = next(w for w in r["workouts"] if w["sport"] == "Run")
+    assert run["week"] == 1 and run["day"] == 2 and run["has_structure"] is True
+    assert run["duration_min"] == 30 and run["tss"] == 26.0
+    # period marker surfaces as "Other"
+    assert any(w["sport"] == "Other" for w in r["workouts"])
+
+
+@pytest.mark.asyncio
+async def test_apply_copies_workouts_skips_period_markers():
+    post = APIResponse(success=True, data={"workoutId": 999})
+    inst = _client_with(_get_router, post=post)
+    p = _patch(inst)
+    try:
+        r = await tp_apply_training_plan(163992, "2027-09-01")
+    finally:
+        p.stop()
+    assert r["success"] is True
+    assert r["created"] == 2          # run + day-off
+    assert r["skipped_periods"] == 1  # the type-100 annotation
+    assert r["failed"] == 0
+    # the run workout was POSTed with its structure as a JSON string at day+1
+    posted = [c.kwargs["json"] for c in inst.post.call_args_list]
+    run_post = next(b for b in posted if b["workoutTypeValueId"] == 3)
+    assert run_post["workoutDay"] == "2027-09-02T00:00:00"  # start_date + rel day 1
+    assert run_post["workoutTypeFamilyId"] == 3
+    assert isinstance(run_post["structure"], str) and "primaryLengthMetric" in run_post["structure"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_plan_id_validation():
+    r = await tp_get_training_plan(0)
+    assert r["isError"] is True and r["error_code"] == "VALIDATION_ERROR"


### PR DESCRIPTION
Closes #123.

## Add support for multi-week Training Plans (list / read / apply)

TrainingPeaks **training plans** (Plan Store / "My Plans") are a separate entity from workout libraries (`exerciselibrary`) and the ATP — this adds read + apply support.

### Endpoints (reverse-engineered)
- `GET /plans/v1/plans` — the coach's authored plans (id, title, weekCount, workoutCount, per-week duration/distance, category, price)
- `GET /plans/v1/plans/{id}` — plan summary (`trainingDurationByWeek`, `plannedWorkoutTypeDurations`)
- `GET /plans/v1/plans/{id}/workouts/{start}/{end}` — every plan workout with its **native `structure`** (anchored at the plan's `startDate`; `workoutDay` gives the relative day)

### Tools added
- `tp_list_training_plans`
- `tp_get_training_plan`
- `tp_get_training_plan_workouts` (laid out by week/day)
- `tp_apply_training_plan` — applies a plan to an athlete from a start date

### Apply: native command investigated, not used — and blocked as unsafe
The native apply was reverse-engineered end-to-end:
`POST /plans/v1/commands/applyplan` (array body) → poll `POST /plans/v1/appliedplans/applyPlanStatus` with a **bare array** `[appliedPlanId]` (not `{"AppliedPlanIds":[...]}`), response `{"batchStatus": 2}` = done.

However, every server-side replication produced a **degenerate** application (record created, `batchStatus 2`, but **zero workouts materialised**) across `startType` 1 and 2 — the request body that makes the web app's apply actually populate the calendar couldn't be reproduced.

Worse: testing this live on a **published** plan surfaced a real footgun — the degenerate application associated the applied record with the **source template's own workouts**, and a subsequent "Unapply" then **deleted those template workouts**, emptying the published plan. Because of that, this PR:
- keeps `tp_apply_training_plan` as a **synthetic copy** — it reads the plan workouts and recreates each on the athlete's calendar at `start_date + relative_day` via the existing `POST /fitness/v6/athletes/{id}/workouts` (structure/description/TSS preserved; training-period annotation markers skipped);
- **hard-blocks `POST /plans/v1/commands/applyplan` at the HTTP client** (`_is_forbidden()` short-circuits before any auth/request, `ErrorCode.FORBIDDEN_ENDPOINT`) as defense-in-depth, since the connector never needs it and it's demonstrably destructive on a published plan.

Both findings are documented in `src/tp_mcp/tools/plans.py` and `src/tp_mcp/client/http.py`.

### Status
`ruff check src/` + `mypy src/` + `pytest tests/` all green (521 passing, including new `tests/test_tools/test_plans.py` and the applyplan block in `tests/test_client/test_http.py`). Verified live against a real 16-week plan (read + synthetic apply, with cleanup).