### PR TITLE
feat(serve): deterministic read-only mode (--read-only / TP_MCP_READ_ONLY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,24 @@ This server is designed with defence-in-depth. Your TrainingPeaks session cookie
 
 > **Write access:** v2.0 adds full calendar management (create, update, delete workouts, events, notes, equipment, settings). All mutations go through Pydantic validation. The server cannot access billing or payment info.
 
+### Read-Only Mode
+
+For high-stakes accounts (e.g. a coach account holding many athletes), the server can be locked to read-only tools. Start it with the `--read-only` flag, or set `TP_MCP_READ_ONLY=1`:
+
+```json
+"trainingpeaks": {
+  "command": "tp-mcp",
+  "args": ["serve", "--read-only"]
+}
+```
+
+The guarantee is deterministic and enforced server-side at two layers - it does not depend on the AI's behaviour, prompts, or client settings:
+
+1. **Listing**: write tools are never included in `tools/list`, so the AI cannot see or select them.
+2. **Dispatch**: if a write tool is called anyway (stale client cache), the server rejects it with `Tool disabled: server is running in read-only mode.` before any TrainingPeaks API call is made.
+
+The read-only set is an **allowlist** (`tp_get_*`, `tp_list_*`, `tp_download_*`, `tp_search_*`, `tp_validate_*`, `tp_analyze_*`, plus `tp_auth_status`) - any tool not matching it, including tools added in future versions, is excluded by default. Note that `tp_refresh_auth` is also disabled in this mode; use `tp-mcp auth` in a terminal to re-authenticate.
+
 ### Cookie Storage
 
 | Platform | Primary Storage | Fallback |

--- a/src/tp_mcp/cli.py
+++ b/src/tp_mcp/cli.py
@@ -154,15 +154,18 @@ def cmd_auth_clear() -> int:
     return 0
 
 
-def cmd_serve() -> int:
+def cmd_serve(read_only: bool = False) -> int:
     """Start the MCP server.
+
+    Args:
+        read_only: Only expose read-only tools; reject write tool calls.
 
     Returns:
         Exit code.
     """
     from tp_mcp.server import run_server
 
-    return run_server()
+    return run_server(read_only=read_only)
 
 
 def cmd_config() -> int:
@@ -211,6 +214,8 @@ def cmd_help() -> int:
     print("  auth-clear            Clear stored cookie")
     print("  config                Output Claude Desktop config snippet")
     print("  serve                 Start the MCP server")
+    print("    --read-only         Expose only read-only tools; write calls are rejected")
+    print("                        (also enabled by TP_MCP_READ_ONLY=1)")
     print("  help                  Show this help message")
     print()
     print("Examples:")
@@ -232,6 +237,17 @@ def main() -> int:
 
     command = sys.argv[1].lower()
 
+    # Handle serve command with optional --read-only flag; anything else after
+    # 'serve' is rejected (fail closed - a mistyped flag must not start an
+    # unrestricted server).
+    if command == "serve":
+        serve_args = sys.argv[2:]
+        if serve_args not in ([], ["--read-only"]):
+            print(f"Error: invalid arguments for serve: {' '.join(serve_args)}", file=sys.stderr)
+            print("Usage: tp-mcp serve [--read-only]", file=sys.stderr)
+            return 1
+        return cmd_serve(read_only=serve_args == ["--read-only"])
+
     # Handle auth command with optional --from-browser flag
     if command == "auth":
         from_browser = None
@@ -249,7 +265,6 @@ def main() -> int:
         "auth-status": cmd_auth_status,
         "auth-clear": cmd_auth_clear,
         "config": cmd_config,
-        "serve": cmd_serve,
         "help": cmd_help,
         "--help": cmd_help,
         "-h": cmd_help,

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -1409,6 +1409,11 @@ for _tool in TOOLS:
 _READ_ONLY_PREFIXES = ("tp_get_", "tp_list_", "tp_download_", "tp_search_", "tp_validate_", "tp_analyze_")
 _READ_ONLY_EXTRA = {"tp_auth_status"}
 
+
+def _is_read_only_tool(name: str) -> bool:
+    """Allowlist predicate for read-only mode: unmatched names are write tools."""
+    return name.startswith(_READ_ONLY_PREFIXES) or name in _READ_ONLY_EXTRA
+
 # Irrecoverable data removal. Everything else that writes is recoverable by a
 # follow-up call (update/re-add), so destructiveHint stays False there.
 _DESTRUCTIVE_TOOLS = {
@@ -1461,18 +1466,55 @@ def _derive_title(name: str) -> str:
 
 
 for _tool in TOOLS:
-    _read_only = _tool.name.startswith(_READ_ONLY_PREFIXES) or _tool.name in _READ_ONLY_EXTRA
     _tool.title = _TITLE_OVERRIDES.get(_tool.name, _derive_title(_tool.name))
     _tool.annotations = ToolAnnotations(
-        read_only_hint=_read_only,
+        read_only_hint=_is_read_only_tool(_tool.name),
         destructive_hint=_tool.name in _DESTRUCTIVE_TOOLS,
         idempotent_hint=_tool.name not in _NON_IDEMPOTENT_WRITES,
         open_world_hint=True,  # every tool talks to the external TrainingPeaks API
     )
 
 
+# ---------------------------------------------------------------------------
+# Read-only mode: when active, tools failing _is_read_only_tool are neither
+# listed nor dispatchable. Checked at request time (TOOLS is built at import).
+# ---------------------------------------------------------------------------
+
+_read_only_mode = False
+
+_READ_ONLY_ENV_VAR = "TP_MCP_READ_ONLY"
+
+
+def set_read_only_mode(enabled: bool) -> None:
+    """Enable/disable read-only mode (also enabled by TP_MCP_READ_ONLY)."""
+    global _read_only_mode
+    _read_only_mode = enabled
+
+
+def _read_only_env() -> bool:
+    """Parse TP_MCP_READ_ONLY strictly - a malformed value must fail startup
+    rather than silently start an unrestricted server."""
+    raw = os.environ.get(_READ_ONLY_ENV_VAR)
+    if raw is None:
+        return False
+    value = raw.strip().lower()
+    if value in ("1", "true", "yes"):
+        return True
+    if value in ("0", "false", "no"):
+        return False
+    raise ValueError(
+        f"Invalid {_READ_ONLY_ENV_VAR} value {raw!r}: use 1/true/yes or 0/false/no."
+    )
+
+
+def _read_only_active() -> bool:
+    return _read_only_mode or _read_only_env()
+
+
 async def list_tools() -> list[Tool]:
     """List available tools (plain function - tests call it directly)."""
+    if _read_only_active():
+        return [t for t in TOOLS if _is_read_only_tool(t.name)]
     return TOOLS
 
 
@@ -1931,6 +1973,16 @@ async def call_tool(name: str, arguments: dict[str, Any] | None = None) -> list[
     """
     logger.info("Tool call: %s", name)
 
+    # Read-only mode rejects non-allowlisted names before anything else runs
+    # (a stale client tool cache may still offer write tools).
+    if _read_only_active() and not _is_read_only_tool(name):
+        result = {
+            "isError": True,
+            "error_code": "READ_ONLY_MODE",
+            "message": "Tool disabled: server is running in read-only mode.",
+        }
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+
     # A client may legally omit arguments entirely for no-arg tools.
     args = dict(arguments or {})
     # Extract athlete targeting for coach accounts and set context var
@@ -2038,6 +2090,9 @@ async def _validate_auth_on_startup() -> bool:
 async def run_server_async() -> None:
     """Run the MCP server (async)."""
     logger.info("Starting TrainingPeaks MCP Server")
+    if _read_only_active():
+        disabled = sum(1 for t in TOOLS if not _is_read_only_tool(t.name))
+        logger.info("READ-ONLY MODE: %d write tools disabled.", disabled)
     if os.environ.get("TP_MCP_SKIP_STARTUP_VALIDATION") != "1":
         await _validate_auth_on_startup()
 
@@ -2049,8 +2104,15 @@ async def run_server_async() -> None:
         )
 
 
-def run_server() -> int:
+def run_server(read_only: bool = False) -> int:
     """Run the MCP server (entry point)."""
+    try:
+        env_read_only = _read_only_env()
+    except ValueError as exc:
+        logger.error("%s", exc)
+        return 1
+    if read_only or env_read_only:
+        set_read_only_mode(True)
     try:
         asyncio.run(run_server_async())
         return 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,13 @@ TEST_ATHLETE_ID = 123456
 TEST_EMAIL = "test@example.com"
 
 
+@pytest.fixture(autouse=True)
+def _default_read_write_mode(monkeypatch):
+    """Pin tests to default (read-write) mode regardless of the shell's
+    TP_MCP_READ_ONLY; read-only tests opt in explicitly."""
+    monkeypatch.delenv("TP_MCP_READ_ONLY", raising=False)
+
+
 @pytest.fixture
 def mock_keyring():
     """Mock keyring for testing credential storage."""

--- a/tests/test_read_only_mode.py
+++ b/tests/test_read_only_mode.py
@@ -1,0 +1,179 @@
+"""Tests for read-only mode (--read-only / TP_MCP_READ_ONLY=1).
+
+Read-only mode is a two-layer, allowlist-based guarantee:
+1. Listing: tools failing _is_read_only_tool never appear in tools/list.
+2. Dispatch: calling a non-allowlisted name (stale client cache, injection)
+   returns an explicit error before any handler or HTTP request runs.
+"""
+
+import json
+import logging
+import sys
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tp_mcp import cli, server
+from tp_mcp.server import (
+    TOOLS,
+    _is_read_only_tool,
+    call_tool,
+    list_tools,
+    set_read_only_mode,
+)
+
+
+def _parse_result(text_contents: list) -> dict:
+    """Extract the JSON dict from a call_tool response."""
+    assert len(text_contents) == 1
+    return json.loads(text_contents[0].text)
+
+
+@pytest.fixture(autouse=True)
+def _clean_read_only_state(monkeypatch):
+    """Each test starts from default mode and cannot leak state."""
+    monkeypatch.delenv("TP_MCP_READ_ONLY", raising=False)
+    yield
+    set_read_only_mode(False)
+
+
+class TestListing:
+    async def test_read_only_list_contains_no_write_tools(self):
+        set_read_only_mode(True)
+        tools = await list_tools()
+        offenders = [t.name for t in tools if not _is_read_only_tool(t.name)]
+        assert offenders == []
+        # Sanity: the read-only surface is non-trivial, not an empty list.
+        assert {"tp_get_workouts", "tp_auth_status"} <= {t.name for t in tools}
+
+    async def test_env_var_activates_read_only_mode(self, monkeypatch):
+        monkeypatch.setenv("TP_MCP_READ_ONLY", "1")
+        tools = await list_tools()
+        assert all(_is_read_only_tool(t.name) for t in tools)
+        assert "tp_delete_workout" not in {t.name for t in tools}
+
+    async def test_default_mode_list_is_unchanged(self):
+        tools = await list_tools()
+        assert tools is TOOLS
+
+    async def test_injected_write_tool_is_excluded(self, monkeypatch):
+        """Allowlist semantics: an unknown future write tool is excluded by
+        default, without appearing in any blocklist."""
+        fake = TOOLS[0].model_copy(update={"name": "tp_wipe_calendar"})
+        monkeypatch.setattr(server, "TOOLS", TOOLS + [fake])
+        set_read_only_mode(True)
+        assert "tp_wipe_calendar" not in {t.name for t in await list_tools()}
+
+
+class TestDispatch:
+    @pytest.mark.parametrize("name", ["tp_create_workout", "tp_delete_workout"])
+    async def test_write_call_rejected_without_handler_running(self, monkeypatch, name):
+        handler = AsyncMock()
+        monkeypatch.setitem(server._TOOL_HANDLERS, name, handler)
+        set_read_only_mode(True)
+
+        result = _parse_result(await call_tool(name, {"workout_id": "123"}))
+
+        assert result["isError"] is True
+        assert result["error_code"] == "READ_ONLY_MODE"
+        assert result["message"] == "Tool disabled: server is running in read-only mode."
+        handler.assert_not_awaited()
+
+    async def test_unknown_write_name_rejected(self):
+        """Names outside the allowlist are rejected even if never registered."""
+        set_read_only_mode(True)
+        result = _parse_result(await call_tool("tp_wipe_calendar", {}))
+        assert result["error_code"] == "READ_ONLY_MODE"
+
+    async def test_read_tool_still_dispatches(self, monkeypatch):
+        handler = AsyncMock(return_value={"ok": True})
+        monkeypatch.setitem(server._TOOL_HANDLERS, "tp_get_profile", handler)
+        set_read_only_mode(True)
+
+        result = _parse_result(await call_tool("tp_get_profile", {}))
+
+        assert result == {"ok": True}
+        handler.assert_awaited_once()
+
+    async def test_default_mode_does_not_reject_writes(self, monkeypatch):
+        handler = AsyncMock(return_value={"ok": True})
+        monkeypatch.setitem(server._TOOL_HANDLERS, "tp_delete_workout", handler)
+
+        result = _parse_result(await call_tool("tp_delete_workout", {"workout_id": "123"}))
+
+        assert result == {"ok": True}
+        handler.assert_awaited_once()
+
+
+class TestEnvVar:
+    @pytest.mark.parametrize("value", ["1", "true", "True", "TRUE", "yes", "YES"])
+    async def test_truthy_values_enable(self, monkeypatch, value):
+        monkeypatch.setenv("TP_MCP_READ_ONLY", value)
+        tools = await list_tools()
+        assert tools is not TOOLS
+        assert all(_is_read_only_tool(t.name) for t in tools)
+
+    @pytest.mark.parametrize("value", ["0", "false", "False", "no", "NO"])
+    async def test_falsy_values_disable(self, monkeypatch, value):
+        monkeypatch.setenv("TP_MCP_READ_ONLY", value)
+        assert await list_tools() is TOOLS
+
+    async def test_unset_disables(self):
+        assert await list_tools() is TOOLS
+
+    @pytest.mark.parametrize("value", ["banana", "2", "on", " "])
+    def test_invalid_value_fails_startup(self, monkeypatch, caplog, value):
+        """A malformed value must abort startup, never fall back to
+        read-write silently."""
+        monkeypatch.setenv("TP_MCP_READ_ONLY", value)
+        with caplog.at_level(logging.ERROR, logger="tp-mcp"):
+            rc = server.run_server()
+        assert rc == 1
+        assert "Invalid TP_MCP_READ_ONLY value" in caplog.text
+
+
+class TestCliWiring:
+    @pytest.fixture(autouse=True)
+    def _no_real_server(self, monkeypatch):
+        """cli.main() must never start a real stdio server in tests."""
+        monkeypatch.setattr(server, "run_server_async", AsyncMock())
+
+    def test_read_only_flag_reaches_set_read_only_mode(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["tp-mcp", "serve", "--read-only"])
+        assert cli.main() == 0
+        assert server._read_only_active() is True
+
+    def test_serve_without_flag_stays_read_write(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["tp-mcp", "serve"])
+        assert cli.main() == 0
+        assert server._read_only_active() is False
+
+    @pytest.mark.parametrize(
+        "tail",
+        [["--bogus"], ["--read-only", "extra"], ["--READ-ONLY"], ["--read-only", "--read-only"]],
+    )
+    def test_unknown_serve_argument_exits_nonzero(self, monkeypatch, capsys, tail):
+        monkeypatch.setattr(sys, "argv", ["tp-mcp", "serve", *tail])
+        assert cli.main() == 1
+        err = capsys.readouterr().err
+        assert "Error: invalid arguments for serve" in err
+        assert "Usage: tp-mcp serve [--read-only]" in err
+
+
+class TestStartupLog:
+    async def test_startup_logs_disabled_tool_count(self, monkeypatch, caplog):
+        set_read_only_mode(True)
+        monkeypatch.setenv("TP_MCP_SKIP_STARTUP_VALIDATION", "1")
+
+        @asynccontextmanager
+        async def fake_stdio():
+            yield (MagicMock(), MagicMock())
+
+        monkeypatch.setattr(server, "stdio_server", fake_stdio)
+        monkeypatch.setattr(server.server, "run", AsyncMock())
+        with caplog.at_level(logging.INFO, logger="tp-mcp"):
+            await server.run_server_async()
+
+        expected = sum(1 for t in TOOLS if not _is_read_only_tool(t.name))
+        assert f"READ-ONLY MODE: {expected} write tools disabled." in caplog.text


### PR DESCRIPTION
## Motivation

Coach accounts expose an entire athlete roster, and some deployments need a hard
guarantee that Claude cannot write before they'll enable the server at all.
Prompt-level "don't modify anything" instructions are probabilistic; tool
non-registration is deterministic. The repo already draws exactly the right
line via the `read_only_hint` annotations — this PR promotes that existing
classification from hint to enforcement.

## What it does

- `tp-mcp serve --read-only`, or `TP_MCP_READ_ONLY=1|true|yes` (case-insensitive).
- Two enforcement layers:
  1. **Listing** — `list_tools()` filters to the 41 read-only tools. Allowlist
     semantics: any future tool not matching the read-only predicate is excluded
     by default.
  2. **Dispatch** — `call_tool()` rejects non-allowlisted names before argument
     parsing or handler lookup, returning `error_code: "READ_ONLY_MODE"` in the
     repo's existing JSON-in-TextContent error convention. This layer matters
     because of the 1-hour tools/list TTL: a client can hold a stale
     write-capable list — verified with an SDK 1.x client, which got the clean
     rejection on a cached write tool.
- The predicate is extracted to `_is_read_only_tool()` and shared by the
  annotation loop and both enforcement layers, so hints and enforcement cannot
  drift apart.
- **Fail-closed by design:** unknown `serve` arguments and malformed env values
  print an error to stderr and exit 1. A typo'd security flag must never
  silently start an unrestricted server. Note this is a deliberate behavior
  change — `serve` previously ignored unknown argv.
- Startup logs `READ-ONLY MODE: 43 write tools disabled.` to stderr.
- Default mode is untouched: canonical-JSON serialization of `tools/list` on
  this branch equals `main`, all 84 tools.

Claude Desktop config:

```json
"trainingpeaks": {
  "command": "/path/to/.venv/bin/tp-mcp",
  "args": ["serve", "--read-only"]
}
```

## Testing

- 32 new tests (mode behavior, allowlist proof via a synthetic injected write
  tool, CLI/env wiring, fail-closed paths, startup log); suite now 585 passing.
  `ruff` and `mypy` clean.
- Live stdio verification: both activation paths list exactly 41 tools;
  `tp_create_workout` / `tp_delete_workout` rejected with zero outbound
  connections (HTTPS proxy-trap instrumentation, with a positive control on an
  allowlisted call).
- `scripts/legacy_client_check.py` passes under `mcp==1.26.0`, including
  against `serve --read-only`.

## Notes

- No changes to auth, cookie handling, or any tool implementation.
- `tp_refresh_auth` is excluded in read-only mode since it mutates stored
  credentials; the terminal `tp-mcp auth` path is unaffected.
- README gains a "Read-Only Mode" subsection under Security.