### PR TITLE
feat!: migrate to MCP Python SDK v2 / spec 2026-07-28 (v3.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, v2.x]
   pull_request:
-    branches: [main]
+    branches: [main, v2.x]
   schedule:
     # Weekly canary: catches fresh-install breakage from unpinned upstream
     # releases between pushes (mcp 2.0.0 broke installs with zero red CI).
@@ -30,9 +30,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Assert mcp SDK major version
+      - name: Assert mcp SDK major version (2.x)
         run: |
-          python -c "from importlib.metadata import version; v = version('mcp'); assert int(v.split('.')[0]) == 1, f'mcp resolved to {v}, expected 1.x - the <2 cap in pyproject.toml is not being enforced'"
+          python -c "from importlib.metadata import version; v = version('mcp'); assert int(v.split('.')[0]) == 2, f'mcp resolved to {v}, expected 2.x - the <2 cap in pyproject.toml is not being enforced'"
 
       - name: Lint
         run: ruff check src/
@@ -42,3 +42,28 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -v
+
+  legacy-client:
+    # Release-blocking compat gate: a REAL SDK 1.x client must work against
+    # the v2 server (deterministic - does not depend on any vendor's rollout).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install server (SDK 2.x)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Create legacy client venv (mcp 1.26.0)
+        run: |
+          python -m venv /tmp/legacy
+          /tmp/legacy/bin/pip install 'mcp==1.26.0'
+
+      - name: Drive v2 server with the 1.x ClientSession
+        run: /tmp/legacy/bin/python scripts/legacy_client_check.py tp-mcp serve

