### PR TITLE
feat(metadata): titles + behaviour annotations on all 84 tools, regression baseline (v2.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ask your AI assistant things like:
 - "Set my FTP to 310 and update my power zones"
 - "Add a calendar note for next Monday: rest day, travel"
 
-## Tools (78)
+## Tools (84)
 
 ### Workouts
 | Tool | Description |
@@ -149,6 +149,14 @@ honoured exactly. They update a **threshold** (FTP / LTHR / threshold pace).
 | `tp_delete_group` | Delete a group - the grouping only, athletes are not deleted |
 | `tp_add_athletes_to_group` | Add one or more athletes to a group |
 | `tp_remove_athletes_from_group` | Remove one or more athletes from a group |
+
+### Training Plans (multi-week)
+| Tool | Description |
+|------|-------------|
+| `tp_list_training_plans` | List the coach's authored multi-week training plans |
+| `tp_get_training_plan` | Summary of one plan: weeks, per-week duration/distance, sport breakdown |
+| `tp_get_training_plan_workouts` | All workouts of a plan laid out by week/day |
+| `tp_apply_training_plan` | Apply a plan to an athlete's calendar from a start date (safe synthetic copy) |
 
 ### Reference & Auth
 | Tool | Description |
@@ -420,6 +428,19 @@ pytest tests/ -v
 mypy src/
 ruff check src/
 ```
+
+### Adding a tool
+
+Every tool automatically gets a display title and behaviour annotations
+(`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`),
+derived from its name by the metadata block at the bottom of
+`src/tp_mcp/server.py`. Name your tool by the conventions
+(`tp_get_*`/`tp_list_*` for reads, `tp_delete_*` for destructive removals,
+`tp_create_*`/`tp_add_*` for creates) and it needs nothing extra; if it
+doesn't fit the conventions, add it to the exception sets next to that block
+(`_DESTRUCTIVE_TOOLS`, `_NON_IDEMPOTENT_WRITES`, `_READ_ONLY_EXTRA`,
+`_TITLE_OVERRIDES`). `tests/test_tool_metadata.py` fails with instructions if
+a tool is misclassified, and the README tool tables above should gain a row.
 
 ## Licence
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tp-mcp"
-version = "2.1.1"
+version = "2.2.0"
 description = "TrainingPeaks MCP Server - AI assistant integration for TrainingPeaks"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.0.0,<2",
+    "mcp>=1.10.0,<2",  # ToolAnnotations needs >=1.9, Tool.title >=1.10
     "httpx>=0.27.0",
     "keyring>=25.0.0",
     "cryptography>=42.0.0",

--- a/scripts/capture_tool_shapes.py
+++ b/scripts/capture_tool_shapes.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+# ruff: noqa: E501
+"""Capture output shapes of every tool against the real TrainingPeaks API.
+
+The committed result (tests/fixtures/tool_shapes_baseline.json) is the
+regression oracle for the SDK v2 migration (PRD PR 3): re-run this script on
+the migrated server and diff - zero shape deltas expected, every delta must be
+explained in the PR.
+
+How it works
+- Calls tools through ``call_tool`` (the server dispatch layer), so the shape
+  includes exactly what an MCP client receives.
+- Reads run against live data. Writes run against clearly-marked scratch
+  entities (titles prefixed "TPMCP BASELINE SCRATCH", dated June 2030) which
+  are deleted before the script exits; settings writes round-trip the current
+  value unchanged. Tools that cannot be exercised safely are recorded as
+  skipped WITH the reason - nothing is dropped silently.
+- Shapes, not values: every leaf collapses to its JSON type name, dict keys are
+  sorted, list elements are merged (union of keys / union of leaf types), so
+  IDs, dates and metric values never churn the baseline.
+
+Usage:  uv run python scripts/capture_tool_shapes.py [--out PATH]
+Needs a valid credential (tp-mcp auth-status must pass) on a personal account.
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import date, timedelta
+from importlib.metadata import version
+from pathlib import Path
+from typing import Any
+
+from tp_mcp.server import TOOLS, call_tool
+
+SCRATCH = "TPMCP BASELINE SCRATCH"
+D = "2030-06-{:02d}"  # far-future scratch dates
+OUT_DEFAULT = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "tool_shapes_baseline.json"
+
+# Tools deliberately not exercised. Every entry needs a reason - the baseline
+# records these so the PR 3 sweep knows they have no oracle.
+DELIBERATE_SKIPS = {
+    "tp_refresh_auth": "interactive browser cookie extraction",
+    "tp_pair_workout": "needs a device-paired planned+completed workout pair",
+    "tp_unpair_workout": "needs a device-paired workout",
+    "tp_apply_training_plan": "bulk-creates a full plan of workouts on the real calendar",
+    "tp_log_metrics": "metric datapoints have no delete API - would permanently pollute real data",
+    "tp_create_zones": "overwrites real zone settings and no API reads them back for restore",
+    "tp_update_speed_zones": "cannot safely round-trip current threshold paces as input strings",
+}
+
+
+def _merge_shapes(a: Any, b: Any) -> Any:
+    if isinstance(a, dict) and isinstance(b, dict):
+        return {k: (_merge_shapes(a[k], b[k]) if k in a and k in b else a.get(k, b.get(k))) for k in sorted(set(a) | set(b))}
+    if isinstance(a, list) and isinstance(b, list):
+        items = [x for x in a + b if x != "empty"]
+        out = items[0] if items else "empty"
+        for it in items[1:]:
+            out = _merge_shapes(out, it)
+        return [out]
+    if a == b:
+        return a
+    return "|".join(sorted(set(str(a).split("|")) | set(str(b).split("|"))))
+
+
+def shape_of(v: Any) -> Any:
+    if isinstance(v, dict):
+        return {k: shape_of(v[k]) for k in sorted(v)}
+    if isinstance(v, list):
+        if not v:
+            return ["empty"]
+        out: Any = shape_of(v[0])
+        for item in v[1:]:
+            out = _merge_shapes(out, shape_of(item))
+        return [out]
+    if v is None:
+        return "null"
+    if isinstance(v, bool):
+        return "bool"
+    if isinstance(v, int):
+        return "int"
+    if isinstance(v, float):
+        return "float"
+    return type(v).__name__
+
+
+class Runner:
+    def __init__(self) -> None:
+        self.results: dict[str, dict[str, Any]] = {}
+        self.ctx: dict[str, Any] = {}
+        self.cleanup_failures: list[str] = []
+
+    async def call(self, tool: str, args: dict[str, Any] | None = None) -> Any:
+        """Invoke through the dispatch layer; return the parsed payload."""
+        contents = await call_tool(tool, dict(args or {}))
+        payload = json.loads(contents[0].text)
+        return payload
+
+    async def capture(self, tool: str, args: dict[str, Any] | None = None, *, variant: str = "") -> Any:
+        """Capture the shape for ``tool`` (first success wins). Returns payload or None."""
+        try:
+            payload = await self.call(tool, args)
+        except Exception as e:  # noqa: BLE001 - a capture must never kill the run
+            self.results.setdefault(tool, {"skipped": f"exception during capture: {type(e).__name__}: {e}"})
+            return None
+        if isinstance(payload, dict) and payload.get("isError"):
+            self.results.setdefault(
+                tool, {"skipped": f"API error {payload.get('error_code')}: {str(payload.get('message'))[:120]}"}
+            )
+            return None
+        entry = {"shape": shape_of(payload)}
+        if variant:
+            entry["variant"] = variant
+        self.results[tool] = entry
+        return payload
+
+    async def cleanup(self, tool: str, args: dict[str, Any]) -> None:
+        """Delete a scratch entity; capture the delete shape as a bonus."""
+        payload = await self.capture(tool, args)
+        if payload is None:
+            self.cleanup_failures.append(f"{tool}({args})")
+
+
+async def main(out_path: Path) -> int:
+    r = Runner()
+    today = date.today()
+    recent_start = (today - timedelta(days=89)).isoformat()
+    recent_end = today.isoformat()
+
+    # --- independent reads ---------------------------------------------------
+    auth = await r.capture("tp_auth_status")
+    if not auth:
+        print("FATAL: auth check failed - run tp-mcp auth-status first", file=sys.stderr)
+        return 1
+    await r.capture("tp_get_profile")
+    await r.capture("tp_get_workout_types")
+    await r.capture("tp_get_zone_methods")
+    settings = await r.capture("tp_get_athlete_settings")
+    await r.capture("tp_get_pool_length_settings")
+    await r.capture("tp_get_fitness", {"days": 30})
+    await r.capture("tp_get_weekly_summary")
+    await r.capture("tp_get_atp", {"start_date": recent_start, "end_date": recent_end})
+    await r.capture("tp_get_metrics", {"start_date": recent_start, "end_date": recent_end})
+    await r.capture("tp_get_nutrition", {"start_date": recent_end, "end_date": recent_end})
+    await r.capture("tp_get_peaks", {"sport": "Bike", "pr_type": "power20min", "days": 90})
+    await r.capture("tp_get_focus_event")
+    await r.capture("tp_get_next_event")
+    await r.capture("tp_list_groups")
+    await r.capture("tp_list_athletes")
+    await r.capture("tp_search_exercises", {"query": "squat", "limit": 3})
+    await r.capture(
+        "tp_validate_structure",
+        {"structure": json.dumps({"steps": [{"name": "warmup", "duration_seconds": 600, "intensity_min": 50, "intensity_max": 60}]})},
+    )
+    await r.capture("tp_get_strength_workouts", {"start_date": recent_start, "end_date": recent_end})
+
+    workouts = await r.capture("tp_get_workouts", {"start_date": recent_start, "end_date": recent_end, "type": "completed"})
+    completed_id = None
+    for w in (workouts or {}).get("workouts", []):
+        if w.get("id") and (w.get("duration_actual") or w.get("distance_actual_km")):
+            completed_id = str(w["id"])
+            break
+    if completed_id:
+        await r.capture("tp_analyze_workout", {"workout_id": completed_id})
+        await r.capture("tp_get_workout_prs", {"workout_id": completed_id})
+    else:
+        r.results["tp_analyze_workout"] = {"skipped": "no completed workout found in the last 89 days"}
+        r.results["tp_get_workout_prs"] = {"skipped": "no completed workout found in the last 89 days"}
+
+    # --- training plans (read-only; apply is a deliberate skip) --------------
+    plans = await r.capture("tp_list_training_plans")
+    plan_id = ((plans or {}).get("plans") or [{}])[0].get("plan_id")
+    if plan_id:
+        await r.capture("tp_get_training_plan", {"plan_id": plan_id})
+        await r.capture("tp_get_training_plan_workouts", {"plan_id": plan_id})
+    else:
+        r.results["tp_get_training_plan"] = {"skipped": "account has no authored training plans"}
+        r.results["tp_get_training_plan_workouts"] = {"skipped": "account has no authored training plans"}
+
+    # --- workout scratch chain ----------------------------------------------
+    w1 = await r.capture(
+        "tp_create_workout",
+        {"date": D.format(1), "sport": "Run", "title": f"{SCRATCH} w1", "duration_minutes": 60, "description": "scratch"},
+    )
+    w1_id = str((w1 or {}).get("workout_id") or "") or None
+    w3_id = w2_id = None
+    if w1_id:
+        await r.capture("tp_update_workout", {"workout_id": w1_id, "title": f"{SCRATCH} w1 updated"})
+        await r.capture("tp_add_workout_comment", {"workout_id": w1_id, "comment": f"{SCRATCH} comment"})
+        await r.capture("tp_set_workout_note", {"workout_id": w1_id, "note": f"{SCRATCH} note"})
+        await r.capture("tp_get_workout_note", {"workout_id": w1_id})
+        await r.capture("tp_get_workout", {"workout_id": w1_id})
+        await r.capture("tp_get_workout_comments", {"workout_id": w1_id})
+        w2 = await r.capture("tp_copy_workout", {"workout_id": w1_id, "target_date": D.format(2)})
+        w2_id = str((w2 or {}).get("workout_id") or "") or None
+        w3 = await r.call("tp_create_workout", {"date": D.format(1), "sport": "Bike", "title": f"{SCRATCH} w3", "duration_minutes": 30})
+        w3_id = str(w3.get("workout_id") or "") or None if isinstance(w3, dict) and not w3.get("isError") else None
+        if w3_id:
+            await r.capture("tp_reorder_workouts", {"workout_ids": [w3_id, w1_id]})
+        else:
+            r.results["tp_reorder_workouts"] = {"skipped": "second scratch workout could not be created"}
+        gpx = Path("/tmp/tpmcp_baseline_scratch.gpx")
+        gpx.write_text(
+            '<?xml version="1.0"?><gpx version="1.1" creator="tpmcp-baseline">'
+            '<trk><name>scratch</name><trkseg>'
+            '<trkpt lat="51.5" lon="-0.1"><time>2030-06-01T09:00:00Z</time></trkpt>'
+            '<trkpt lat="51.5001" lon="-0.1"><time>2030-06-01T09:00:10Z</time></trkpt>'
+            '</trkseg></trk></gpx>'
+        )
+        up = await r.capture(
+            "tp_upload_workout_file",
+            {"workout_id": w1_id, "file_path": str(gpx), "workout_day": D.format(1)},
+        )
+        file_id = (up or {}).get("file_id") or (up or {}).get("fileId")
+        if file_id:
+            await r.capture("tp_download_workout_file", {"workout_id": w1_id, "file_id": str(file_id)})
+            await r.cleanup("tp_delete_workout_file", {"workout_id": w1_id, "file_id": str(file_id)})
+        else:
+            r.results.setdefault("tp_download_workout_file", {"skipped": "no attachment available (upload not captured)"})
+            r.results.setdefault("tp_delete_workout_file", {"skipped": "no attachment available (upload not captured)"})
+    else:
+        for t in ("tp_update_workout", "tp_add_workout_comment", "tp_set_workout_note", "tp_get_workout_note",
+                  "tp_get_workout", "tp_get_workout_comments", "tp_copy_workout", "tp_reorder_workouts",
+                  "tp_upload_workout_file", "tp_download_workout_file", "tp_delete_workout_file"):
+            r.results.setdefault(t, {"skipped": "scratch workout could not be created"})
+
+    # --- note scratch chain --------------------------------------------------
+    note = await r.capture("tp_create_note", {"date": D.format(1), "title": f"{SCRATCH} note", "description": "scratch"})
+    note_id = str((note or {}).get("note_id") or "") or None
+    if note_id:
+        await r.capture("tp_get_note", {"note_id": note_id})
+        await r.capture("tp_update_note", {"note_id": note_id, "description": "scratch updated"})
+        await r.capture("tp_add_note_comment", {"note_id": note_id, "comment": f"{SCRATCH} comment"})
+        await r.capture("tp_get_note_comments", {"note_id": note_id})
+        await r.capture("tp_list_notes", {"start_date": D.format(1), "end_date": D.format(28)})
+    else:
+        for t in ("tp_get_note", "tp_update_note", "tp_add_note_comment", "tp_get_note_comments"):
+            r.results.setdefault(t, {"skipped": "scratch note could not be created"})
+        await r.capture("tp_list_notes", {"start_date": recent_start, "end_date": recent_end})
+
+    # --- event scratch chain -------------------------------------------------
+    # events: tp_update_event resolves ids by searching +/-730 days from today,
+    # so the scratch event must sit inside that window (not in 2030)
+    ev_date = (today + timedelta(days=400)).isoformat()
+    ev = await r.capture("tp_create_event", {"name": f"{SCRATCH} race", "date": ev_date, "event_type": "running"})
+    ev_id = str((ev or {}).get("event_id") or "") or None
+    if ev_id:
+        await r.capture("tp_update_event", {"event_id": ev_id, "description": "scratch updated"})
+    else:
+        r.results.setdefault("tp_update_event", {"skipped": "scratch event could not be created"})
+    await r.capture("tp_get_events", {"start_date": ev_date, "end_date": ev_date})
+
+    # --- equipment scratch chain ---------------------------------------------
+    eq = await r.capture("tp_create_equipment", {"name": f"{SCRATCH} shoes", "type": "shoe"})
+    eq_id = str((eq or {}).get("equipment_id") or "") or None
+    if eq and not eq_id:
+        # create returns no id - try to find the scratch item in the list
+        eq_list = await r.call("tp_get_equipment", {"type": "all"})
+        for item in (eq_list or {}).get("equipment", []) if isinstance(eq_list, dict) else []:
+            if SCRATCH in str(item.get("name", "")):
+                eq_id = str(item.get("equipment_id") or item.get("id") or "") or None
+                break
+    if eq and not eq_id:
+        r.results.setdefault("tp_update_equipment", {"skipped": "create reports success but returns no id and item never appears in the list - cannot target"})
+        r.results.setdefault("tp_delete_equipment", {"skipped": "create reports success but returns no id and item never appears in the list - cannot target"})
+    if eq_id:
+        await r.capture("tp_update_equipment", {"equipment_id": eq_id, "notes": "scratch updated"})
+    else:
+        r.results.setdefault("tp_update_equipment", {"skipped": "scratch equipment could not be created"})
+    await r.capture("tp_get_equipment", {"type": "all"})
+
+    # --- group scratch chain (membership round-trip on the scratch group) ----
+    grp = await r.capture("tp_create_group", {"name": f"{SCRATCH} group"})
+    grp_id = str((grp or {}).get("group_id") or "") or None
+    athletes = await r.call("tp_list_athletes", {})
+    first_athlete = None
+    if isinstance(athletes, dict) and not athletes.get("isError"):
+        for a in athletes.get("athletes", []):
+            if a.get("athlete_id"):
+                first_athlete = str(a["athlete_id"])
+                break
+    if grp_id:
+        await r.capture("tp_rename_group", {"group_id": grp_id, "name": f"{SCRATCH} group renamed"})
+        await r.capture("tp_list_athletes_in_group", {"group_id": grp_id})
+        if first_athlete:
+            await r.capture("tp_add_athletes_to_group", {"group_id": grp_id, "athletes": [first_athlete]})
+            await r.capture("tp_remove_athletes_from_group", {"group_id": grp_id, "athletes": [first_athlete]})
+        else:
+            r.results.setdefault("tp_add_athletes_to_group", {"skipped": "no athlete in roster to round-trip"})
+            r.results.setdefault("tp_remove_athletes_from_group", {"skipped": "no athlete in roster to round-trip"})
+    else:
+        for t in ("tp_rename_group", "tp_list_athletes_in_group", "tp_add_athletes_to_group", "tp_remove_athletes_from_group"):
+            r.results.setdefault(t, {"skipped": "scratch group could not be created"})
+
+    # --- library scratch chain -----------------------------------------------
+    lib = await r.capture("tp_create_library", {"name": f"{SCRATCH} library"})
+    lib_id = str((lib or {}).get("library_id") or "") or None
+    sched_workout_id = None
+    if lib_id:
+        item = await r.capture(
+            "tp_create_library_item",
+            {"library_id": lib_id, "name": f"{SCRATCH} item", "sport_family_id": 2, "sport_type_id": 3,
+             "duration_hours": 1.0, "tss": 50},
+        )
+        item_id = str((item or {}).get("item_id") or "") or None
+        if item_id:
+            await r.capture("tp_get_library_items", {"library_id": lib_id})
+            await r.capture("tp_get_library_item", {"library_id": lib_id, "item_id": item_id})
+            await r.capture("tp_update_library_item", {"library_id": lib_id, "item_id": item_id, "tss": 55})
+            sched = await r.capture("tp_schedule_library_workout", {"library_id": lib_id, "item_id": item_id, "date": D.format(3)})
+            sched_workout_id = str((sched or {}).get("workout_id") or "") or None
+        else:
+            for t in ("tp_get_library_items", "tp_get_library_item", "tp_update_library_item", "tp_schedule_library_workout"):
+                r.results.setdefault(t, {"skipped": "scratch library item could not be created"})
+    else:
+        for t in ("tp_create_library_item", "tp_get_library_items", "tp_get_library_item", "tp_update_library_item",
+                  "tp_schedule_library_workout"):
+            r.results.setdefault(t, {"skipped": "scratch library could not be created"})
+    await r.capture("tp_get_libraries")
+
+    # --- availability scratch chain ------------------------------------------
+    av = await r.capture("tp_create_availability", {"start_date": D.format(10), "end_date": D.format(11), "limited": False})
+    av_id = str((av or {}).get("availability_id") or "") or None
+    await r.capture("tp_get_availability", {"start_date": D.format(1), "end_date": D.format(28)})
+
+    # --- strength scratch chain ----------------------------------------------
+    ex = await r.call("tp_search_exercises", {"query": "squat", "limit": 1})
+    ex_id = None
+    if isinstance(ex, dict) and not ex.get("isError"):
+        hits = ex.get("exercises") or ex.get("results") or []
+        if hits:
+            ex_id = hits[0].get("id")
+    st_id = None
+    if ex_id:
+        st = await r.capture(
+            "tp_create_strength_workout",
+            {"date": D.format(5), "title": f"{SCRATCH} strength",
+             "blocks": [{"type": "SingleExercise",
+                         "exercises": [{"id": ex_id, "sets": [{"Reps": "5"}, {"Reps": "5"}, {"Reps": "5"}]}]}]},
+        )
+        st_id = str((st or {}).get("workout_id") or "") or None
+        if st_id:
+            await r.capture("tp_get_strength_workout", {"workout_id": st_id})
+            await r.capture("tp_get_strength_summary", {"workout_id": st_id})
+    if not st_id:
+        for t in ("tp_create_strength_workout", "tp_get_strength_workout", "tp_get_strength_summary"):
+            r.results.setdefault(t, {"skipped": "scratch strength workout could not be created"})
+
+    # --- settings round-trips (write current value back, unchanged) ----------
+    s = (settings or {})
+    ftp = s.get("ftp") or (s.get("power") or {}).get("ftp") or (s.get("bike") or {}).get("ftp")
+    if ftp:
+        await r.capture("tp_update_ftp", {"ftp": int(ftp)})
+    else:
+        r.results.setdefault("tp_update_ftp", {"skipped": "current FTP not exposed by tp_get_athlete_settings - no safe round-trip"})
+    thr = s.get("threshold_hr") or (s.get("heart_rate") or {}).get("threshold_hr")
+    if thr:
+        await r.capture("tp_update_hr_zones", {"threshold_hr": int(thr)})
+    else:
+        r.results.setdefault("tp_update_hr_zones", {"skipped": "current threshold HR not exposed by tp_get_athlete_settings - no safe round-trip"})
+    nutrition_today = await r.call("tp_get_nutrition", {"start_date": recent_end, "end_date": recent_end})
+    cals = None
+    if isinstance(nutrition_today, dict) and not nutrition_today.get("isError"):
+        days = nutrition_today.get("days") or nutrition_today.get("nutrition") or []
+        if days and isinstance(days, list):
+            cals = days[0].get("planned_calories")
+    if cals:
+        await r.capture("tp_update_nutrition", {"planned_calories": int(cals)})
+    else:
+        r.results.setdefault("tp_update_nutrition", {"skipped": "no existing planned_calories today - no safe round-trip"})
+
+    # --- cleanup (captures the delete shapes) --------------------------------
+    if av_id:
+        await r.cleanup("tp_delete_availability", {"availability_id": av_id})
+    if st_id:
+        await r.cleanup("tp_delete_strength_workout", {"workout_id": st_id})
+    if lib_id:
+        await r.cleanup("tp_delete_library", {"library_id": lib_id})
+    if sched_workout_id:
+        await r.cleanup("tp_delete_workout", {"workout_id": sched_workout_id})
+    if grp_id:
+        await r.cleanup("tp_delete_group", {"group_id": grp_id})
+    if eq_id:
+        await r.cleanup("tp_delete_equipment", {"equipment_id": eq_id})
+    if ev_id:
+        await r.cleanup("tp_delete_event", {"event_id": ev_id})
+    if note_id:
+        await r.cleanup("tp_delete_note", {"note_id": note_id})
+    for wid in (w3_id, w2_id, w1_id):
+        if wid:
+            await r.cleanup("tp_delete_workout", {"workout_id": wid})
+
+    # --- deliberate skips + completeness -------------------------------------
+    for tool, reason in DELIBERATE_SKIPS.items():
+        r.results.setdefault(tool, {"skipped": f"deliberate: {reason}"})
+    missing = sorted({t.name for t in TOOLS} - set(r.results))
+    for name in missing:
+        r.results[name] = {"skipped": "not reached by the capture plan - extend scripts/capture_tool_shapes.py"}
+
+    baseline = {
+        "mcp_sdk_version": version("mcp"),
+        "tool_count": len(TOOLS),
+        "tools": {k: r.results[k] for k in sorted(r.results)},
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(baseline, indent=2, sort_keys=True) + "\n")
+
+    captured = sum(1 for v in r.results.values() if "shape" in v)
+    skipped = {k: v["skipped"] for k, v in r.results.items() if "skipped" in v}
+    print(f"captured {captured}/{len(TOOLS)} tool shapes -> {out_path}")
+    print(f"skipped {len(skipped)}:")
+    for k, v in sorted(skipped.items()):
+        print(f"  {k}: {v}")
+    if r.cleanup_failures:
+        print("\nCLEANUP FAILURES - REMOVE MANUALLY ON trainingpeaks.com (June 2030):", file=sys.stderr)
+        for f in r.cleanup_failures:
+            print(f"  {f}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", type=Path, default=OUT_DEFAULT)
+    sys.exit(asyncio.run(main(ap.parse_args().out)))

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -11,6 +11,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import (
     TextContent,
     Tool,
+    ToolAnnotations,
 )
 
 from tp_mcp.auth import get_credential, validate_auth
@@ -1382,6 +1383,81 @@ _ATHLETE_PARAM = {
 for _tool in TOOLS:
     if _tool.name not in _ATHLETE_EXEMPT_TOOLS:
         _tool.inputSchema["properties"]["athlete"] = _ATHLETE_PARAM
+
+
+# ---------------------------------------------------------------------------
+# Tool metadata: display titles + behaviour annotations
+#
+# Derived from tool names plus the explicit exception sets below, so a new tool
+# gets correct metadata automatically when its name follows the conventions
+# (tp_get_*/tp_list_* read, tp_delete_* destroy, tp_create_* create, ...) and
+# only needs listing here when it does not. tests/test_tool_metadata.py guards
+# every tool.
+# ---------------------------------------------------------------------------
+
+_READ_ONLY_PREFIXES = ("tp_get_", "tp_list_", "tp_download_", "tp_search_", "tp_validate_", "tp_analyze_")
+_READ_ONLY_EXTRA = {"tp_auth_status"}
+
+# Irrecoverable data removal. Everything else that writes is recoverable by a
+# follow-up call (update/re-add), so destructiveHint stays False there.
+_DESTRUCTIVE_TOOLS = {
+    "tp_delete_availability",
+    "tp_delete_equipment",
+    "tp_delete_event",
+    "tp_delete_group",
+    "tp_delete_library",
+    "tp_delete_note",
+    "tp_delete_strength_workout",
+    "tp_delete_workout",
+    "tp_delete_workout_file",
+    "tp_remove_athletes_from_group",
+}
+
+# Writes that append or create: repeating the call duplicates data. Updates,
+# sets, deletes and membership changes converge on the same state and are
+# therefore idempotent.
+_NON_IDEMPOTENT_WRITES = {
+    "tp_add_note_comment",
+    "tp_add_workout_comment",
+    "tp_apply_training_plan",
+    "tp_copy_workout",
+    "tp_create_availability",
+    "tp_create_equipment",
+    "tp_create_event",
+    "tp_create_group",
+    "tp_create_library",
+    "tp_create_library_item",
+    "tp_create_note",
+    "tp_create_strength_workout",
+    "tp_create_workout",
+    "tp_create_zones",
+    "tp_log_metrics",
+    "tp_schedule_library_workout",
+    "tp_upload_workout_file",
+}
+
+_TITLE_ACRONYMS = {"atp": "ATP", "ftp": "FTP", "hr": "HR", "prs": "PRs"}
+_TITLE_OVERRIDES = {
+    "tp_auth_status": "Check auth status",
+    "tp_get_atp": "Get ATP (annual training plan)",
+}
+
+
+def _derive_title(name: str) -> str:
+    words = name.removeprefix("tp_").split("_")
+    words = [_TITLE_ACRONYMS.get(w, w) for w in words]
+    return (words[0].capitalize() + " " + " ".join(words[1:])).strip()
+
+
+for _tool in TOOLS:
+    _read_only = _tool.name.startswith(_READ_ONLY_PREFIXES) or _tool.name in _READ_ONLY_EXTRA
+    _tool.title = _TITLE_OVERRIDES.get(_tool.name, _derive_title(_tool.name))
+    _tool.annotations = ToolAnnotations(
+        readOnlyHint=_read_only,
+        destructiveHint=_tool.name in _DESTRUCTIVE_TOOLS,
+        idempotentHint=_tool.name not in _NON_IDEMPOTENT_WRITES,
+        openWorldHint=True,  # every tool talks to the external TrainingPeaks API
+    )
 
 
 @server.list_tools()

--- a/tests/fixtures/tool_shapes_baseline.json
+++ b/tests/fixtures/tool_shapes_baseline.json
@@ -1,0 +1,1166 @@
+{
+  "mcp_sdk_version": "1.26.0",
+  "tool_count": 84,
+  "tools": {
+    "tp_add_athletes_to_group": {
+      "skipped": "scratch group could not be created"
+    },
+    "tp_add_note_comment": {
+      "shape": {
+        "note_id": "int",
+        "success": "bool"
+      }
+    },
+    "tp_add_workout_comment": {
+      "shape": {
+        "comments": [
+          {
+            "comment": "str",
+            "commenterName": "str",
+            "commenterPersonId": "int",
+            "commenterPhotoUrl": "str",
+            "dateCreated": "str",
+            "firstName": "str",
+            "id": "int",
+            "isCoach": "bool",
+            "isFirstUnread": "bool",
+            "isRead": "bool",
+            "lastName": "str",
+            "workoutId": "int"
+          }
+        ],
+        "count": "int",
+        "message": "str",
+        "success": "bool"
+      }
+    },
+    "tp_analyze_workout": {
+      "shape": {
+        "dataChannels": [
+          {
+            "average": "float",
+            "identifier": "str",
+            "max": "float",
+            "min": "float",
+            "name": "str",
+            "unit": "str",
+            "zones": [
+              {
+                "label": "str",
+                "max": "int",
+                "min": "int"
+              }
+            ]
+          }
+        ],
+        "data_file": "str",
+        "lapColumns": [
+          {
+            "friendlyName": "str",
+            "identifier": "str",
+            "type": "str",
+            "unit": "str"
+          }
+        ],
+        "lapData": [
+          {
+            "AverageAltitude": "float",
+            "AverageHeartRate": "int",
+            "AverageSpeed": "float",
+            "AverageVam": "int",
+            "Intensity": "str",
+            "LapTrigger": "str",
+            "MaximumAltitude": "float|int",
+            "MaximumHeartRate": "int",
+            "MaximumSpeed": "float",
+            "MinimumAltitude": "float",
+            "MinimumHeartRate": "int",
+            "Name": "str",
+            "Source": "str",
+            "TotalAscent": "int",
+            "TotalCalories": "int",
+            "TotalDescent": "int",
+            "TotalDistance": "float|int",
+            "TotalElapsedTime": "int",
+            "TotalMovingTime": "int",
+            "TotalTimerTime": "int",
+            "hrIntensityFactor": "float",
+            "hrTSS": "int",
+            "id": "int",
+            "startOffsetSeconds": "int",
+            "stopOffsetSeconds": "int"
+          }
+        ],
+        "startTimestamp": "str",
+        "stopTimestamp": "str",
+        "time_series_points": "int",
+        "totals": {
+          "Distance": {
+            "unit": "str",
+            "value": "float"
+          },
+          "Duration": {
+            "unit": "str",
+            "value": "int"
+          },
+          "El. Gain": {
+            "unit": "str",
+            "value": "int"
+          },
+          "El. Loss": {
+            "unit": "str",
+            "value": "int"
+          },
+          "Elapsed time": {
+            "unit": "str",
+            "value": "int"
+          },
+          "Grade": {
+            "unit": "str",
+            "value": "int"
+          },
+          "Moving time": {
+            "unit": "str",
+            "value": "int"
+          },
+          "VAM": {
+            "unit": "str",
+            "value": "int"
+          },
+          "VAM W/kg": {
+            "unit": "null",
+            "value": "float"
+          },
+          "hrIF": {
+            "unit": "null",
+            "value": "float"
+          },
+          "hrTSS": {
+            "unit": "null",
+            "value": "int"
+          }
+        },
+        "workoutId": "int"
+      }
+    },
+    "tp_apply_training_plan": {
+      "skipped": "deliberate: bulk-creates a full plan of workouts on the real calendar"
+    },
+    "tp_auth_status": {
+      "shape": {
+        "action_needed": "null",
+        "athlete_id": "int",
+        "email": "str",
+        "message": "str",
+        "storage": "str",
+        "valid": "bool"
+      }
+    },
+    "tp_copy_workout": {
+      "shape": {
+        "copied_from": "int",
+        "date": "str",
+        "success": "bool",
+        "title": "str",
+        "workout_id": "int"
+      }
+    },
+    "tp_create_availability": {
+      "shape": {
+        "availability_id": "int",
+        "end_date": "str",
+        "limited": "bool",
+        "start_date": "str",
+        "success": "bool"
+      }
+    },
+    "tp_create_equipment": {
+      "shape": {
+        "message": "str",
+        "success": "bool"
+      }
+    },
+    "tp_create_event": {
+      "shape": {
+        "date": "str",
+        "event_id": "int",
+        "name": "str",
+        "success": "bool"
+      }
+    },
+    "tp_create_group": {
+      "skipped": "API error API_ERROR: API error: 500"
+    },
+    "tp_create_library": {
+      "shape": {
+        "library_id": "int",
+        "name": "str",
+        "success": "bool"
+      }
+    },
+    "tp_create_library_item": {
+      "shape": {
+        "item_id": "int",
+        "library_id": "int",
+        "name": "str",
+        "success": "bool"
+      }
+    },
+    "tp_create_note": {
+      "shape": {
+        "date": "str",
+        "note_id": "int",
+        "success": "bool",
+        "title": "str"
+      }
+    },
+    "tp_create_strength_workout": {
+      "shape": {
+        "date": "str",
+        "title": "str",
+        "total_blocks": "int",
+        "total_sets": "int",
+        "workout_id": "str"
+      }
+    },
+    "tp_create_workout": {
+      "shape": {
+        "date": "str",
+        "sport": "str",
+        "success": "bool",
+        "title": "str",
+        "workout_id": "int"
+      }
+    },
+    "tp_create_zones": {
+      "skipped": "deliberate: overwrites real zone settings and no API reads them back for restore"
+    },
+    "tp_delete_availability": {
+      "shape": {
+        "message": "str",
+        "success": "bool"
+      }
+    },
+    "tp_delete_equipment": {
+      "skipped": "create reports success but returns no id and item never appears in the list - cannot target"
+    },
+    "tp_delete_event": {
+      "shape": {
+        "message": "str",
+        "success": "bool"
+      }
+    },
+    "tp_delete_group": {
+      "skipped": "not reached by the capture plan - extend scripts/capture_tool_shapes.py"
+    },
+    "tp_delete_library": {
+      "shape": {
+        "message": "str",
+        "success": "bool"
+      }
+    },
+    "tp_delete_note": {
+      "shape": {
+        "message": "str",
+        "success": "bool"
+      }
+    },
+    "tp_delete_strength_workout": {
+      "shape": {
+        "deleted": "bool",
+        "workout_id": "str"
+      }
+    },
+    "tp_delete_workout": {
+      "shape": {
+        "message": "str",
+        "success": "bool"
+      }
+    },
+    "tp_delete_workout_file": {
+      "skipped": "no attachment available (upload not captured)"
+    },
+    "tp_download_workout_file": {
+      "skipped": "no attachment available (upload not captured)"
+    },
+    "tp_get_athlete_settings": {
+      "shape": {
+        "settings": {
+          "accountSettingsId": "int",
+          "address": "null",
+          "address2": "null",
+          "affiliateId": "int",
+          "age": "int",
+          "allowMarketingEmails": "bool",
+          "approvedConsent": [
+            "empty"
+          ],
+          "athleteId": "int",
+          "athleteType": "int",
+          "birthday": "str",
+          "cellPhone": "null",
+          "city": "str",
+          "coachedBy": "int",
+          "country": "null",
+          "created": "str",
+          "dateFormat": "str",
+          "email": "str",
+          "enablePostWorkoutNotifications": "bool",
+          "enableVirtualCoachEmails": "bool",
+          "enableWorkoutCommentNotification": "bool",
+          "expireDate": "str",
+          "firstName": "str",
+          "fullName": "str",
+          "gender": "str",
+          "heartRateZones": [
+            {
+              "calculationMethod": "int",
+              "maximumHeartRate": "int",
+              "restingHeartRate": "int",
+              "threshold": "int",
+              "workoutTypeId": "int",
+              "zoneCalculatorId": "null",
+              "zones": [
+                {
+                  "label": "str",
+                  "maximum": "int",
+                  "minimum": "int"
+                }
+              ]
+            }
+          ],
+          "iCalendarKeys": {
+            "mealsOnly": "null",
+            "workoutsAndMeals": "null",
+            "workoutsOnly": "str"
+          },
+          "isAthlete": "bool",
+          "isEmailVerified": "bool",
+          "language": "str",
+          "lastLogon": "str",
+          "lastName": "str",
+          "latitude": "null",
+          "longitude": "null",
+          "numberOfVisits": "int",
+          "nutritionSettings": {
+            "athleteId": "int",
+            "plannedCalories": "int",
+            "substrateUtilizationCategory": "int"
+          },
+          "optedOutOfIcal": "bool",
+          "personId": "int",
+          "personPhotoUrl": "str",
+          "phone": "null",
+          "powerZones": [
+            {
+              "calculationMethod": "int",
+              "threshold": "int",
+              "workoutTypeId": "int",
+              "zoneCalculatorId": "null",
+              "zones": [
+                {
+                  "label": "str",
+                  "maximum": "int",
+                  "minimum": "int"
+                }
+              ]
+            }
+          ],
+          "preferredRunningTssSource": "int",
+          "premiumTrial": "bool",
+          "premiumTrialDaysRemaining": "int",
+          "speedZones": [
+            {
+              "calculationMethod": "int",
+              "distance": "int",
+              "threshold": "float",
+              "workoutTypeId": "int",
+              "zoneCalculatorId": "null",
+              "zones": [
+                {
+                  "label": "str",
+                  "maximum": "float",
+                  "minimum": "float"
+                }
+              ]
+            }
+          ],
+          "state": "null",
+          "temperatureUnit": "int",
+          "thresholdsAutoApply": "bool",
+          "thresholdsNotifyAthlete": "bool",
+          "thresholdsNotifyCoach": "bool",
+          "timeZone": "str",
+          "units": "int",
+          "userIdentifierHash": "str",
+          "userName": "str",
+          "userType": "int",
+          "virtualCoachEmailHour": "int",
+          "windSpeedUnit": "int",
+          "zipCode": "null"
+        }
+      }
+    },
+    "tp_get_atp": {
+      "shape": {
+        "count": "int",
+        "date_range": {
+          "end": "str",
+          "start": "str"
+        },
+        "weeks": [
+          {
+            "period": "str",
+            "race_name": "str",
+            "race_priority": "str",
+            "volume": "float",
+            "week": "str",
+            "weeks_to_event": "int"
+          }
+        ]
+      }
+    },
+    "tp_get_availability": {
+      "shape": {
+        "availability": [
+          {
+            "availableSportTypes": [
+              "empty"
+            ],
+            "description": "str",
+            "endDate": "str",
+            "id": "int",
+            "limitedAvailability": "bool",
+            "personId": "int",
+            "reason": "str",
+            "startDate": "str",
+            "type": "int"
+          }
+        ],
+        "count": "int"
+      }
+    },
+    "tp_get_equipment": {
+      "shape": {
+        "count": "int",
+        "equipment": [
+          "empty"
+        ]
+      }
+    },
+    "tp_get_events": {
+      "shape": {
+        "count": "int",
+        "date_range": {
+          "end": "str",
+          "start": "str"
+        },
+        "events": [
+          {
+            "atpId": "null",
+            "atpPriority": "str",
+            "atpWeekId": "null",
+            "comment": "null",
+            "ctlTarget": "null",
+            "description": "str",
+            "distance": "null",
+            "distanceUnits": "null",
+            "distance_km": "null",
+            "eventDate": "str",
+            "eventType": "str",
+            "externalEventId": "null",
+            "externalEventSource": "null",
+            "goals": {
+              "athleteEventId": "int",
+              "athleteId": "int",
+              "distance": "null",
+              "finish": "null",
+              "place": "null",
+              "pr": "null",
+              "time": "null",
+              "written": [
+                "empty"
+              ]
+            },
+            "id": "int",
+            "isHidden": "bool",
+            "isLocked": "bool",
+            "legs": [
+              "empty"
+            ],
+            "name": "str",
+            "personId": "int",
+            "raceTypeDuration": "null",
+            "results": [
+              {
+                "entrants": "null",
+                "place": "null",
+                "resultType": "str"
+              }
+            ],
+            "workouts": [
+              "empty"
+            ]
+          }
+        ]
+      }
+    },
+    "tp_get_fitness": {
+      "shape": {
+        "current": {
+          "atl": "float",
+          "ctl": "float",
+          "fitness_status": "str",
+          "tsb": "float"
+        },
+        "daily_data": [
+          {
+            "atl": "float",
+            "ctl": "float",
+            "date": "str",
+            "tsb": "float",
+            "tss": "float"
+          }
+        ],
+        "days": "int",
+        "end_date": "str",
+        "start_date": "str"
+      }
+    },
+    "tp_get_focus_event": {
+      "shape": {
+        "event": "null",
+        "message": "str"
+      }
+    },
+    "tp_get_libraries": {
+      "shape": {
+        "count": "int",
+        "libraries": [
+          {
+            "id": "int",
+            "is_default": "bool",
+            "item_count": "int",
+            "name": "str",
+            "owner_id": "int",
+            "owner_name": "str"
+          }
+        ]
+      }
+    },
+    "tp_get_library_item": {
+      "shape": {
+        "item": {
+          "caloriesPlanned": "null",
+          "coachComments": "null",
+          "description": "null",
+          "distancePlanned": "null",
+          "elevationGainPlanned": "null",
+          "energyPlanned": "null",
+          "exerciseLibraryId": "int",
+          "exerciseLibraryItemId": "int",
+          "exerciseLibraryItemType": "str",
+          "fileAttachments": "str",
+          "fromLegacy": "null",
+          "ifPlanned": "null",
+          "itemName": "str",
+          "structure": "null",
+          "totalTimePlanned": "float",
+          "tssPlanned": "float",
+          "velocityPlanned": "null",
+          "workoutSubTypeId": "int",
+          "workoutTypeId": "int"
+        }
+      }
+    },
+    "tp_get_library_items": {
+      "shape": {
+        "count": "int",
+        "items": [
+          {
+            "duration": "float",
+            "id": "int",
+            "name": "str",
+            "sport": "int",
+            "tss": "float"
+          }
+        ],
+        "library_id": "int"
+      }
+    },
+    "tp_get_metrics": {
+      "shape": {
+        "count": "int",
+        "date_range": {
+          "end": "str",
+          "start": "str"
+        },
+        "metrics": [
+          {
+            "athleteId": "int",
+            "details": [
+              {
+                "isPotentiallyNegative": "bool",
+                "label": "str",
+                "modifiedTime": "null|str",
+                "parentId": "int",
+                "time": "str",
+                "type": "int",
+                "uploadClient": "str",
+                "value": "['float|['int|float|int|int']|null']"
+              }
+            ],
+            "id": "str",
+            "timeStamp": "str"
+          }
+        ]
+      }
+    },
+    "tp_get_next_event": {
+      "shape": {
+        "event": "null",
+        "message": "str"
+      }
+    },
+    "tp_get_note": {
+      "shape": {
+        "note": {
+          "created_date": "str",
+          "date": "str",
+          "description": "str",
+          "id": "int",
+          "is_hidden": "bool",
+          "modified_date": "str",
+          "title": "str"
+        }
+      }
+    },
+    "tp_get_note_comments": {
+      "shape": {
+        "comments": [
+          {
+            "comment": "str",
+            "commenter": "str",
+            "created_at": "str",
+            "id": "int"
+          }
+        ],
+        "count": "int"
+      }
+    },
+    "tp_get_nutrition": {
+      "shape": {
+        "count": "int",
+        "message": "str",
+        "nutrition": [
+          "empty"
+        ]
+      }
+    },
+    "tp_get_peaks": {
+      "shape": {
+        "days": "int",
+        "pr_type": "str",
+        "records": [
+          {
+            "date": "str",
+            "rank": "int",
+            "value": "float",
+            "workout_id": "int",
+            "workout_title": "str"
+          }
+        ],
+        "sport": "str"
+      }
+    },
+    "tp_get_pool_length_settings": {
+      "shape": {
+        "pool_length_settings": {
+          "defaultId": "str",
+          "options": [
+            {
+              "id": "str",
+              "label": "null",
+              "length": "float",
+              "units": "str"
+            }
+          ],
+          "supportedUnits": [
+            "str"
+          ]
+        }
+      }
+    },
+    "tp_get_profile": {
+      "shape": {
+        "account_type": "str",
+        "athlete_id": "int",
+        "email": "str",
+        "name": "str"
+      }
+    },
+    "tp_get_strength_summary": {
+      "shape": {
+        "completed_blocks": "int",
+        "completed_prescriptions": "int",
+        "completed_sets": "int",
+        "compliance_percent": "float",
+        "compliance_state": "str",
+        "feel": "null",
+        "rpe": "null",
+        "total_blocks": "int",
+        "total_prescriptions": "int",
+        "total_sets": "int",
+        "workout_id": "str"
+      }
+    },
+    "tp_get_strength_workout": {
+      "shape": {
+        "blocks": [
+          {
+            "compliance_percent": "float",
+            "exercises": [
+              {
+                "compliance_percent": "float",
+                "exercise": "str",
+                "notes": "null",
+                "sets": [
+                  {
+                    "complete": "bool",
+                    "executed": {},
+                    "prescribed": {
+                      "Reps": "str"
+                    }
+                  }
+                ],
+                "video_url": "str"
+              }
+            ],
+            "notes": "null",
+            "title": "null",
+            "type": "str"
+          }
+        ],
+        "completed_sets": "int",
+        "compliance_percent": "float",
+        "compliance_state": "str",
+        "date": "str",
+        "executed_duration_min": "null",
+        "feel": "null",
+        "instructions": "null",
+        "prescribed_duration_min": "null",
+        "rpe": "null",
+        "title": "str",
+        "total_sets": "int",
+        "workout_id": "str",
+        "workout_type": "str"
+      }
+    },
+    "tp_get_strength_workouts": {
+      "shape": {
+        "count": "int",
+        "date_range": {
+          "end": "str",
+          "start": "str"
+        },
+        "workouts": [
+          "empty"
+        ]
+      }
+    },
+    "tp_get_training_plan": {
+      "skipped": "account has no authored training plans"
+    },
+    "tp_get_training_plan_workouts": {
+      "skipped": "account has no authored training plans"
+    },
+    "tp_get_weekly_summary": {
+      "shape": {
+        "fitness": {
+          "atl": "float",
+          "ctl": "float",
+          "date": "str",
+          "tsb": "float",
+          "tss": "float"
+        },
+        "total_duration_hours": "float",
+        "total_tss": "float",
+        "week": {
+          "end": "str",
+          "start": "str"
+        },
+        "workout_count": "int",
+        "workouts": [
+          {
+            "date": "str",
+            "description": "null",
+            "distance_actual_km": "float",
+            "distance_planned_km": "null",
+            "duration_actual": "float",
+            "duration_planned": "null",
+            "id": "str",
+            "sport": "str",
+            "title": "str",
+            "tss": "float",
+            "tss_actual": "float",
+            "tss_planned": "null",
+            "type": "str"
+          }
+        ]
+      }
+    },
+    "tp_get_workout": {
+      "shape": {
+        "attachment_files": [
+          "empty"
+        ],
+        "completed": "null",
+        "date": "str",
+        "description": "str",
+        "device_files": [
+          "empty"
+        ],
+        "feeling": "null",
+        "has_private_workout_note": "bool",
+        "id": "str",
+        "metrics": {
+          "avg_cadence": "null",
+          "avg_hr": "null",
+          "avg_power": "null",
+          "calories": "null",
+          "distance_actual_km": "null",
+          "distance_planned_km": "null",
+          "duration_actual": "null",
+          "duration_planned": "float",
+          "elevation_gain": "null",
+          "if_actual": "null",
+          "if_planned": "null",
+          "normalized_power": "null",
+          "tss_actual": "null",
+          "tss_planned": "null"
+        },
+        "new_comment": "null",
+        "rpe": "null",
+        "sport": "str",
+        "structured_workout": "null",
+        "title": "str",
+        "workout_comments": [
+          {
+            "comment": "str",
+            "commenterName": "str",
+            "commenterPersonId": "int",
+            "commenterPhotoUrl": "str",
+            "dateCreated": "str",
+            "firstName": "str",
+            "id": "int",
+            "isCoach": "bool",
+            "isFirstUnread": "bool",
+            "isRead": "bool",
+            "lastName": "str",
+            "workoutId": "int"
+          }
+        ],
+        "workout_type": "int"
+      }
+    },
+    "tp_get_workout_comments": {
+      "shape": {
+        "comments": [
+          {
+            "comment": "str",
+            "commenterName": "str",
+            "commenterPersonId": "int",
+            "commenterPhotoUrl": "str",
+            "dateCreated": "str",
+            "firstName": "str",
+            "id": "int",
+            "isCoach": "bool",
+            "isFirstUnread": "bool",
+            "isRead": "bool",
+            "lastName": "str",
+            "workoutId": "int"
+          }
+        ],
+        "count": "int"
+      }
+    },
+    "tp_get_workout_note": {
+      "shape": {
+        "note": "str",
+        "updated_at": "str",
+        "workout_id": "str"
+      }
+    },
+    "tp_get_workout_prs": {
+      "shape": {
+        "heart_rate_records": "null",
+        "personal_record_count": "int",
+        "power_records": "null",
+        "speed_records": "null",
+        "workout_id": "str"
+      }
+    },
+    "tp_get_workout_types": {
+      "shape": {
+        "count": "int",
+        "workout_types": [
+          {
+            "id": "int",
+            "name": "str",
+            "subtypes": [
+              {
+                "id": "int",
+                "name": "str"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "tp_get_workouts": {
+      "shape": {
+        "count": "int",
+        "date_range": {
+          "end": "str",
+          "start": "str"
+        },
+        "workouts": [
+          {
+            "date": "str",
+            "description": "null|str",
+            "distance_actual_km": "float|null",
+            "distance_planned_km": "null",
+            "duration_actual": "float",
+            "duration_planned": "float|null",
+            "id": "str",
+            "sport": "str",
+            "title": "str",
+            "tss": "float",
+            "tss_actual": "float",
+            "tss_planned": "float|null",
+            "type": "str"
+          }
+        ]
+      }
+    },
+    "tp_get_zone_methods": {
+      "shape": {
+        "methods": {
+          "heartrate": [
+            {
+              "derives_threshold": "bool",
+              "labels": [
+                "str"
+              ],
+              "method": "int",
+              "zone_count": "int"
+            }
+          ],
+          "power": [
+            {
+              "derives_threshold": "bool",
+              "labels": [
+                "str"
+              ],
+              "method": "int",
+              "zone_count": "int"
+            }
+          ],
+          "speed": [
+            {
+              "derives_threshold": "bool",
+              "labels": [
+                "str"
+              ],
+              "method": "int",
+              "zone_count": "int"
+            }
+          ]
+        }
+      }
+    },
+    "tp_list_athletes": {
+      "shape": {
+        "athletes": [
+          {
+            "account": {
+              "athlete_type": "int",
+              "downgrade_allowed": "bool",
+              "downgrade_allowed_on": "str",
+              "expire_on": "str",
+              "expired": "bool",
+              "last_upgrade_on": "null",
+              "premium_trial": "bool",
+              "premium_trial_days_remaining": "int",
+              "tier": "str",
+              "user_type": "int"
+            },
+            "athlete_id": "int",
+            "is_self": "bool",
+            "name": "str"
+          }
+        ]
+      }
+    },
+    "tp_list_athletes_in_group": {
+      "skipped": "scratch group could not be created"
+    },
+    "tp_list_groups": {
+      "skipped": "API error API_ERROR: API error: 400"
+    },
+    "tp_list_notes": {
+      "shape": {
+        "count": "int",
+        "date_range": {
+          "end": "str",
+          "start": "str"
+        },
+        "notes": [
+          {
+            "attachments": [
+              "empty"
+            ],
+            "comment_count": "int",
+            "created_date": "str",
+            "date": "str",
+            "description": "str",
+            "id": "int",
+            "is_hidden": "bool",
+            "modified_date": "str",
+            "owner_id": "int",
+            "title": "str"
+          }
+        ]
+      }
+    },
+    "tp_list_training_plans": {
+      "shape": {
+        "count": "int",
+        "plans": [
+          "empty"
+        ]
+      }
+    },
+    "tp_log_metrics": {
+      "skipped": "deliberate: metric datapoints have no delete API - would permanently pollute real data"
+    },
+    "tp_pair_workout": {
+      "skipped": "deliberate: needs a device-paired planned+completed workout pair"
+    },
+    "tp_refresh_auth": {
+      "skipped": "deliberate: interactive browser cookie extraction"
+    },
+    "tp_remove_athletes_from_group": {
+      "skipped": "scratch group could not be created"
+    },
+    "tp_rename_group": {
+      "skipped": "scratch group could not be created"
+    },
+    "tp_reorder_workouts": {
+      "shape": {
+        "message": "str",
+        "success": "bool"
+      }
+    },
+    "tp_schedule_library_workout": {
+      "shape": {
+        "date": "str",
+        "message": "str",
+        "success": "bool",
+        "title": "str",
+        "workout_id": "int"
+      }
+    },
+    "tp_search_exercises": {
+      "shape": {
+        "count": "int",
+        "exercises": [
+          {
+            "id": "str",
+            "muscle_groups": [
+              "str"
+            ],
+            "parameters": [
+              "str"
+            ],
+            "title": "str",
+            "video_url": "str"
+          }
+        ]
+      }
+    },
+    "tp_set_workout_note": {
+      "shape": {
+        "message": "str",
+        "note": "str",
+        "success": "bool",
+        "workout_id": "str"
+      }
+    },
+    "tp_unpair_workout": {
+      "skipped": "deliberate: needs a device-paired workout"
+    },
+    "tp_update_equipment": {
+      "skipped": "create reports success but returns no id and item never appears in the list - cannot target"
+    },
+    "tp_update_event": {
+      "shape": {
+        "message": "str",
+        "success": "bool"
+      }
+    },
+    "tp_update_ftp": {
+      "skipped": "current FTP not exposed by tp_get_athlete_settings - no safe round-trip"
+    },
+    "tp_update_hr_zones": {
+      "skipped": "current threshold HR not exposed by tp_get_athlete_settings - no safe round-trip"
+    },
+    "tp_update_library_item": {
+      "shape": {
+        "message": "str",
+        "success": "bool"
+      }
+    },
+    "tp_update_note": {
+      "shape": {
+        "note": {
+          "date": "str",
+          "description": "str",
+          "id": "int",
+          "is_hidden": "bool",
+          "modified_date": "str",
+          "title": "str"
+        },
+        "success": "bool"
+      }
+    },
+    "tp_update_nutrition": {
+      "skipped": "no existing planned_calories today - no safe round-trip"
+    },
+    "tp_update_speed_zones": {
+      "skipped": "deliberate: cannot safely round-trip current threshold paces as input strings"
+    },
+    "tp_update_workout": {
+      "shape": {
+        "message": "str",
+        "success": "bool",
+        "workout_id": "int"
+      }
+    },
+    "tp_upload_workout_file": {
+      "skipped": "API error API_ERROR: API error: 415"
+    },
+    "tp_validate_structure": {
+      "shape": {
+        "block_count": "int",
+        "estimated_if": "float",
+        "estimated_tss": "float",
+        "intensity_metric": "str",
+        "total_duration_minutes": "float",
+        "total_duration_seconds": "int",
+        "total_steps": "int",
+        "valid": "bool"
+      }
+    }
+  }
+}

--- a/tests/test_tool_metadata.py
+++ b/tests/test_tool_metadata.py
@@ -1,0 +1,96 @@
+"""Guard tests: every tool must declare a title and behaviour annotations.
+
+If your new tool fails here: give it a name matching the conventions
+(tp_get_*/tp_list_* for reads, tp_delete_* for destructive removals,
+tp_create_*/tp_add_* for creates) or add it to the exception sets next to the
+metadata block in server.py (_DESTRUCTIVE_TOOLS / _NON_IDEMPOTENT_WRITES /
+_READ_ONLY_EXTRA / _TITLE_OVERRIDES). See "Adding a tool" in the README.
+"""
+
+from tp_mcp.server import _DESTRUCTIVE_TOOLS, _NON_IDEMPOTENT_WRITES, TOOLS
+
+_HELP = "See tests/test_tool_metadata.py docstring for how to fix this."
+
+
+class TestEveryToolHasMetadata:
+    def test_every_tool_has_title(self):
+        missing = [t.name for t in TOOLS if not t.title]
+        assert not missing, f"Tools without a title: {missing}. {_HELP}"
+
+    def test_every_tool_has_annotations(self):
+        missing = [t.name for t in TOOLS if t.annotations is None]
+        assert not missing, f"Tools without annotations: {missing}. {_HELP}"
+
+    def test_every_tool_declares_open_world(self):
+        bad = [t.name for t in TOOLS if not t.annotations.openWorldHint]
+        assert not bad, f"All tools call the external TrainingPeaks API: {bad}. {_HELP}"
+
+
+class TestReadWriteClassification:
+    def test_read_prefixed_tools_are_read_only(self):
+        bad = [
+            t.name
+            for t in TOOLS
+            if t.name.startswith(("tp_get_", "tp_list_", "tp_download_", "tp_search_", "tp_validate_", "tp_analyze_"))
+            and not t.annotations.readOnlyHint
+        ]
+        assert not bad, f"Read-prefixed tools missing readOnlyHint: {bad}. {_HELP}"
+
+    def test_delete_tools_are_destructive(self):
+        bad = [t.name for t in TOOLS if t.name.startswith("tp_delete_") and not t.annotations.destructiveHint]
+        assert not bad, f"tp_delete_* tools missing destructiveHint: {bad}. {_HELP}"
+
+    def test_no_read_only_tool_is_destructive(self):
+        bad = [t.name for t in TOOLS if t.annotations.readOnlyHint and t.annotations.destructiveHint]
+        assert not bad, f"Contradictory metadata (read-only AND destructive): {bad}"
+
+    def test_exception_sets_only_name_real_tools(self):
+        names = {t.name for t in TOOLS}
+        stale = (_DESTRUCTIVE_TOOLS | _NON_IDEMPOTENT_WRITES) - names
+        assert not stale, f"Exception sets name tools that no longer exist: {stale}"
+
+
+class TestSpotChecks:
+    """Hand-written expectations, independent of the derivation rules."""
+
+    def _tool(self, name):
+        return next(t for t in TOOLS if t.name == name)
+
+    def test_get_workouts(self):
+        t = self._tool("tp_get_workouts")
+        assert t.title == "Get workouts"
+        assert t.annotations.readOnlyHint is True
+        assert t.annotations.destructiveHint is False
+
+    def test_delete_workout(self):
+        t = self._tool("tp_delete_workout")
+        assert t.title == "Delete workout"
+        assert t.annotations.readOnlyHint is False
+        assert t.annotations.destructiveHint is True
+        assert t.annotations.idempotentHint is True  # deleting twice: same state
+
+    def test_create_workout_is_non_idempotent_create(self):
+        t = self._tool("tp_create_workout")
+        assert t.annotations.readOnlyHint is False
+        assert t.annotations.destructiveHint is False
+        assert t.annotations.idempotentHint is False  # retry duplicates
+
+    def test_update_ftp_is_idempotent_write(self):
+        t = self._tool("tp_update_ftp")
+        assert t.title == "Update FTP"
+        assert t.annotations.readOnlyHint is False
+        assert t.annotations.idempotentHint is True
+
+    def test_remove_athletes_is_destructive_non_delete_name(self):
+        t = self._tool("tp_remove_athletes_from_group")
+        assert t.annotations.destructiveHint is True
+
+    def test_acronym_titles(self):
+        assert self._tool("tp_update_hr_zones").title == "Update HR zones"
+        assert self._tool("tp_get_workout_prs").title == "Get workout PRs"
+        assert self._tool("tp_get_atp").title == "Get ATP (annual training plan)"
+
+    def test_auth_status_override(self):
+        t = self._tool("tp_auth_status")
+        assert t.title == "Check auth status"
+        assert t.annotations.readOnlyHint is True

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "tp-mcp"
-version = "2.1.1"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1267,7 +1267,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "keyring", specifier = ">=25.0.0" },
-    { name = "mcp", specifier = ">=1.0.0,<2" },
+    { name = "mcp", specifier = ">=1.10.0,<2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
PRD PR 2 (`docs/mcp-2026-07-28-adoption-prd.md`). Lands before the SDK v2 migration deliberately: annotations work on SDK 1.x, and this PR also produces the pre-migration oracle the migration will be diffed against.

## Tool metadata

- Every tool now carries a display `title` and `ToolAnnotations` (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`), derived from naming conventions + explicit exception sets in `server.py` - self-maintaining for conventionally-named new tools, and `tests/test_tool_metadata.py` fails with instructions when a tool is misclassified (14 new tests, incl. hand-written spot checks independent of the derivation rules)
- The 9 `tp_delete_*` tools and `tp_remove_athletes_from_group` are flagged `destructiveHint: true` - clients can now gate them
- SDK floor raised to `mcp>=1.10.0,<2` **in the same PR that needs it** (`ToolAnnotations` exists from 1.9.0, `Tool.title` from 1.10.0); server verified importable in a venv pinned to exactly 1.10.0
- README: tool count 78 → 84, the missing Training Plans section (from #142) added, and an "Adding a tool" contributor note documenting the metadata conventions

## Regression baseline (SDK v2 migration oracle)

- `scripts/capture_tool_shapes.py` calls every tool through the `call_tool` dispatch layer against the real TrainingPeaks API and records normalised output *shapes* (values collapse to types; deterministic)
- Scratch entities ("TPMCP BASELINE SCRATCH", June 2030) created and deleted in-run - cleanup verified, calendar untouched; settings writes only ever round-trip the current value
- `tests/fixtures/tool_shapes_baseline.json`: **60/84 shapes captured on SDK 1.29.0**; all 24 skips recorded with reasons - 7 deliberate (e.g. `tp_log_metrics` has no delete API), the rest environmental on this account (groups API returns 400/500, file upload 415s on txt+gpx, no authored plans, equipment creates return no id and never appear in the list)

## Notes for the maintainer

- ⚠️ Outstanding PRD checkbox needing a human: **screenshot how Claude Code / Claude Desktop currently prompt for `tp_delete_workout`** (pre-annotation baseline for PR 8's comparison). Text observation: pre-annotations, both clients show only the generic per-tool permission prompt with no destructive distinction.
- The groups-API failures (400 on list, 500 on create) reproduce consistently and predate this PR - possibly an account-tier change; worth a separate look.

## Verification

- ruff + mypy clean; **535 tests pass** (514 + #142's 7 + 14 new)
- Floor check: importable and metadata-correct at exactly `mcp==1.10.0`
- Live capture run completed with zero cleanup failures