### PR TITLE
chore(release): v3.1.0 sweep - version bump, README fix, PRD close-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ pip install -e .
 If you're logged into TrainingPeaks in your browser:
 
 ```bash
-pip install tp-mcp[browser]  # One-time: install browser support
+pip install -e ".[browser]"  # One-time: install browser support
 tp-mcp auth --from-browser chrome  # Or: firefox, safari, edge, auto
 ```
 

--- a/docs/mcp-2026-07-28-adoption-prd.md
+++ b/docs/mcp-2026-07-28-adoption-prd.md
@@ -161,13 +161,13 @@ Interval profile (steps, durations, targets) from `tp_get_workout`.
 
 One release and one full smoke pass for all three apps, plus the sequence-wide close-out.
 
-- [ ] Tag `v3.1.0` (single release for PRs 4–7 per amended decision); release notes include per-client app-rendering status from PR 5's record
-- [ ] Fresh `git clone` + `pip install -e .` in a clean venv on the tag: server starts, auth works (the real install path - there is no PyPI package to test)
-- [ ] Full smoke in Claude Code AND Claude Desktop: auth status, one read, one write, one delete on scratch data, all three app tools
-- [ ] Destructive gating compared against PR 2's baseline screenshots: the delete prompt observably changed
-- [ ] Old-protocol confidence: the pinned-1.x CI compat test is green on the tag (deterministic); additionally note which real client, if any, still speaks pre-2026 and smoke it
-- [ ] README final sweep: `pip install tp-mcp[browser]` (`README.md:195`) → `pip install -e ".[browser]"` (the bare form would resolve against PyPI if the name ever gets published there, silently replacing a clone install); stale counts; version references
-- [ ] Close the loop: release notes link this PRD; announcement issue updated; open issues re-triaged against 3.x
+- [x] Tag `v3.1.0` (single release for PRs 4–7 per amended decision); release notes include per-client app-rendering status from PR 5's record
+- [x] Fresh `git clone` + `pip install -e .` in a clean venv on the tag: server starts, auth works (the real install path - there is no PyPI package to test)
+- [ ] (Claude Code portion DONE headless - auth/read/apps verified; **Claude Desktop needs James**) Full smoke in Claude Code AND Claude Desktop: auth status, one read, one write, one delete on scratch data, all three app tools
+- [ ] (**needs James** - PR 2 baseline screenshot was never taken; observe current prompt and compare notes instead) Destructive gating compared against PR 2's baseline screenshots: the delete prompt observably changed
+- [x] Old-protocol confidence: the pinned-1.x CI compat test is green on the tag (deterministic); additionally note which real client, if any, still speaks pre-2026 and smoke it
+- [x] README final sweep: `pip install tp-mcp[browser]` (`README.md:195`) → `pip install -e ".[browser]"` (the bare form would resolve against PyPI if the name ever gets published there, silently replacing a clone install); stale counts; version references
+- [x] Close the loop: release notes link this PRD; announcement issue updated; open issues re-triaged against 3.x
 
 ## Out of scope / future additions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tp-mcp"
-version = "3.0.0"
+version = "3.1.0"
 description = "TrainingPeaks MCP Server - AI assistant integration for TrainingPeaks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1266,7 +1266,7 @@ wheels = [
 
 [[package]]
 name = "tp-mcp"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Final PR of the adoption PRD's build phase. Bumps to 3.1.0 for the apps release, fixes the README `[browser]` install form (PRD PR 8 item - the bare `pip install tp-mcp[browser]` would resolve against PyPI if the name ever gets claimed there), and closes out the PRD checklist. Two items remain flagged for James in the PRD: Claude Desktop GUI smoke and the destructive-gating prompt comparison.