### PR TITLE
feat(metadata): description pass on the 18 weakest-scored tools (v3.1.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tp-mcp"
-version = "3.1.0"
+version = "3.1.1"
 description = "TrainingPeaks MCP Server - AI assistant integration for TrainingPeaks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -315,7 +315,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_delete_workout",
-        description="Delete a workout.",
+        description=(
+            "Permanently delete a workout from the calendar - irreversible, applies to planned and completed "
+            "workouts alike. Workout ID from tp_get_workouts."
+        ),
         input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string"}},
@@ -337,7 +340,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_reorder_workouts",
-        description="Reorder workouts on a given day.",
+        description=(
+            "Reorder the workouts displayed on a single day. Pass every workout ID for that day (from "
+            "tp_get_workouts) in the desired order. Changes display order only - dates and content untouched."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -390,7 +396,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_get_workout_comments",
-        description="Get comments on a workout.",
+        description=(
+            "List the comment thread on a workout (athlete and coach comments with author and timestamp). Workout "
+            "ID from tp_get_workouts. For the private workout note use tp_get_workout_note."
+        ),
         input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string"}},
@@ -399,7 +408,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_add_workout_comment",
-        description="Add a comment to a workout.",
+        description=(
+            "Append a comment to a workout's thread - visible to both athlete and coach. Repeating the call posts "
+            "a duplicate. For a private note use tp_set_workout_note instead."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -499,7 +511,10 @@ TOOLS = [
     # --- Analysis & Peaks ---
     Tool(
         name="tp_get_workout_prs",
-        description="Get PRs set during a specific workout.",
+        description=(
+            "List personal records set during one completed workout. Returns an empty list when none. For an "
+            "athlete's bests across a period use tp_get_peaks."
+        ),
         input_schema={
             "type": "object",
             "properties": {"workout_id": {"type": "string"}},
@@ -508,7 +523,11 @@ TOOLS = [
     ),
     Tool(
         name="tp_get_peaks",
-        description="Get top performances by type. For comparing PRs over time.",
+        description=(
+            "Get an athlete's top performances for one sport and PR type over a period (days, default 90). Bike "
+            "pr_type: power1min/5min/20min; Run: speed5K/10K/Half. For PRs from a single workout use "
+            "tp_get_workout_prs."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -621,7 +640,10 @@ TOOLS = [
     # --- Athlete Settings ---
     Tool(
         name="tp_get_athlete_settings",
-        description="Get athlete settings: FTP, thresholds, zones, profile.",
+        description=(
+            "Get athlete account settings and profile fields (athlete type, linked coach, preferences, units). To "
+            "change training values use tp_update_ftp / tp_update_hr_zones / tp_update_speed_zones."
+        ),
         input_schema={"type": "object", "properties": {}, "required": []},
     ),
     Tool(
@@ -772,7 +794,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_create_equipment",
-        description="Add new equipment (bike or shoe).",
+        description=(
+            "Add a bike or shoes to the athlete's equipment list. type is 'bike' or 'shoe'; bike-only fields are "
+            "rejected on shoes. The API returns no ID on create - verify with tp_get_equipment afterwards."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -862,7 +887,11 @@ TOOLS = [
     ),
     Tool(
         name="tp_update_event",
-        description="Update an event.",
+        description=(
+            "Update fields on an existing race/event (name, date, priority, distance, description, attached "
+            "workout legs). Only the provided fields change. Event ID from tp_get_events; events more than ~2 "
+            "years from today cannot be resolved for update."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -888,7 +917,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_delete_event",
-        description="Delete an event.",
+        description=(
+            "Permanently delete a race/event from the calendar - irreversible. Event ID from tp_get_events. "
+            "Calendar workouts are separate: delete those with tp_delete_workout."
+        ),
         input_schema={
             "type": "object",
             "properties": {"event_id": {"type": "string"}},
@@ -910,7 +942,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_delete_note",
-        description="Delete a calendar note.",
+        description=(
+            "Permanently delete a calendar note and its comment thread - irreversible. Note ID from "
+            "tp_list_notes."
+        ),
         input_schema={
             "type": "object",
             "properties": {"note_id": {"type": "string"}},
@@ -952,7 +987,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_add_note_comment",
-        description="Add a comment to a calendar note.",
+        description=(
+            "Append a comment to a calendar note's thread. Repeating the call posts a duplicate. Note ID from "
+            "tp_list_notes or tp_create_note."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -988,7 +1026,11 @@ TOOLS = [
     ),
     Tool(
         name="tp_create_availability",
-        description="Mark dates as unavailable or limited.",
+        description=(
+            "Mark a date range as unavailable for training (or limited to certain sports). limited=false means "
+            "fully unavailable; with limited=true, sport_types lists the sports that REMAIN available. Returns "
+            "availability_id, needed for tp_delete_availability."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -1010,7 +1052,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_delete_availability",
-        description="Remove an availability entry.",
+        description=(
+            "Remove an availability entry so those dates become plannable again. availability_id from "
+            "tp_get_availability or the create response."
+        ),
         input_schema={
             "type": "object",
             "properties": {"availability_id": {"type": "string"}},
@@ -1055,7 +1100,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_get_library_items",
-        description="List templates in a workout library.",
+        description=(
+            "List the workout templates in one library (slim listing). library_id from tp_get_libraries. For a "
+            "template's full interval structure use tp_get_library_item."
+        ),
         input_schema={
             "type": "object",
             "properties": {"library_id": {"type": "string"}},
@@ -1064,7 +1112,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_get_library_item",
-        description="Get full template details including structure.",
+        description=(
+            "Get one workout template in full, including its interval structure - use before "
+            "tp_schedule_library_workout or when reusing structure. IDs from tp_get_library_items."
+        ),
         input_schema={
             "type": "object",
             "properties": {
@@ -1076,7 +1127,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_create_library",
-        description="Create a workout library folder.",
+        description=(
+            "Create an empty workout library (a folder for reusable templates). Returns library_id; add templates "
+            "with tp_create_library_item."
+        ),
         input_schema={
             "type": "object",
             "properties": {"name": {"type": "string"}},
@@ -1085,7 +1139,10 @@ TOOLS = [
     ),
     Tool(
         name="tp_delete_library",
-        description="Delete a library folder and all templates.",
+        description=(
+            "Permanently delete a library AND every template inside it - irreversible, and there is no per- "
+            "template delete. Schedule anything you want to keep first."
+        ),
         input_schema={
             "type": "object",
             "properties": {"library_id": {"type": "string"}},

--- a/uv.lock
+++ b/uv.lock
@@ -1266,7 +1266,7 @@ wheels = [
 
 [[package]]
 name = "tp-mcp"
-version = "3.1.0"
+version = "3.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
The bounded description pass. Targets the bottom 18 tools from Glama's TDQS scorecard (their server grade is 60% mean + 40% *minimum*, so lifting the floor moves the grade most - but the real motivation is agent behaviour: their critiques of the delete/update/create descriptions were fair).

Style preserved (terse, token-economical); each description gains only what an agent needs:
- **Irreversibility** stated on every delete (incl. `tp_delete_library`'s no-per-template-delete trap)
- **ID provenance** ("workout ID from tp_get_workouts") on every ID-taking tool
- **Sibling disambiguation** (comments vs private note, workout PRs vs period peaks, library list vs item)
- **Honesty fixes** from this week's findings: `tp_create_equipment` now says the API returns no ID (#145), `tp_update_event` documents the ~2-year resolution window, `tp_get_athlete_settings` no longer claims FTP/zones it doesn't return

553 tests green, ruff+mypy clean. Wire-visible change → v3.1.1.