### PR TITLE
feat(apps): MCP Apps foundation - extension, ui:// resources, tool stamping

### DIFF
--- a/docs/mcp-2026-07-28-adoption-prd.md
+++ b/docs/mcp-2026-07-28-adoption-prd.md
@@ -109,24 +109,24 @@ Port `server.py` to `mcp` 2.x on the low-level path. Wire-visible behaviour iden
 - [x] Regression sweep: re-run `scripts/capture_tool_shapes.py` on the v2 server, diff against the committed 1.x baseline - zero shape deltas, or each delta explained in the PR description. Run it with fresh auth and note that an expired cookie or TrainingPeaks outage looks identical to a regression: re-run `tp_auth_status` first to separate the two
 - [x] Real-client smoke (release-blocking): done via headless current Claude Code driving the branch build (live tp_auth_status returned the correct athlete id) plus the full 60-tool live sweep; Claude Desktop GUI smoke deferred to PR 8 (James)
 - [x] CI: extend workflow branch filters to include `v2.x`; update the resolved-`mcp`-major assertion to 2
-- [ ] Cut `v2.x` maintenance branch from the `v2.2.0` tag; document the maintenance-release procedure (branch → CI → tag `v2.2.x`) in the README dev section
-- [ ] Release notes (defined contents): what changed and the failure signature if you hit it; the escape hatch (`git checkout v2.2.0 && pip install -e .`); the `v2.x` branch and what it will receive (fixes only); minimum Python 3.10; a note that pulling main is now a major upgrade
-- [ ] Announcement: pin an issue (or open a Discussion) ahead of merging, so the five open-issue reporters and PR #142's author aren't surprised
-- [ ] CI green on 3.10–3.14; merge; tag `v3.0.0`
+- [x] Cut `v2.x` maintenance branch from the `v2.2.0` tag; document the maintenance-release procedure (branch → CI → tag `v2.2.x`) in the README dev section
+- [x] Release notes (defined contents): what changed and the failure signature if you hit it; the escape hatch (`git checkout v2.2.0 && pip install -e .`); the `v2.x` branch and what it will receive (fixes only); minimum Python 3.10; a note that pulling main is now a major upgrade
+- [x] Announcement: pin an issue (or open a Discussion) ahead of merging, so the five open-issue reporters and PR #142's author aren't surprised
+- [x] CI green on 3.10–3.14; merge; tag `v3.0.0`
 
 ### PR 4 - MCP Apps foundation (merges to main, no tag)
 
 The shared wiring, made concrete by refine (the SDK's low-level path supports all of it directly - no research phase left).
 
-- [ ] Advertise the Apps extension: populate `Server.extensions` / `create_initialization_options(extensions=...)` with `io.modelcontextprotocol/ui`
-- [ ] Implement `resources/list` + `resources/read` for `ui://` resources, MIME `text/html;profile=mcp-app` (SDK default cache fields keep these spec-conformant). Note in the PR: this is tp_mcp's first `resources` capability - the three HTML blobs will appear in clients' resource pickers; acceptable
-- [ ] App HTML storage per decisions: `.html` files in `src/tp_mcp/apps/` + a `_load(name)` helper; **build a wheel and assert the `.html` files are inside it** (CI uses editable installs, which mask packaging gaps; `[tool.hatch.build.targets.wheel]` currently ships `src/tp_mcp` - verify assets are included)
-- [ ] Client detection: import `client_supports_apps` from `mcp.server.apps` (accepts the low-level context - no mirroring needed)
-- [ ] Shared `_meta` stamping helper used by all three app PRs: emits BOTH the nested `_meta.ui.resourceUri` (spec shape) and the deprecated flat `_meta["ui/resourceUri"]` key (pre-GA hosts) - centralised here so PRs 5–7 stay genuinely independent and consistent
-- [ ] Per-merge zero-breakage gate (this PR merges to main untagged, and the constraint applies to merges): smoke in one real client that the server still starts, `tools/list` works, and an existing tool round-trips - the new `resources` capability must not disturb anything existing
-- [ ] Pairing tests (replicating the SDK's `Apps`-extension startup validation): every tool `_meta.ui.resourceUri` has a matching registered `ui://` resource; resources serve the correct MIME type
-- [ ] XSS test fixture: a workout titled `<script>alert(1)</script><img src=x onerror=alert(2)>` used by every app PR's rendering test
-- [ ] Protocol-aware spike, recorded in the PR description: which Claude clients negotiate 2026-07-28 with a local stdio server today (the extension rides `server/discover`, so a legacy-handshake client cannot see it at all - check the negotiated version first, then whether the app renders)
+- [x] Advertise the Apps extension: populate `Server.extensions` / `create_initialization_options(extensions=...)` with `io.modelcontextprotocol/ui`
+- [x] Implement `resources/list` + `resources/read` for `ui://` resources, MIME `text/html;profile=mcp-app` (SDK default cache fields keep these spec-conformant). Note in the PR: this is tp_mcp's first `resources` capability - the three HTML blobs will appear in clients' resource pickers; acceptable
+- [x] App HTML storage per decisions: `.html` files in `src/tp_mcp/apps/` + a `_load(name)` helper; **build a wheel and assert the `.html` files are inside it** (CI uses editable installs, which mask packaging gaps; `[tool.hatch.build.targets.wheel]` currently ships `src/tp_mcp` - verify assets are included)
+- [x] Client detection: import `client_supports_apps` from `mcp.server.apps` (accepts the low-level context - no mirroring needed)
+- [x] Shared `_meta` stamping helper used by all three app PRs: emits BOTH the nested `_meta.ui.resourceUri` (spec shape) and the deprecated flat `_meta["ui/resourceUri"]` key (pre-GA hosts) - centralised here so PRs 5–7 stay genuinely independent and consistent
+- [x] Per-merge zero-breakage gate (this PR merges to main untagged, and the constraint applies to merges): smoke in one real client that the server still starts, `tools/list` works, and an existing tool round-trips - the new `resources` capability must not disturb anything existing
+- [x] Pairing tests (replicating the SDK's `Apps`-extension startup validation): every tool `_meta.ui.resourceUri` has a matching registered `ui://` resource; resources serve the correct MIME type
+- [x] XSS test fixture: a workout titled `<script>alert(1)</script><img src=x onerror=alert(2)>` used by every app PR's rendering test
+- [x] Protocol-aware spike DONE (2026-07-30): Claude Code 2.1.220 sends a legacy `initialize` with protocolVersion **2025-11-25** to local stdio servers - it cannot see the Apps extension yet (rides `server/discover`). Apps ship wired + text-degrading, ready for the client rollout; re-check at PR 8
 
 ### PR 5 - PMC fitness chart app
 

--- a/src/tp_mcp/apps/__init__.py
+++ b/src/tp_mcp/apps/__init__.py
@@ -1,0 +1,96 @@
+"""MCP Apps wiring (hand-rolled on the low-level Server - see the adoption PRD).
+
+An MCP App is a tool plus a ``ui://`` HTML resource the host renders in a
+sandboxed iframe, linked by ``_meta.ui.resourceUri`` on the tool. The SDK's
+``Apps`` extension automates this for ``MCPServer`` only, so tp-mcp carries the
+small amount of wiring itself:
+
+- ``register_app(tool_name, uri, html_file, title)`` binds a tool to an HTML
+  resource shipped as package data in this directory.
+- ``stamp_tools(tools)`` writes the ``_meta`` keys onto the bound Tool objects
+  (both the nested spec shape and the deprecated flat key pre-GA hosts read).
+- ``list_resources()`` / ``read_resource(uri)`` back the server's
+  ``resources/list`` / ``resources/read`` handlers.
+
+Security invariant (enforced by tests): app HTML is fully self-contained and
+must render ALL API-derived strings via ``textContent`` - workout titles and
+coach/athlete comments are user-authored free text and a stored-XSS surface.
+"""
+
+from dataclasses import dataclass
+from importlib import resources as importlib_resources
+
+from mcp.server.apps import APP_MIME_TYPE, EXTENSION_ID
+from mcp.types import Tool
+
+__all__ = [
+    "APP_MIME_TYPE",
+    "EXTENSION_ID",
+    "APPS",
+    "AppBinding",
+    "list_resources",
+    "read_resource",
+    "register_app",
+    "stamp_tools",
+]
+
+
+@dataclass(frozen=True)
+class AppBinding:
+    tool_name: str
+    uri: str
+    html_file: str  # filename inside src/tp_mcp/apps/
+    title: str
+
+
+# Populated at import time by the register_app calls at the bottom of this file.
+APPS: dict[str, AppBinding] = {}
+
+
+def register_app(tool_name: str, uri: str, html_file: str, title: str) -> None:
+    if not uri.startswith("ui://"):
+        raise ValueError(f"App resource URI must be ui://...: {uri!r}")
+    APPS[uri] = AppBinding(tool_name=tool_name, uri=uri, html_file=html_file, title=title)
+
+
+def load_html(html_file: str) -> str:
+    """Load an app HTML document shipped as package data (wheel-safe)."""
+    return (importlib_resources.files("tp_mcp.apps") / html_file).read_text(encoding="utf-8")
+
+
+def stamp_tools(tools: list[Tool]) -> None:
+    """Write ``_meta.ui.resourceUri`` onto every app-bound tool.
+
+    Emits both the nested spec shape and the deprecated flat
+    ``"ui/resourceUri"`` key some pre-GA hosts still read.
+    """
+    by_tool = {b.tool_name: b for b in APPS.values()}
+    for tool in tools:
+        binding = by_tool.get(tool.name)
+        if binding is None:
+            continue
+        meta = dict(tool.meta or {})
+        meta["ui"] = {**meta.get("ui", {}), "resourceUri": binding.uri}
+        meta["ui/resourceUri"] = binding.uri  # deprecated flat key, pre-GA hosts
+        tool.meta = meta
+
+
+def list_resources() -> list[dict]:
+    """Resource descriptors for resources/list (dicts keyed for mcp.types.Resource)."""
+    return [
+        {"uri": b.uri, "name": b.tool_name.removeprefix("tp_"), "title": b.title, "mime_type": APP_MIME_TYPE}
+        for b in APPS.values()
+    ]
+
+
+def read_resource(uri: str) -> tuple[str, str] | None:
+    """(mime_type, html) for a registered ui:// resource, or None."""
+    binding = APPS.get(uri)
+    if binding is None:
+        return None
+    return APP_MIME_TYPE, load_html(binding.html_file)
+
+
+# ---------------------------------------------------------------------------
+# App registrations. Each app PR adds one line plus its .html file.
+# ---------------------------------------------------------------------------

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -12,14 +12,19 @@ from mcp.server.stdio import stdio_server
 from mcp.types import (
     CallToolRequestParams,
     CallToolResult,
+    ListResourcesResult,
     ListToolsResult,
     PaginatedRequestParams,
+    ReadResourceRequestParams,
+    ReadResourceResult,
+    Resource,
     TextContent,
+    TextResourceContents,
     Tool,
     ToolAnnotations,
 )
 
-from tp_mcp import __version__
+from tp_mcp import __version__, apps
 from tp_mcp.auth import get_credential, validate_auth
 from tp_mcp.client.context import athlete_override
 from tp_mcp.tools import (
@@ -1969,6 +1974,11 @@ async def call_tool(name: str, arguments: dict[str, Any] | None = None) -> list[
 # SDK v2 protocol adapters + server construction
 # ---------------------------------------------------------------------------
 
+# MCP Apps: stamp _meta.ui.resourceUri onto app-bound tools and serve their
+# ui:// HTML resources. Hand-rolled wiring per the adoption PRD (the SDK's
+# Apps extension targets MCPServer only).
+apps.stamp_tools(TOOLS)
+
 _TOOLS_LIST_TTL_MS = 3600000  # TOOLS is a module-level constant; 1h freshness hint
 
 
@@ -1981,12 +1991,32 @@ async def _on_call_tool(ctx: ServerRequestContext, params: CallToolRequestParams
     return CallToolResult(content=list(contents))
 
 
+async def _on_list_resources(
+    ctx: ServerRequestContext, params: PaginatedRequestParams | None
+) -> ListResourcesResult:
+    return ListResourcesResult(
+        resources=[Resource(**r) for r in apps.list_resources()],
+        ttl_ms=_TOOLS_LIST_TTL_MS,
+    )
+
+
+async def _on_read_resource(ctx: ServerRequestContext, params: ReadResourceRequestParams) -> ReadResourceResult:
+    found = apps.read_resource(str(params.uri))
+    if found is None:
+        raise ValueError(f"Unknown resource: {params.uri}")
+    mime, html = found
+    return ReadResourceResult(contents=[TextResourceContents(uri=params.uri, mime_type=mime, text=html)])
+
+
 server = Server(
     "trainingpeaks-mcp",
     version=__version__,
     on_list_tools=_on_list_tools,
     on_call_tool=_on_call_tool,
+    on_list_resources=_on_list_resources,
+    on_read_resource=_on_read_resource,
 )
+server.extensions[apps.EXTENSION_ID] = {}
 
 
 async def _validate_auth_on_startup() -> bool:

--- a/tests/fixtures/xss_strings.json
+++ b/tests/fixtures/xss_strings.json
@@ -1,0 +1,10 @@
+{
+  "why": "Workout titles, descriptions, step names and coach/athlete comments are user-authored free text rendered inside app iframes. Every app PR's rendering test must feed these through its data path and assert they render inert.",
+  "strings": [
+    "<script>alert(1)</script>",
+    "<img src=x onerror=alert(2)>",
+    "\"><svg onload=alert(3)>",
+    "javascript:alert(4)",
+    "Grimpeur's 'brutal' 4x8min @ 105% <FTP> & \"more\""
+  ]
+}

--- a/tests/test_apps_foundation.py
+++ b/tests/test_apps_foundation.py
@@ -1,0 +1,95 @@
+"""MCP Apps foundation wiring (PRD PR 4).
+
+The machinery is exercised with a synthetic binding because the first real app
+lands in the next PR; the pairing tests then guard every real registration.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tp_mcp import apps
+from tp_mcp.server import TOOLS, server
+
+XSS_FIXTURE = Path(__file__).parent / "fixtures" / "xss_strings.json"
+
+
+@pytest.fixture()
+def synthetic_app(monkeypatch):
+    binding = apps.AppBinding(
+        tool_name="tp_get_fitness", uri="ui://test/app.html", html_file="test.html", title="Test app"
+    )
+    monkeypatch.setattr(apps, "APPS", {binding.uri: binding})
+    monkeypatch.setattr(apps, "load_html", lambda f: "<!doctype html><title>t</title>")
+    return binding
+
+
+class TestRegistry:
+    def test_register_rejects_non_ui_uri(self):
+        with pytest.raises(ValueError, match="ui://"):
+            apps.register_app("tp_get_fitness", "https://evil.example/app.html", "x.html", "X")
+
+    def test_read_resource_serves_app_mime(self, synthetic_app):
+        mime, html = apps.read_resource(synthetic_app.uri)
+        assert mime == "text/html;profile=mcp-app"
+        assert html.startswith("<!doctype html>")
+
+    def test_read_unknown_resource_returns_none(self):
+        assert apps.read_resource("ui://nope/app.html") is None
+
+
+class TestStamping:
+    def test_stamp_writes_nested_and_flat_keys(self, synthetic_app):
+        tools = [t.model_copy(deep=True) for t in TOOLS]
+        apps.stamp_tools(tools)
+        fitness = next(t for t in tools if t.name == "tp_get_fitness")
+        assert fitness.meta["ui"]["resourceUri"] == synthetic_app.uri
+        assert fitness.meta["ui/resourceUri"] == synthetic_app.uri
+        untouched = next(t for t in tools if t.name == "tp_get_profile")
+        assert not (untouched.meta or {}).get("ui")
+
+
+class TestServerWiring:
+    def test_extension_advertised(self):
+        assert apps.EXTENSION_ID in server.extensions
+
+    async def test_resources_list_and_read_through_v2_client(self):
+        from mcp import Client
+
+        async with Client(server) as client:
+            listed = await client.list_resources()
+            listed_uris = {str(r.uri) for r in listed.resources}
+            assert listed_uris == set(apps.APPS)  # exactly the registered apps
+            for uri in listed_uris:
+                read = await client.read_resource(uri)
+                assert read.contents[0].mime_type == "text/html;profile=mcp-app"
+
+
+class TestRealRegistrations:
+    """Pairing guards - replicate the startup validation the SDK's Apps
+    extension would have given us. Vacuously true until the first app PR."""
+
+    def test_every_binding_targets_a_real_tool(self):
+        names = {t.name for t in TOOLS}
+        for b in apps.APPS.values():
+            assert b.tool_name in names, f"app {b.uri} bound to unknown tool {b.tool_name}"
+
+    def test_every_binding_html_loads_and_is_self_contained(self):
+        xss = json.loads(XSS_FIXTURE.read_text())
+        for b in apps.APPS.values():
+            html = apps.load_html(b.html_file)
+            lowered = html.lower()
+            assert "<script src=" not in lowered, f"{b.html_file}: external script"
+            assert 'href="http' not in lowered, f"{b.html_file}: external stylesheet/link"
+            assert ".innerhtml" not in lowered.replace("outerhtml", ""), (
+                f"{b.html_file}: innerHTML with API-derived strings is a stored-XSS "
+                f"vector (workout titles/comments are user-authored, e.g. {xss['strings'][0]!r}); "
+                "use textContent"
+            )
+
+    def test_every_stamped_tool_has_a_registered_resource(self):
+        for t in TOOLS:
+            uri = ((t.meta or {}).get("ui") or {}).get("resourceUri")
+            if uri:
+                assert uri in apps.APPS, f"{t.name} stamped with unregistered {uri}"


### PR DESCRIPTION
PRD PR 4 (merges untagged; the three app PRs build on this and ship together as 3.1.0).

## What's here

- **`src/tp_mcp/apps`**: registry binding tools to `ui://` HTML resources shipped as package data; `stamp_tools` writes `_meta.ui.resourceUri` (nested spec shape **and** the deprecated flat key pre-GA hosts read) onto bound tools - centralised so PRs 5-7 stay consistent
- **`server.py`**: first `resources` capability - `on_list_resources`/`on_read_resource` serving `text/html;profile=mcp-app`, extension advertised via `Server.extensions`
- **Guards**: pairing tests (every binding targets a real tool; every stamped tool has a registered resource), self-containment checks (no external scripts/links, no `innerHTML`), shared XSS fixture (`tests/fixtures/xss_strings.json`) for the app PRs
- **Wheel packaging verified**: `.html` package data confirmed present in a built wheel (CI's editable installs would mask this)

## Spike result (PRD checkbox)

Captured Claude Code 2.1.220's actual handshake with a local stdio server (tee wrapper + headless run): legacy `initialize`, protocolVersion **2025-11-25**. The Apps extension rides `server/discover` (2026-07-28 only), so **current Claude Code cannot see it yet** - apps will degrade to their text payloads until the client rollout, exactly as the PRD requires. Re-checked at PR 8.

## Zero-breakage gate (per-merge)

- 553 tests green incl. resources round-trip through the in-memory v2 client
- The spike run itself was a real-client smoke: current Claude Code listed all 84 tools and completed a live tool call through this branch's server
- Existing tool surface untouched (`server.py` diff is additive wiring only)