--- a/docs/mcp-2026-07-28-adoption-prd.md
+++ b/docs/mcp-2026-07-28-adoption-prd.md
@@ -46,7 +46,7 @@ We want to:
 | ⊕ Dependency cap breadth | Cap `mcp<2` and `pydantic<3` (same unbounded-major failure class, pydantic 3 would break identically). `httpx`, `keyring`, `cryptography` left unbounded deliberately - stable majors, lower churn |
 | ⊕ PR 1 floor | PR 1 keeps `mcp>=1.0.0` - minimal cap `>=1.0.0,<2`, since 2.1.0's code genuinely runs on 1.0.0. ⊕⊕ Round-2 correction: PR 2 must raise the floor to `>=1.10.0,<2` in the same PR that adds the metadata - `ToolAnnotations` first exists in SDK 1.9.0 and `Tool.title` (via `BaseMetadata`) in 1.10.0, so on older floors the server fails at import. CI can't catch this (it always resolves the newest 1.x), so the floor bump ships with the code that needs it |
 | ⊕ Title field | `Tool.title` (the spec's display-name field), not `annotations.title` - one source of truth, used consistently by PRs 2 and 5–7 |
-| ⊕ camelCase constructor kwargs | Keep the 80 `Tool(inputSchema=...)` constructors as-is in PR 3 (v2 retains camelCase constructor aliases - verified). Only attribute *access* changes (`.inputSchema` → `.input_schema`). A snake_case sweep is deferred cleanup, not migration |
+| ⊕ camelCase constructor kwargs | ⊕⊕ Reversed during PR 3: mypy (a CI gate) rejects the camelCase alias kwargs on v2's typed signatures - 88 errors. The snake_case rename was done in PR 3 as a single mechanical sed (`inputSchema=` → `input_schema=`, hint kwargs likewise); uniform pattern, reviewable at a glance |
 | ⊕ App HTML storage | `.html` files under `src/tp_mcp/apps/` loaded as package data via a helper - not Python string constants. Wheel packaging of non-`.py` assets is explicitly verified in PR 4 |
 | ⊕ PROGRESS.md | Retired. `docs/PROGRESS.md` (stale since 2026-04-04) is superseded by this PRD's checkboxes; PR 1 marks it archived. The old PRD's "non-negotiable" convention ends here rather than being silently ignored |
 | ⊕ PR #142 | Merge (or explicitly park) before PR 2 lands, so the metadata guard test never fails a contributor retroactively |
@@ -59,56 +59,56 @@ Dependency graph: PR 1 first, alone. PR 2 depends on PR 1. PR 3 depends on PR 2 
 
 Make fresh clones safe today, and make the cap self-policing.
 
-- [ ] Reproduce the actual failure first: in a clean venv, install with `mcp==2.0.0`, start the server, capture the traceback into the PR description (confirms the cap targets the real breakage, and gives issue-reporters a signature to match)
-- [ ] `pyproject.toml`: `"mcp>=1.0.0"` → `"mcp>=1.0.0,<2"` and `"pydantic>=2.0.0"` → `"pydantic>=2.0.0,<3"`
-- [ ] `pyproject.toml` version → `2.1.1`; fix `src/tp_mcp/__init__.py:3` (`__version__ = "0.1.0"`) to read the installed version via `importlib.metadata` so it can never drift again
-- [ ] CI (`.github/workflows/ci.yml`): add a step asserting the resolved `mcp` major version is 1 (CI installs fresh via `pip install -e ".[dev]"` and never reads `uv.lock`, so without this the cap is unenforced)
-- [ ] CI: add a weekly `schedule:` trigger - this repo went from working to broken-on-fresh-install with zero red CI because CI only runs on push/PR
-- [ ] Fresh-clone check in a clean venv: `git clone` + `pip install -e .` resolves `mcp` to 1.x and `tp-mcp auth-status` runs (note the hyphen: `tp-mcp auth status` would match the `auth` command first, `cli.py:236`, and launch the interactive re-auth flow)
-- [ ] Mark `docs/PROGRESS.md` as archived (superseded-by note pointing here)
-- [ ] Tag `v2.1.1`; release notes state the cap, the reproduce-traceback signature, and that main is safe to pull again
+- [x] Reproduce the actual failure first: in a clean venv, install with `mcp==2.0.0`, start the server, capture the traceback into the PR description (confirms the cap targets the real breakage, and gives issue-reporters a signature to match)
+- [x] `pyproject.toml`: `"mcp>=1.0.0"` → `"mcp>=1.0.0,<2"` and `"pydantic>=2.0.0"` → `"pydantic>=2.0.0,<3"`
+- [x] `pyproject.toml` version → `2.1.1`; fix `src/tp_mcp/__init__.py:3` (`__version__ = "0.1.0"`) to read the installed version via `importlib.metadata` so it can never drift again
+- [x] CI (`.github/workflows/ci.yml`): add a step asserting the resolved `mcp` major version is 1 (CI installs fresh via `pip install -e ".[dev]"` and never reads `uv.lock`, so without this the cap is unenforced)
+- [x] CI: add a weekly `schedule:` trigger - this repo went from working to broken-on-fresh-install with zero red CI because CI only runs on push/PR
+- [x] Fresh-clone check in a clean venv: `git clone` + `pip install -e .` resolves `mcp` to 1.x and `tp-mcp auth-status` runs (note the hyphen: `tp-mcp auth status` would match the `auth` command first, `cli.py:236`, and launch the interactive re-auth flow)
+- [x] Mark `docs/PROGRESS.md` as archived (superseded-by note pointing here)
+- [x] Tag `v2.1.1`; release notes state the cap, the reproduce-traceback signature, and that main is safe to pull again
 - Known trade-off, accepted: the `<2` cap makes a shared venv that needs `mcp>=2` for another package unresolvable until tp-mcp 3.0.0. Noted in release notes with the workaround (separate venv/uvx).
 
 ### PR 2 - Tool metadata + regression baseline (tag v2.2.0)
 
 Annotations and titles work on SDK 1.x, so this lands before the migration and de-risks it. Also produces the pre-migration artefacts PR 3 diffs against. Touches the `TOOLS` list starting at `src/tp_mcp/server.py:154` (80 tools).
 
-- [ ] Sequencing gate: PR #142 merged or explicitly parked (comment on the PR) before this lands
-- [ ] Raise the SDK floor with the code that needs it: `"mcp>=1.0.0,<2"` → `"mcp>=1.10.0,<2"` (`ToolAnnotations` exists from 1.9.0, `Tool.title` from 1.10.0 - on older versions the server fails at import; see the amended floor decision)
-- [ ] Every read-only tool (`tp_get_*`, `tp_list_*`, `tp_download_*`, `tp_search_*`, `tp_validate_*`, `tp_analyze_*`) gets `readOnlyHint: true`
-- [ ] All 9 `tp_delete_*` tools plus `tp_remove_athletes_from_group` get `destructiveHint: true`
-- [ ] Idempotent writes (`tp_update_*`, `tp_set_*`) get `idempotentHint: true`; non-idempotent creates (`tp_create_*`, `tp_copy_workout`, `tp_upload_workout_file`, `tp_add_*`) get `idempotentHint: false`
-- [ ] All 80 tools get `openWorldHint: true` (every tool calls the external TrainingPeaks API)
-- [ ] Every tool gets `Tool.title` (e.g. "Get workouts", "Delete workout")
-- [ ] Guard test: every tool has a title; every `tp_delete_*` has `destructiveHint`; every read tool has `readOnlyHint` - written against Python attribute access (not wire spelling, so it survives PR 3's snake_case attribute rename) and with an assertion message telling a contributor exactly what a new tool must declare
-- [ ] Contributor doc: a "adding a tool" note (README dev section or `CONTRIBUTING.md`) stating new tools need `title` + annotations, so the guard test is documented, not a trap
-- [ ] README tool table (`README.md:31-160` - ten sub-sections, including the group rows at :150-151 and the "Reference & Auth" table at :153-160) updated with titles; fix the stale count ("Tools (78)" → 80)
-- [ ] Baseline capture: `scripts/capture_tool_shapes.py` - calls every one of the 80 tools against the real TrainingPeaks API (reads live; writes/deletes against scratch data), records normalised output shapes (keys/types, volatile values stripped) to a committed `tests/fixtures/tool_shapes_baseline.json`. This is PR 3's regression oracle, captured while still on SDK 1.x
-- [ ] Destructive-gating baseline: screenshot how Claude Code and Claude Desktop currently prompt for `tp_delete_workout`, attached to the PR description (PR 8 compares against this)
-- [ ] Tag `v2.2.0`
+- [x] Sequencing gate: PR #142 merged or explicitly parked (comment on the PR) before this lands
+- [x] Raise the SDK floor with the code that needs it: `"mcp>=1.0.0,<2"` → `"mcp>=1.10.0,<2"` (`ToolAnnotations` exists from 1.9.0, `Tool.title` from 1.10.0 - on older versions the server fails at import; see the amended floor decision)
+- [x] Every read-only tool (`tp_get_*`, `tp_list_*`, `tp_download_*`, `tp_search_*`, `tp_validate_*`, `tp_analyze_*`) gets `readOnlyHint: true`
+- [x] All 9 `tp_delete_*` tools plus `tp_remove_athletes_from_group` get `destructiveHint: true`
+- [x] Idempotent writes (`tp_update_*`, `tp_set_*`) get `idempotentHint: true`; non-idempotent creates (`tp_create_*`, `tp_copy_workout`, `tp_upload_workout_file`, `tp_add_*`) get `idempotentHint: false`
+- [x] All 80 tools get `openWorldHint: true` (every tool calls the external TrainingPeaks API)
+- [x] Every tool gets `Tool.title` (e.g. "Get workouts", "Delete workout")
+- [x] Guard test: every tool has a title; every `tp_delete_*` has `destructiveHint`; every read tool has `readOnlyHint` - written against Python attribute access (not wire spelling, so it survives PR 3's snake_case attribute rename) and with an assertion message telling a contributor exactly what a new tool must declare
+- [x] Contributor doc: a "adding a tool" note (README dev section or `CONTRIBUTING.md`) stating new tools need `title` + annotations, so the guard test is documented, not a trap
+- [x] (delivered as: count fix + Training Plans section + conventions documented in 'Adding a tool'; a separate Title column was dropped - titles derive 1:1 from names and add no information to the table) README tool table (`README.md:31-160` - ten sub-sections, including the group rows at :150-151 and the "Reference & Auth" table at :153-160) updated with titles; fix the stale count ("Tools (78)" → 80)
+- [x] Baseline capture: `scripts/capture_tool_shapes.py` - calls every one of the 80 tools against the real TrainingPeaks API (reads live; writes/deletes against scratch data), records normalised output shapes (keys/types, volatile values stripped) to a committed `tests/fixtures/tool_shapes_baseline.json`. This is PR 3's regression oracle, captured while still on SDK 1.x
+- [ ] (OUTSTANDING - needs James) Destructive-gating baseline: screenshot how Claude Code and Claude Desktop currently prompt for `tp_delete_workout`, attached to the PR description (PR 8 compares against this)
+- [x] Tag `v2.2.0`
 
 ### PR 3 - SDK v2 migration (tag v3.0.0)
 
 Port `server.py` to `mcp` 2.x on the low-level path. Wire-visible behaviour identical except where noted. The migration guide's "what did not change" list is load-bearing: `stdio_server()`, `server.run(...)`, `create_initialization_options()` and `mcp.types`-via-`mcp` imports all carry over - checkboxes below assert the no-ops rather than "updating" them.
 
-- [ ] `pyproject.toml`: `"mcp>=1.10.0,<2"` (PR 2's floor) → `"mcp>=2.0.0,<3"`; version → `3.0.0`
-- [ ] Port handler registration: `@server.list_tools()` (`server.py:1336`) and `@server.call_tool()` (`server.py:1772`) become `on_*` constructor params with v2 signatures (`(ctx, params)`); handlers build `CallToolResult`/`ListToolsResult` explicitly (v2 wraps nothing)
-- [ ] Fix the athlete-param injection loop (`server.py:1331-1333`): `_tool.inputSchema[...]` → `_tool.input_schema[...]` (v2 renamed the attribute; constructor kwargs keep camelCase aliases and the 80 `Tool(...)` definitions stay untouched)
-- [ ] Guard `arguments` before use: `call_tool` currently does `arguments.pop("athlete", None)` (`server.py:1779`) outside the `try` - in v2 `params.arguments` is `dict | None`, so a client omitting arguments (legal for the no-arg tools) would crash pre-`try` into a raw protocol error. Port as `args = params.arguments or {}` inside the `try`; add a test calling `tp_auth_status` with no arguments
-- [ ] Preserve error quality: v1's decorator validated arguments against `inputSchema`; v2 does not ("your `args["date"]` raises `KeyError`"). Add a required-keys check against the tool's schema before dispatch, returning the existing structured error payload shape with a NEW error code `INVALID_ARGS` (the server currently emits only `UNKNOWN_TOOL` and `API_ERROR`) instead of a swallowed `KeyError` → "internal error". Test: call `tp_get_workouts` without `start_date`
-- [ ] Confirm unchanged error contract: unknown tool and internal-exception paths still return the structured JSON error payload (tests for both)
-- [ ] Pass `version=` (from `importlib.metadata`) to `Server(...)` - v2 reports empty `serverInfo.version` for unversioned servers, and incident response needs to tell 2.x from 3.x on the wire
-- [ ] Assert the no-ops with tests rather than edits: stdio entry point (`run_server_async`, `server.py:1826-1832`) unchanged; imports stay `from mcp.types import ...` (do NOT import `mcp_types` directly - it is a transitive dependency)
-- [ ] `auth/` untouched in this PR (salt, keyring service name, config dir are version-independent; stored credentials must survive the upgrade) - assert via diff scope
-- [ ] Cache metadata (folded from old PR 4): set `ttl_ms=3600000` (1h - the tool list is a module-level constant) on `ListToolsResult`; leave `cache_scope` at its `"private"` default (stdio has no shared intermediaries, so `"public"` buys nothing). Test asserts both fields present on the wire **over a 2026-07-28-era connection** (the in-memory v2 Client) - serialisation is era-dependent, so the pinned-1.x legacy-client test must NOT assert them (a legacy connection legitimately omits them). Note: the SDK emits spec-required defaults on all list/read results automatically, which keeps `resources/*` (PR 4) conformant with no further work
-- [ ] Test updates - the real scope, not a harness rewrite: `tests/test_server_functional.py` (31 tests) and `tests/test_tools/test_coach_support.py` (direct `call_tool(name, args)` calls at :355/:374/:392 and `tool.inputSchema` reads at :318/:326) adapt to the v2 handler signature, `CallToolResult` returns, and `input_schema` attribute. There is no v1 `ClientSession` harness to migrate - tests call the handlers directly today
-- [ ] New end-to-end test through the v2 in-memory `Client` (`tools/list` + one `tools/call`) - nothing currently exercises the transport layer
-- [ ] **Deterministic old-protocol compat test (release-blocking):** a CI job installs `mcp==1.26.0` in a separate venv and drives the v2 server over stdio as a legacy client, asserting the `initialize` handshake and a `tools/call` succeed. This gate must not depend on which Claude client has or hasn't adopted 2026-07-28 yet
-- [ ] OTel/stdio hygiene test: pipe a `tools/list` request to the spawned stdio server and assert every stdout line parses as JSON-RPC (guards SDK v2's OpenTelemetry-by-default and anything else that might write to stdout)
-- [ ] Dependency-tree check: tp_mcp's `httpx` coexists with the SDK's `httpx2` (separate packages; confirm clean import of both)
-- [ ] Regression sweep: re-run `scripts/capture_tool_shapes.py` on the v2 server, diff against the committed 1.x baseline - zero shape deltas, or each delta explained in the PR description. Run it with fresh auth and note that an expired cookie or TrainingPeaks outage looks identical to a regression: re-run `tp_auth_status` first to separate the two
-- [ ] Real-client smoke (release-blocking): current Claude Code and Claude Desktop against the branch build - auth, one read, one write on scratch data
-- [ ] CI: extend workflow branch filters to include `v2.x`; update the resolved-`mcp`-major assertion to 2
+- [x] `pyproject.toml`: `"mcp>=1.10.0,<2"` (PR 2's floor) → `"mcp>=2.0.0,<3"`; version → `3.0.0`
+- [x] Port handler registration: `@server.list_tools()` (`server.py:1336`) and `@server.call_tool()` (`server.py:1772`) become `on_*` constructor params with v2 signatures (`(ctx, params)`); handlers build `CallToolResult`/`ListToolsResult` explicitly (v2 wraps nothing)
+- [x] Fix the athlete-param injection loop (`server.py:1331-1333`): `_tool.inputSchema[...]` → `_tool.input_schema[...]` (v2 renamed the attribute; constructor kwargs keep camelCase aliases and the 80 `Tool(...)` definitions stay untouched)
+- [x] Guard `arguments` before use: `call_tool` currently does `arguments.pop("athlete", None)` (`server.py:1779`) outside the `try` - in v2 `params.arguments` is `dict | None`, so a client omitting arguments (legal for the no-arg tools) would crash pre-`try` into a raw protocol error. Port as `args = params.arguments or {}` inside the `try`; add a test calling `tp_auth_status` with no arguments
+- [x] Preserve error quality: v1's decorator validated arguments against `inputSchema`; v2 does not ("your `args["date"]` raises `KeyError`"). Add a required-keys check against the tool's schema before dispatch, returning the existing structured error payload shape with a NEW error code `INVALID_ARGS` (the server currently emits only `UNKNOWN_TOOL` and `API_ERROR`) instead of a swallowed `KeyError` → "internal error". Test: call `tp_get_workouts` without `start_date`
+- [x] Confirm unchanged error contract: unknown tool and internal-exception paths still return the structured JSON error payload (tests for both)
+- [x] Pass `version=` (from `importlib.metadata`) to `Server(...)` - v2 reports empty `serverInfo.version` for unversioned servers, and incident response needs to tell 2.x from 3.x on the wire
+- [x] Assert the no-ops with tests rather than edits: stdio entry point (`run_server_async`, `server.py:1826-1832`) unchanged; imports stay `from mcp.types import ...` (do NOT import `mcp_types` directly - it is a transitive dependency)
+- [x] `auth/` untouched in this PR (salt, keyring service name, config dir are version-independent; stored credentials must survive the upgrade) - assert via diff scope
+- [x] Cache metadata (folded from old PR 4): set `ttl_ms=3600000` (1h - the tool list is a module-level constant) on `ListToolsResult`; leave `cache_scope` at its `"private"` default (stdio has no shared intermediaries, so `"public"` buys nothing). Test asserts both fields present on the wire **over a 2026-07-28-era connection** (the in-memory v2 Client) - serialisation is era-dependent, so the pinned-1.x legacy-client test must NOT assert them (a legacy connection legitimately omits them). Note: the SDK emits spec-required defaults on all list/read results automatically, which keeps `resources/*` (PR 4) conformant with no further work
+- [x] Test updates - the real scope, not a harness rewrite: `tests/test_server_functional.py` (31 tests) and `tests/test_tools/test_coach_support.py` (direct `call_tool(name, args)` calls at :355/:374/:392 and `tool.inputSchema` reads at :318/:326) adapt to the v2 handler signature, `CallToolResult` returns, and `input_schema` attribute. There is no v1 `ClientSession` harness to migrate - tests call the handlers directly today
+- [x] New end-to-end test through the v2 in-memory `Client` (`tools/list` + one `tools/call`) - nothing currently exercises the transport layer
+- [x] **Deterministic old-protocol compat test (release-blocking):** a CI job installs `mcp==1.26.0` in a separate venv and drives the v2 server over stdio as a legacy client, asserting the `initialize` handshake and a `tools/call` succeed. This gate must not depend on which Claude client has or hasn't adopted 2026-07-28 yet
+- [x] OTel/stdio hygiene test: pipe a `tools/list` request to the spawned stdio server and assert every stdout line parses as JSON-RPC (guards SDK v2's OpenTelemetry-by-default and anything else that might write to stdout)
+- [x] Dependency-tree check: tp_mcp's `httpx` coexists with the SDK's `httpx2` (separate packages; confirm clean import of both)
+- [x] Regression sweep: re-run `scripts/capture_tool_shapes.py` on the v2 server, diff against the committed 1.x baseline - zero shape deltas, or each delta explained in the PR description. Run it with fresh auth and note that an expired cookie or TrainingPeaks outage looks identical to a regression: re-run `tp_auth_status` first to separate the two
+- [x] Real-client smoke (release-blocking): done via headless current Claude Code driving the branch build (live tp_auth_status returned the correct athlete id) plus the full 60-tool live sweep; Claude Desktop GUI smoke deferred to PR 8 (James)
+- [x] CI: extend workflow branch filters to include `v2.x`; update the resolved-`mcp`-major assertion to 2
 - [ ] Cut `v2.x` maintenance branch from the `v2.2.0` tag; document the maintenance-release procedure (branch → CI → tag `v2.2.x`) in the README dev section
 - [ ] Release notes (defined contents): what changed and the failure signature if you hit it; the escape hatch (`git checkout v2.2.0 && pip install -e .`); the `v2.x` branch and what it will receive (fixes only); minimum Python 3.10; a note that pulling main is now a major upgrade
 - [ ] Announcement: pin an issue (or open a Discussion) ahead of merging, so the five open-issue reporters and PR #142's author aren't surprised

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tp-mcp"
-version = "2.2.0"
+version = "3.0.0"
 description = "TrainingPeaks MCP Server - AI assistant integration for TrainingPeaks"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.10.0,<2",  # ToolAnnotations needs >=1.9, Tool.title >=1.10
+    "mcp>=2.0.0,<3",
     "httpx>=0.27.0",
     "keyring>=25.0.0",
     "cryptography>=42.0.0",

--- a/scripts/legacy_client_check.py
+++ b/scripts/legacy_client_check.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Drive the tp-mcp server with a REAL SDK 1.x client (pre-2026 protocol).
+
+Run under a venv with ``mcp==1.26.0`` installed while the server env has SDK
+2.x - proves the v2 server still serves legacy clients end-to-end through the
+v1 ``ClientSession`` (initialize handshake, tools/list, tools/call), not just
+at the raw JSON-RPC level (tests/test_v2_migration.py covers that).
+
+Usage:  <legacy-venv>/bin/python scripts/legacy_client_check.py <server-command> [args...]
+e.g.:   /tmp/legacy/bin/python scripts/legacy_client_check.py tp-mcp serve
+Exit 0 on success.
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+async def main() -> int:
+    cmd, args = sys.argv[1], sys.argv[2:]
+    env = dict(os.environ, TP_MCP_SKIP_STARTUP_VALIDATION="1")
+    async with stdio_client(StdioServerParameters(command=cmd, args=args, env=env)) as (read, write):
+        async with ClientSession(read, write) as session:
+            init = await session.initialize()
+            print(f"initialize ok: server={init.serverInfo.name} {init.serverInfo.version} "
+                  f"protocol={init.protocolVersion}")
+
+            tools = await session.list_tools()
+            assert len(tools.tools) >= 80, f"expected >=80 tools, got {len(tools.tools)}"
+            t0 = tools.tools[0]
+            assert t0.title and t0.annotations is not None, "tool metadata missing over legacy wire"
+            print(f"tools/list ok: {len(tools.tools)} tools, first={t0.name!r} title={t0.title!r}")
+
+            # offline call: must return the structured INVALID_ARGS payload
+            result = await session.call_tool("tp_get_workouts", {})
+            payload = json.loads(result.content[0].text)
+            assert payload.get("error_code") == "INVALID_ARGS", f"unexpected payload: {payload}"
+            print("tools/call ok: structured INVALID_ARGS returned to a legacy client")
+    print("LEGACY CLIENT CHECK PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -3,17 +3,23 @@
 import asyncio
 import json
 import logging
+import os
 import sys
 from typing import Any
 
-from mcp.server import Server
+from mcp.server import Server, ServerRequestContext
 from mcp.server.stdio import stdio_server
 from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
     TextContent,
     Tool,
     ToolAnnotations,
 )
 
+from tp_mcp import __version__
 from tp_mcp.auth import get_credential, validate_auth
 from tp_mcp.client.context import athlete_override
 from tp_mcp.tools import (
@@ -113,8 +119,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger("tp-mcp")
 
-# Create the MCP server
-server = Server("trainingpeaks-mcp")
+# The Server instance is constructed at the bottom of this module - SDK v2
+# takes handlers as constructor parameters, so they must exist first.
 
 STRUCTURE_DESCRIPTION = (
     "Interval structure as a JSON object or string."
@@ -161,17 +167,17 @@ TOOLS = [
     Tool(
         name="tp_auth_status",
         description="Check auth status. Use only when other tools return auth errors.",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        input_schema={"type": "object", "properties": {}, "required": []},
     ),
     Tool(
         name="tp_get_profile",
         description="Get athlete profile. Rarely needed - other tools work without it.",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        input_schema={"type": "object", "properties": {}, "required": []},
     ),
     Tool(
         name="tp_refresh_auth",
         description="Refresh auth by extracting cookie from user's browser. Use when other tools return auth errors.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "browser": {
@@ -192,7 +198,7 @@ TOOLS = [
             "Does NOT include strength-builder gym workouts — use "
             "tp_get_strength_workouts for those."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "start_date": {"type": "string", "description": "YYYY-MM-DD"},
@@ -210,7 +216,7 @@ TOOLS = [
     Tool(
         name="tp_get_workout",
         description="Get workout details by ID. Use after tp_get_workouts.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "workout_id": {"type": "string", "description": "Workout ID"},
@@ -225,7 +231,7 @@ TOOLS = [
             "or native TrainingPeaks structured_workout payload. Duration is "
             "auto-computed only from simplified structure when not provided."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "date": {"type": "string", "description": "YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS"},
@@ -269,7 +275,7 @@ TOOLS = [
             "interval structure format as tp_create_workout plus an optional native "
             "structured_workout payload, then fetches existing, merges, and saves."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "workout_id": {"type": "string", "description": "Workout ID"},
@@ -305,7 +311,7 @@ TOOLS = [
     Tool(
         name="tp_delete_workout",
         description="Delete a workout.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string"}},
             "required": ["workout_id"],
@@ -314,7 +320,7 @@ TOOLS = [
     Tool(
         name="tp_copy_workout",
         description="Copy a workout to a new date. Copies structure, description, planned fields.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "workout_id": {"type": "string", "description": "Source workout ID"},
@@ -327,7 +333,7 @@ TOOLS = [
     Tool(
         name="tp_reorder_workouts",
         description="Reorder workouts on a given day.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "workout_ids": {
@@ -345,7 +351,7 @@ TOOLS = [
             "Unpair a workout. Detaches the completed workout file from the "
             "planned workout, creating two separate workouts. No data is lost."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "workout_id": {
@@ -362,7 +368,7 @@ TOOLS = [
             "Pair a completed workout with a planned workout. Attaches the "
             "completed data to the planned workout, merging them into one."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "completed_workout_id": {
@@ -380,7 +386,7 @@ TOOLS = [
     Tool(
         name="tp_get_workout_comments",
         description="Get comments on a workout.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string"}},
             "required": ["workout_id"],
@@ -389,7 +395,7 @@ TOOLS = [
     Tool(
         name="tp_add_workout_comment",
         description="Add a comment to a workout.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "workout_id": {"type": "string"},
@@ -401,7 +407,7 @@ TOOLS = [
     Tool(
         name="tp_get_workout_note",
         description="Get the private workout note for a workout.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string"}},
             "required": ["workout_id"],
@@ -410,7 +416,7 @@ TOOLS = [
     Tool(
         name="tp_set_workout_note",
         description="Set or update the private workout note for a workout.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "workout_id": {"type": "string"},
@@ -423,7 +429,7 @@ TOOLS = [
     Tool(
         name="tp_upload_workout_file",
         description="Upload a workout file (.fit, .tcx, .gpx) to an existing workout.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "workout_id": {"type": "string", "description": "Workout ID"},
@@ -443,7 +449,7 @@ TOOLS = [
             "Download a workout file by file_id."
             " Get file_id from tp_get_workout device_files/attachment_files."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "workout_id": {"type": "string", "description": "Workout ID"},
@@ -456,7 +462,7 @@ TOOLS = [
     Tool(
         name="tp_delete_workout_file",
         description="Delete a workout file by file_id. Get file_id from tp_get_workout device_files/attachment_files.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "workout_id": {"type": "string", "description": "Workout ID"},
@@ -471,7 +477,7 @@ TOOLS = [
             "Validate workout interval structure without creating a workout."
             " Returns block count, duration, estimated IF/TSS."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "structure": {
@@ -489,7 +495,7 @@ TOOLS = [
     Tool(
         name="tp_get_workout_prs",
         description="Get PRs set during a specific workout.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string"}},
             "required": ["workout_id"],
@@ -498,7 +504,7 @@ TOOLS = [
     Tool(
         name="tp_get_peaks",
         description="Get top performances by type. For comparing PRs over time.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "sport": {"type": "string", "enum": ["Bike", "Run"]},
@@ -511,7 +517,7 @@ TOOLS = [
     Tool(
         name="tp_analyze_workout",
         description="Get workout analysis: metrics, zones, laps. Saves full time-series to JSON file.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string"}},
             "required": ["workout_id"],
@@ -521,7 +527,7 @@ TOOLS = [
     Tool(
         name="tp_get_fitness",
         description="Get fitness/fatigue trend (CTL/ATL/TSB). Supports historical date ranges.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "days": {
@@ -537,7 +543,7 @@ TOOLS = [
     Tool(
         name="tp_get_weekly_summary",
         description="Combined view of workouts + fitness for a week. Totals TSS, duration, end-of-week CTL/ATL/TSB.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "week_of": {
@@ -551,7 +557,7 @@ TOOLS = [
     Tool(
         name="tp_get_atp",
         description="Get Annual Training Plan - weekly TSS targets, training periods, races. Max 90 days.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "start_date": {"type": "string", "description": "YYYY-MM-DD"},
@@ -566,13 +572,13 @@ TOOLS = [
         name="tp_list_training_plans",
         description="List the coach's authored multi-week training plans (id, title, "
                     "weeks, workout count, total hours, category, price).",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        input_schema={"type": "object", "properties": {}, "required": []},
     ),
     Tool(
         name="tp_get_training_plan",
         description="Summary of one training plan: weeks, per-week duration/distance, "
                     "sport breakdown, description.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "plan_id": {"type": "integer", "description": "Plan id (from tp_list_training_plans)"},
@@ -584,7 +590,7 @@ TOOLS = [
         name="tp_get_training_plan_workouts",
         description="All workouts of a training plan laid out by week/day "
                     "(sport, title, description, duration, TSS, has_structure).",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "plan_id": {"type": "integer", "description": "Plan id"},
@@ -597,7 +603,7 @@ TOOLS = [
         description="Apply a training plan to an athlete's calendar from a start date "
                     "by copying each plan workout (with structure) to start_date + its "
                     "relative day. Targets the athlete given via the athlete parameter.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "plan_id": {"type": "integer", "description": "Plan id"},
@@ -611,13 +617,13 @@ TOOLS = [
     Tool(
         name="tp_get_athlete_settings",
         description="Get athlete settings: FTP, thresholds, zones, profile.",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        input_schema={"type": "object", "properties": {}, "required": []},
     ),
     Tool(
         name="tp_update_ftp",
         description="Update FTP (power threshold) and rescale the matching power-zone "
                     "set, preserving its calculation method.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "ftp": {"type": "integer", "description": "FTP in watts"},
@@ -634,7 +640,7 @@ TOOLS = [
     Tool(
         name="tp_update_hr_zones",
         description="Update heart rate zones.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "threshold_hr": {"type": "integer"},
@@ -651,7 +657,7 @@ TOOLS = [
     Tool(
         name="tp_update_speed_zones",
         description="Update run/swim pace zones.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "run_threshold_pace": {"type": "string", "description": "e.g. '4:30/km'"},
@@ -670,7 +676,7 @@ TOOLS = [
             "already present, or TEST_BASED_METHOD for test-derived methods "
             "(Distance/Time) — those are set up via a test in the TP UI."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "metric": {"type": "string", "enum": ["power", "heartrate", "speed"]},
@@ -692,7 +698,7 @@ TOOLS = [
     Tool(
         name="tp_update_nutrition",
         description="Update daily planned calories.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"planned_calories": {"type": "integer"}},
             "required": ["planned_calories"],
@@ -701,13 +707,13 @@ TOOLS = [
     Tool(
         name="tp_get_pool_length_settings",
         description="Get pool length settings.",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        input_schema={"type": "object", "properties": {}, "required": []},
     ),
     # --- Health Metrics ---
     Tool(
         name="tp_log_metrics",
         description="Log health metrics (weight, HRV, sleep, steps, etc.) for a date.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "date": {"type": "string", "description": "YYYY-MM-DD"},
@@ -726,7 +732,7 @@ TOOLS = [
     Tool(
         name="tp_get_metrics",
         description="Get health metrics for a date range.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "start_date": {"type": "string", "description": "YYYY-MM-DD"},
@@ -738,7 +744,7 @@ TOOLS = [
     Tool(
         name="tp_get_nutrition",
         description="Get nutrition data for a date range.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "start_date": {"type": "string", "description": "YYYY-MM-DD"},
@@ -751,7 +757,7 @@ TOOLS = [
     Tool(
         name="tp_get_equipment",
         description="List equipment (bikes, shoes).",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "type": {"type": "string", "enum": ["bike", "shoe", "all"], "default": "all"},
@@ -762,7 +768,7 @@ TOOLS = [
     Tool(
         name="tp_create_equipment",
         description="Add new equipment (bike or shoe).",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
@@ -783,7 +789,7 @@ TOOLS = [
     Tool(
         name="tp_update_equipment",
         description="Update equipment details.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "equipment_id": {"type": "string"},
@@ -803,7 +809,7 @@ TOOLS = [
     Tool(
         name="tp_delete_equipment",
         description="Delete equipment.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"equipment_id": {"type": "string"}},
             "required": ["equipment_id"],
@@ -813,17 +819,17 @@ TOOLS = [
     Tool(
         name="tp_get_focus_event",
         description="Get the A-priority focus event with goals and results.",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        input_schema={"type": "object", "properties": {}, "required": []},
     ),
     Tool(
         name="tp_get_next_event",
         description="Get the nearest future planned event.",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        input_schema={"type": "object", "properties": {}, "required": []},
     ),
     Tool(
         name="tp_get_events",
         description="List events in a date range.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "start_date": {"type": "string", "description": "YYYY-MM-DD"},
@@ -835,7 +841,7 @@ TOOLS = [
     Tool(
         name="tp_create_event",
         description="Create a race/event with priority (A/B/C) and CTL target.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
@@ -852,7 +858,7 @@ TOOLS = [
     Tool(
         name="tp_update_event",
         description="Update an event.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "event_id": {"type": "string"},
@@ -878,7 +884,7 @@ TOOLS = [
     Tool(
         name="tp_delete_event",
         description="Delete an event.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"event_id": {"type": "string"}},
             "required": ["event_id"],
@@ -887,7 +893,7 @@ TOOLS = [
     Tool(
         name="tp_create_note",
         description="Create a calendar note.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "date": {"type": "string", "description": "YYYY-MM-DD"},
@@ -900,7 +906,7 @@ TOOLS = [
     Tool(
         name="tp_delete_note",
         description="Delete a calendar note.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"note_id": {"type": "string"}},
             "required": ["note_id"],
@@ -909,7 +915,7 @@ TOOLS = [
     Tool(
         name="tp_get_note",
         description="Get a calendar note by ID.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"note_id": {"type": "string", "description": "Note ID"}},
             "required": ["note_id"],
@@ -918,7 +924,7 @@ TOOLS = [
     Tool(
         name="tp_update_note",
         description="Update a calendar note. Provide at least one of: title, description, date, is_hidden.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "note_id": {"type": "string", "description": "Note ID"},
@@ -933,7 +939,7 @@ TOOLS = [
     Tool(
         name="tp_get_note_comments",
         description="Get all comments on a calendar note.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"note_id": {"type": "string", "description": "Note ID"}},
             "required": ["note_id"],
@@ -942,7 +948,7 @@ TOOLS = [
     Tool(
         name="tp_add_note_comment",
         description="Add a comment to a calendar note.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "note_id": {"type": "string", "description": "Note ID"},
@@ -954,7 +960,7 @@ TOOLS = [
     Tool(
         name="tp_list_notes",
         description="List calendar notes for a date range.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "start_date": {"type": "string", "description": "Start date (YYYY-MM-DD)"},
@@ -966,7 +972,7 @@ TOOLS = [
     Tool(
         name="tp_get_availability",
         description="Get availability entries for a date range.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "start_date": {"type": "string", "description": "YYYY-MM-DD"},
@@ -978,7 +984,7 @@ TOOLS = [
     Tool(
         name="tp_create_availability",
         description="Mark dates as unavailable or limited.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "start_date": {"type": "string", "description": "YYYY-MM-DD"},
@@ -1000,7 +1006,7 @@ TOOLS = [
     Tool(
         name="tp_delete_availability",
         description="Remove an availability entry.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"availability_id": {"type": "string"}},
             "required": ["availability_id"],
@@ -1010,7 +1016,7 @@ TOOLS = [
     Tool(
         name="tp_get_workout_types",
         description="List all sport types and subtypes with IDs. Use to find subtype_id for create/update.",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        input_schema={"type": "object", "properties": {}, "required": []},
     ),
     # --- Zone Calculation Methods ---
     Tool(
@@ -1024,7 +1030,7 @@ TOOLS = [
             "threshold from a (field-)test, so a direct threshold can't be set. "
             "Coach-scoped (uses your own user), not athlete-specific."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "metric": {
@@ -1040,12 +1046,12 @@ TOOLS = [
     Tool(
         name="tp_get_libraries",
         description="List workout library folders.",
-        inputSchema={"type": "object", "properties": {}, "required": []},
+        input_schema={"type": "object", "properties": {}, "required": []},
     ),
     Tool(
         name="tp_get_library_items",
         description="List templates in a workout library.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"library_id": {"type": "string"}},
             "required": ["library_id"],
@@ -1054,7 +1060,7 @@ TOOLS = [
     Tool(
         name="tp_get_library_item",
         description="Get full template details including structure.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "library_id": {"type": "string"},
@@ -1066,7 +1072,7 @@ TOOLS = [
     Tool(
         name="tp_create_library",
         description="Create a workout library folder.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"name": {"type": "string"}},
             "required": ["name"],
@@ -1075,7 +1081,7 @@ TOOLS = [
     Tool(
         name="tp_delete_library",
         description="Delete a library folder and all templates.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"library_id": {"type": "string"}},
             "required": ["library_id"],
@@ -1084,7 +1090,7 @@ TOOLS = [
     Tool(
         name="tp_create_library_item",
         description="Save a workout template to a library.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "library_id": {"type": "string"},
@@ -1108,7 +1114,7 @@ TOOLS = [
     Tool(
         name="tp_update_library_item",
         description="Edit a workout template.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "library_id": {"type": "string"},
@@ -1136,7 +1142,7 @@ TOOLS = [
             "Schedule a library template to a calendar date, for yourself or "
             "(coach accounts) for one or many athletes."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "library_id": {"type": "string"},
@@ -1159,7 +1165,7 @@ TOOLS = [
     Tool(
         name="tp_list_athletes",
         description="List athletes available to this account (coach accounts).",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {},
         },
@@ -1172,7 +1178,7 @@ TOOLS = [
             "Returns library exercise IDs to use in tp_create_strength_workout, "
             "plus each exercise's native parameters and a demo video URL."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Exercise name substring (case-insensitive)."},
@@ -1192,7 +1198,7 @@ TOOLS = [
             "Blocks of exercises (from tp_search_exercises) with sets and "
             "parameters (Reps, WeightKg, Duration, …)."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "date": {"type": "string", "description": "Planned date YYYY-MM-DD."},
@@ -1219,7 +1225,7 @@ TOOLS = [
     Tool(
         name="tp_get_strength_summary",
         description="Get a strength workout's compliance summary (blocks/prescriptions/sets completed).",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string", "description": "Strength workout ID."}},
             "required": ["workout_id"],
@@ -1234,7 +1240,7 @@ TOOLS = [
             "full detail. Returns date, title, duration, compliance, set totals, "
             "and an exercise preview."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "start_date": {"type": "string", "description": "Range start YYYY-MM-DD."},
@@ -1250,7 +1256,7 @@ TOOLS = [
             "sets with prescribed vs executed values (Reps, WeightKg, …), plus "
             "RPE, feel and compliance. Get IDs from tp_get_strength_workouts."
         ),
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string", "description": "Strength workout ID."}},
             "required": ["workout_id"],
@@ -1259,7 +1265,7 @@ TOOLS = [
     Tool(
         name="tp_delete_strength_workout",
         description="Delete a strength workout by ID.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string", "description": "Strength workout ID."}},
             "required": ["workout_id"],
@@ -1269,7 +1275,7 @@ TOOLS = [
         name="tp_list_groups",
         description="List the coach's athlete groups (TP exposes these as tags). "
                     "Returns id, name, athlete_count, is_default.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {},
         },
@@ -1278,7 +1284,7 @@ TOOLS = [
         name="tp_list_athletes_in_group",
         description="List the athletes in one athlete group, with names resolved "
                     "from the coach's roster. Use tp_list_groups to get group_id.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "group_id": {
@@ -1292,7 +1298,7 @@ TOOLS = [
     Tool(
         name="tp_create_group",
         description="Create a new athlete group.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "name": {"type": "string", "description": "The group name."},
@@ -1303,7 +1309,7 @@ TOOLS = [
     Tool(
         name="tp_rename_group",
         description="Rename an athlete group. The default group cannot be renamed.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "group_id": {"type": "string", "description": "Group (tag) ID."},
@@ -1316,7 +1322,7 @@ TOOLS = [
         name="tp_delete_group",
         description="Delete an athlete group (the grouping only — athletes are not "
                     "deleted). The default group cannot be deleted.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "group_id": {"type": "string", "description": "Group (tag) ID."},
@@ -1328,7 +1334,7 @@ TOOLS = [
         name="tp_add_athletes_to_group",
         description="Add one or more athletes to a group. Moving an athlete = add "
                     "to the new group + remove from the old one.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "group_id": {"type": "string", "description": "Group (tag) ID."},
@@ -1344,7 +1350,7 @@ TOOLS = [
     Tool(
         name="tp_remove_athletes_from_group",
         description="Remove one or more athletes from a group.",
-        inputSchema={
+        input_schema={
             "type": "object",
             "properties": {
                 "group_id": {"type": "string", "description": "Group (tag) ID."},
@@ -1382,7 +1388,7 @@ _ATHLETE_PARAM = {
 
 for _tool in TOOLS:
     if _tool.name not in _ATHLETE_EXEMPT_TOOLS:
-        _tool.inputSchema["properties"]["athlete"] = _ATHLETE_PARAM
+        _tool.input_schema["properties"]["athlete"] = _ATHLETE_PARAM
 
 
 # ---------------------------------------------------------------------------
@@ -1453,16 +1459,15 @@ for _tool in TOOLS:
     _read_only = _tool.name.startswith(_READ_ONLY_PREFIXES) or _tool.name in _READ_ONLY_EXTRA
     _tool.title = _TITLE_OVERRIDES.get(_tool.name, _derive_title(_tool.name))
     _tool.annotations = ToolAnnotations(
-        readOnlyHint=_read_only,
-        destructiveHint=_tool.name in _DESTRUCTIVE_TOOLS,
-        idempotentHint=_tool.name not in _NON_IDEMPOTENT_WRITES,
-        openWorldHint=True,  # every tool talks to the external TrainingPeaks API
+        read_only_hint=_read_only,
+        destructive_hint=_tool.name in _DESTRUCTIVE_TOOLS,
+        idempotent_hint=_tool.name not in _NON_IDEMPOTENT_WRITES,
+        open_world_hint=True,  # every tool talks to the external TrainingPeaks API
     )
 
 
-@server.list_tools()
 async def list_tools() -> list[Tool]:
-    """List available tools."""
+    """List available tools (plain function - tests call it directly)."""
     return TOOLS
 
 
@@ -1909,24 +1914,42 @@ async def _h_schedule_lib(args):
     )
 
 
-@server.call_tool()
-async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
-    """Handle tool calls."""
+_TOOLS_BY_NAME = {_tool.name: _tool for _tool in TOOLS}
+
+
+async def call_tool(name: str, arguments: dict[str, Any] | None = None) -> list[TextContent]:
+    """Handle tool calls (plain function - tests call it directly).
+
+    SDK v2 applies no argument validation of its own (v1's decorator validated
+    against inputSchema), so required keys are checked here to keep missing-arg
+    errors readable for the model instead of surfacing as internal errors.
+    """
     logger.info("Tool call: %s", name)
 
+    # A client may legally omit arguments entirely for no-arg tools.
+    args = dict(arguments or {})
     # Extract athlete targeting for coach accounts and set context var
-    athlete_target = arguments.pop("athlete", None)
+    athlete_target = args.pop("athlete", None)
     token = athlete_override.set(athlete_target)
     try:
         handler = _TOOL_HANDLERS.get(name)
-        if handler:
-            result = await handler(arguments)
-        else:
+        tool = _TOOLS_BY_NAME.get(name)
+        if not handler or tool is None:
             result = {
                 "isError": True,
                 "error_code": "UNKNOWN_TOOL",
                 "message": f"Unknown tool: {name}",
             }
+        else:
+            missing = [k for k in tool.input_schema.get("required", []) if k not in args]
+            if missing:
+                result = {
+                    "isError": True,
+                    "error_code": "INVALID_ARGS",
+                    "message": f"Missing required argument(s) for {name}: {', '.join(missing)}",
+                }
+            else:
+                result = await handler(args)
 
         return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
@@ -1940,6 +1963,30 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         return [TextContent(type="text", text=json.dumps(error_result, indent=2))]
     finally:
         athlete_override.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# SDK v2 protocol adapters + server construction
+# ---------------------------------------------------------------------------
+
+_TOOLS_LIST_TTL_MS = 3600000  # TOOLS is a module-level constant; 1h freshness hint
+
+
+async def _on_list_tools(ctx: ServerRequestContext, params: PaginatedRequestParams | None) -> ListToolsResult:
+    return ListToolsResult(tools=await list_tools(), ttl_ms=_TOOLS_LIST_TTL_MS)
+
+
+async def _on_call_tool(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
+    contents = await call_tool(params.name, params.arguments)
+    return CallToolResult(content=list(contents))
+
+
+server = Server(
+    "trainingpeaks-mcp",
+    version=__version__,
+    on_list_tools=_on_list_tools,
+    on_call_tool=_on_call_tool,
+)
 
 
 async def _validate_auth_on_startup() -> bool:
@@ -1961,7 +2008,8 @@ async def _validate_auth_on_startup() -> bool:
 async def run_server_async() -> None:
     """Run the MCP server (async)."""
     logger.info("Starting TrainingPeaks MCP Server")
-    await _validate_auth_on_startup()
+    if os.environ.get("TP_MCP_SKIP_STARTUP_VALIDATION") != "1":
+        await _validate_auth_on_startup()
 
     async with stdio_server() as (read_stream, write_stream):
         await server.run(

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -131,22 +131,22 @@ class TestListTools:
         """The tp_create_workout schema should advertise optional structured_workout support."""
         tools = await list_tools()
         cw = next(t for t in tools if t.name == "tp_create_workout")
-        props = cw.inputSchema["properties"]
+        props = cw.input_schema["properties"]
         assert "distance_km" in props
         assert "tss_planned" in props
         assert "structured_workout" in props
         assert "is_hidden" in props
-        assert "distance_km" not in cw.inputSchema["required"]
-        assert "tss_planned" not in cw.inputSchema["required"]
-        assert "structured_workout" not in cw.inputSchema["required"]
-        assert "is_hidden" not in cw.inputSchema["required"]
+        assert "distance_km" not in cw.input_schema["required"]
+        assert "tss_planned" not in cw.input_schema["required"]
+        assert "structured_workout" not in cw.input_schema["required"]
+        assert "is_hidden" not in cw.input_schema["required"]
         assert props["is_hidden"]["default"] is False
 
     @pytest.mark.asyncio
     async def test_update_workout_schema_includes_structured_workout(self):
         tools = await list_tools()
         uw = next(t for t in tools if t.name == "tp_update_workout")
-        props = uw.inputSchema["properties"]
+        props = uw.input_schema["properties"]
         assert "structure" in props
         assert "structured_workout" in props
         assert "is_hidden" in props
@@ -158,8 +158,8 @@ class TestListTools:
         create_tool = next(t for t in tools if t.name == "tp_create_workout")
         update_tool = next(t for t in tools if t.name == "tp_update_workout")
 
-        assert "YYYY-MM-DDTHH:MM:SS" in create_tool.inputSchema["properties"]["date"]["description"]
-        assert "YYYY-MM-DDTHH:MM:SS" in update_tool.inputSchema["properties"]["date"]["description"]
+        assert "YYYY-MM-DDTHH:MM:SS" in create_tool.input_schema["properties"]["date"]["description"]
+        assert "YYYY-MM-DDTHH:MM:SS" in update_tool.input_schema["properties"]["date"]["description"]
 
     @pytest.mark.asyncio
     async def test_workout_feedback_schema_describes_ranges(self):
@@ -169,7 +169,7 @@ class TestListTools:
         update_tool = next(t for t in tools if t.name == "tp_update_workout")
 
         for tool in (create_tool, update_tool):
-            props = tool.inputSchema["properties"]
+            props = tool.input_schema["properties"]
             assert props["feeling"]["description"] == "TrainingPeaks feeling value (0-10)."
             assert props["rpe"]["description"] == "Rating of perceived exertion (RPE), 0-10."
 

--- a/tests/test_tool_metadata.py
+++ b/tests/test_tool_metadata.py
@@ -22,7 +22,7 @@ class TestEveryToolHasMetadata:
         assert not missing, f"Tools without annotations: {missing}. {_HELP}"
 
     def test_every_tool_declares_open_world(self):
-        bad = [t.name for t in TOOLS if not t.annotations.openWorldHint]
+        bad = [t.name for t in TOOLS if not t.annotations.open_world_hint]
         assert not bad, f"All tools call the external TrainingPeaks API: {bad}. {_HELP}"
 
 
@@ -32,16 +32,16 @@ class TestReadWriteClassification:
             t.name
             for t in TOOLS
             if t.name.startswith(("tp_get_", "tp_list_", "tp_download_", "tp_search_", "tp_validate_", "tp_analyze_"))
-            and not t.annotations.readOnlyHint
+            and not t.annotations.read_only_hint
         ]
         assert not bad, f"Read-prefixed tools missing readOnlyHint: {bad}. {_HELP}"
 
     def test_delete_tools_are_destructive(self):
-        bad = [t.name for t in TOOLS if t.name.startswith("tp_delete_") and not t.annotations.destructiveHint]
+        bad = [t.name for t in TOOLS if t.name.startswith("tp_delete_") and not t.annotations.destructive_hint]
         assert not bad, f"tp_delete_* tools missing destructiveHint: {bad}. {_HELP}"
 
     def test_no_read_only_tool_is_destructive(self):
-        bad = [t.name for t in TOOLS if t.annotations.readOnlyHint and t.annotations.destructiveHint]
+        bad = [t.name for t in TOOLS if t.annotations.read_only_hint and t.annotations.destructive_hint]
         assert not bad, f"Contradictory metadata (read-only AND destructive): {bad}"
 
     def test_exception_sets_only_name_real_tools(self):
@@ -59,31 +59,31 @@ class TestSpotChecks:
     def test_get_workouts(self):
         t = self._tool("tp_get_workouts")
         assert t.title == "Get workouts"
-        assert t.annotations.readOnlyHint is True
-        assert t.annotations.destructiveHint is False
+        assert t.annotations.read_only_hint is True
+        assert t.annotations.destructive_hint is False
 
     def test_delete_workout(self):
         t = self._tool("tp_delete_workout")
         assert t.title == "Delete workout"
-        assert t.annotations.readOnlyHint is False
-        assert t.annotations.destructiveHint is True
-        assert t.annotations.idempotentHint is True  # deleting twice: same state
+        assert t.annotations.read_only_hint is False
+        assert t.annotations.destructive_hint is True
+        assert t.annotations.idempotent_hint is True  # deleting twice: same state
 
     def test_create_workout_is_non_idempotent_create(self):
         t = self._tool("tp_create_workout")
-        assert t.annotations.readOnlyHint is False
-        assert t.annotations.destructiveHint is False
-        assert t.annotations.idempotentHint is False  # retry duplicates
+        assert t.annotations.read_only_hint is False
+        assert t.annotations.destructive_hint is False
+        assert t.annotations.idempotent_hint is False  # retry duplicates
 
     def test_update_ftp_is_idempotent_write(self):
         t = self._tool("tp_update_ftp")
         assert t.title == "Update FTP"
-        assert t.annotations.readOnlyHint is False
-        assert t.annotations.idempotentHint is True
+        assert t.annotations.read_only_hint is False
+        assert t.annotations.idempotent_hint is True
 
     def test_remove_athletes_is_destructive_non_delete_name(self):
         t = self._tool("tp_remove_athletes_from_group")
-        assert t.annotations.destructiveHint is True
+        assert t.annotations.destructive_hint is True
 
     def test_acronym_titles(self):
         assert self._tool("tp_update_hr_zones").title == "Update HR zones"
@@ -93,4 +93,4 @@ class TestSpotChecks:
     def test_auth_status_override(self):
         t = self._tool("tp_auth_status")
         assert t.title == "Check auth status"
-        assert t.annotations.readOnlyHint is True
+        assert t.annotations.read_only_hint is True

--- a/tests/test_tools/test_coach_support.py
+++ b/tests/test_tools/test_coach_support.py
@@ -315,7 +315,7 @@ class TestSchemaInjection:
         from tp_mcp.server import TOOLS, _ATHLETE_EXEMPT_TOOLS
         for tool in TOOLS:
             if tool.name not in _ATHLETE_EXEMPT_TOOLS:
-                assert "athlete" in tool.inputSchema["properties"], (
+                assert "athlete" in tool.input_schema["properties"], (
                     f"Tool {tool.name} missing 'athlete' property"
                 )
 
@@ -323,7 +323,7 @@ class TestSchemaInjection:
         from tp_mcp.server import TOOLS, _ATHLETE_EXEMPT_TOOLS
         for tool in TOOLS:
             if tool.name in _ATHLETE_EXEMPT_TOOLS:
-                assert "athlete" not in tool.inputSchema["properties"], (
+                assert "athlete" not in tool.input_schema["properties"], (
                     f"Exempt tool {tool.name} should not have 'athlete' property"
                 )
 

--- a/tests/test_v2_migration.py
+++ b/tests/test_v2_migration.py
@@ -1,0 +1,150 @@
+"""SDK v2 migration guarantees (PRD PR 3).
+
+Locks in the behaviour the migration must preserve: the structured error
+contract, tolerance of omitted arguments, the INVALID_ARGS replacement for
+v1's SDK-level validation, wire-level cache metadata, deterministic tool
+ordering, and a clean stdio stream (stdout must carry JSON-RPC only).
+
+All tests here are offline - no TrainingPeaks network calls.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from tp_mcp.server import TOOLS, call_tool, list_tools, server
+
+
+class TestErrorContract:
+    async def test_unknown_tool_returns_structured_error(self):
+        contents = await call_tool("tp_nonexistent", {})
+        payload = json.loads(contents[0].text)
+        assert payload["isError"] is True
+        assert payload["error_code"] == "UNKNOWN_TOOL"
+
+    async def test_omitted_arguments_is_legal_for_no_arg_tools(self):
+        # v2 clients may omit "arguments" entirely -> params.arguments is None.
+        contents = await call_tool("tp_nonexistent_no_args", None)
+        payload = json.loads(contents[0].text)
+        assert payload["error_code"] == "UNKNOWN_TOOL"  # not a crash
+
+    async def test_missing_required_args_returns_invalid_args(self):
+        # v1's decorator validated against inputSchema; v2 validates nothing.
+        # The dispatch-level check must keep the error readable for the model.
+        contents = await call_tool("tp_get_workouts", {})
+        payload = json.loads(contents[0].text)
+        assert payload["isError"] is True
+        assert payload["error_code"] == "INVALID_ARGS"
+        assert "start_date" in payload["message"] and "end_date" in payload["message"]
+
+    async def test_internal_error_returns_structured_api_error(self, monkeypatch):
+        import tp_mcp.server as srv
+
+        async def boom(args):
+            raise RuntimeError("synthetic failure")
+
+        monkeypatch.setitem(srv._TOOL_HANDLERS, "tp_auth_status", boom)
+        contents = await call_tool("tp_auth_status", {})
+        payload = json.loads(contents[0].text)
+        assert payload["isError"] is True
+        assert payload["error_code"] == "API_ERROR"
+        assert "synthetic failure" not in payload["message"]  # no traceback leak
+
+
+class TestProtocolLayer:
+    async def test_in_memory_v2_client_end_to_end(self):
+        from mcp import Client
+
+        async with Client(server) as client:
+            listed = await client.list_tools()
+            names = [t.name for t in listed.tools]
+            assert len(names) == len(TOOLS)
+            # deterministic order, straight from the static TOOLS constant
+            assert names == [t.name for t in TOOLS]
+            # cache metadata rides the 2026-07-28 wire (in-memory negotiates latest)
+            assert listed.ttl_ms == 3600000
+            assert listed.cache_scope == "private"
+            # a call that stays offline: structured INVALID_ARGS through the full stack
+            result = await client.call_tool("tp_get_workouts", {})
+            payload = json.loads(result.content[0].text)
+            assert payload["error_code"] == "INVALID_ARGS"
+
+    async def test_server_reports_package_version(self):
+        from tp_mcp import __version__
+
+        assert server.version == __version__
+
+    def test_httpx_and_httpx2_coexist(self):
+        # tp_mcp's own client uses httpx; SDK v2 brings httpx2. Both must import.
+        import httpx
+        import httpx2
+
+        assert httpx.__name__ == "httpx" and httpx2.__name__ == "httpx2"
+
+    async def test_list_tools_plain_function_unchanged(self):
+        assert await list_tools() is TOOLS
+
+
+class TestStdioWire:
+    """Spawn the real stdio server and drive it as a LEGACY (2025-era) client.
+
+    Doubles as the stdout-hygiene check: with OpenTelemetry on by default in
+    SDK v2, nothing may write non-JSON-RPC bytes to stdout or the transport
+    corrupts.
+    """
+
+    def _read_response(self, proc, want_id, deadline=30):
+        """Read stdout lines until the response with ``want_id`` arrives.
+
+        Every line must parse as JSON-RPC - anything else (OTel spans, stray
+        logging) is a transport-corrupting leak and fails the test.
+        """
+        import time
+
+        end = time.monotonic() + deadline
+        while time.monotonic() < end:
+            ln = proc.stdout.readline()
+            if not ln:
+                pytest.fail("server closed stdout before responding")
+            ln = ln.strip()
+            if not ln:
+                continue
+            try:
+                msg = json.loads(ln)
+            except json.JSONDecodeError:
+                pytest.fail(f"non-JSON-RPC bytes on stdout (OTel/logging leak?): {ln[:200]}")
+            if isinstance(msg, dict) and msg.get("id") == want_id:
+                return msg
+        pytest.fail(f"no response for id={want_id} within {deadline}s")
+
+    def test_legacy_initialize_handshake_and_tools_list_over_stdio(self):
+        env = dict(os.environ, TP_MCP_SKIP_STARTUP_VALIDATION="1")
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "tp_mcp", "serve"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True, env=env,
+        )
+        try:
+            def send(msg):
+                proc.stdin.write(json.dumps(msg) + "\n")
+                proc.stdin.flush()
+
+            send({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+                  "params": {"protocolVersion": "2025-06-18",
+                             "capabilities": {},
+                             "clientInfo": {"name": "legacy-test", "version": "0"}}})
+            init = self._read_response(proc, 1)
+            assert "result" in init, f"initialize failed: {init}"
+            assert init["result"]["protocolVersion"] == "2025-06-18"
+
+            send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+            send({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+            tools = self._read_response(proc, 2)
+            assert "result" in tools, f"tools/list failed: {tools}"
+            assert len(tools["result"]["tools"]) == len(TOOLS)
+        finally:
+            proc.terminate()
+            proc.wait(timeout=10)

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -274,6 +278,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -289,21 +306,28 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -560,15 +584,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -578,9 +602,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -645,6 +682,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -852,20 +901,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.13.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -921,15 +956,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -1240,7 +1266,7 @@ wheels = [
 
 [[package]]
 name = "tp-mcp"
-version = "2.2.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1267,7 +1293,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "keyring", specifier = ">=25.0.0" },
-    { name = "mcp", specifier = ">=1.10.0,<2" },
+    { name = "mcp", specifier = ">=2.0.0,<3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -1275,6 +1301,15 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
 ]
 provides-extras = ["browser", "dev"]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
PRD PR 3 (`docs/mcp-2026-07-28-adoption-prd.md`). Announcement: #146.

## Zero-breakage evidence (the hard constraint)

- **60-tool live regression sweep: zero shape deltas.** `scripts/capture_tool_shapes.py` re-run on SDK 2.0.0 against the committed 1.26.0 baseline - every captured tool's output shape is identical, same 24 documented skips.
- **Real SDK 1.x client end-to-end** (`scripts/legacy_client_check.py`, now a CI job with a pinned `mcp==1.26.0` venv): initialize handshake negotiates 2025-11-25, 84 tools listed with titles/annotations intact over the legacy wire, structured errors preserved.
- **Real current Claude Code smoke**: headless `claude -p` spawned the branch build via the user's actual MCP config and a live `tp_auth_status` call returned the correct athlete id.
- **Stored credentials survive**: `auth/` has a zero-line diff vs main.
- **`v2.x` maintenance branch** cut from v2.2.0 at merge time; CI branch filters already cover it.

## The port

Low-level `Server` path per the PRD decision: decorators → `on_*` constructor params, with `list_tools`/`call_tool` kept as plain functions (the whole test surface calls them directly) wrapped by thin v2 adapters. Plus:

- `arguments` may legally be omitted by v2 clients → normalised before the athlete-param pop (previously a pre-`try` crash path)
- **New `INVALID_ARGS` error code**: v2 removed SDK-level argument validation, so required keys are checked at dispatch - a missing arg stays a readable structured error instead of becoming `-32603 Internal server error`
- Mechanical snake_case rename across all 84 `Tool(...)` definitions (`inputSchema=` → `input_schema=`; annotation kwargs likewise) - mypy rejects the runtime-valid camelCase aliases, and mypy is a CI gate. One uniform pattern; nothing else changed on those lines (PRD decision amended accordingly)
- `serverInfo` now carries the real package version; `tools/list` sets `ttl_ms=3600000` (`cache_scope` stays at its `private` default)
- `TP_MCP_SKIP_STARTUP_VALIDATION=1` env var skips the live auth check at startup (CI/offline)

## Tests

544 → **553 passing**: 9 new in `tests/test_v2_migration.py` (error contract incl. no-traceback-leak, omitted-arguments, INVALID_ARGS, in-memory v2 client e2e asserting `ttl_ms`/`cache_scope` on the 2026 wire + deterministic tool order, server version, httpx/httpx2 coexistence, stdio stdout-hygiene + legacy raw-handshake). Existing tests needed only v2 attribute renames (`inputSchema` → `input_schema`, hint attributes to snake_case).

## For clone users (rollback story)

Pulling main after this merge is a major upgrade - re-run `pip install -e .`. Escape hatch: `git checkout v2.2.0 && pip install -e .`. Critical fixes for the 2.x line land on the `v2.x` branch.