### PR TITLE
fix(apps): implement the MCP Apps host handshake - apps now render in Claude Desktop (v3.1.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tp-mcp"
-version = "3.1.1"
+version = "3.1.2"
 description = "TrainingPeaks MCP Server - AI assistant integration for TrainingPeaks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tp_mcp/apps/pmc_chart.html
+++ b/src/tp_mcp/apps/pmc_chart.html
@@ -16,6 +16,17 @@
       --tile: #1c2127;
     }
   }
+  /* Host-driven theme (MCP Apps hostContext) overrides the media query */
+  :root[data-theme="dark"] {
+      --bg: #111418; --fg: #e5e7eb; --muted: #9ca3af; --grid: #2a2f36;
+      --ctl: #60a5fa; --atl: #f87171; --tsb-pos: #4ade8033; --tsb-neg: #f8717133;
+      --tile: #1c2127;
+  }
+  :root[data-theme="light"] {
+    --bg: #ffffff; --fg: #1a1d21; --muted: #6b7280; --grid: #e5e7eb;
+    --ctl: #2563eb; --atl: #dc2626; --tsb-pos: #16a34a33; --tsb-neg: #dc262633;
+    --tile: #f3f4f6;
+  }
   html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg);
                font: 13px/1.4 -apple-system, system-ui, sans-serif; }
   .wrap { padding: 12px 14px; }
@@ -170,10 +181,66 @@ function render(p) {
   svg.addEventListener("mouseleave", () => { tip.style.display = "none"; });
 }
 
+const APP_NAME = "Fitness chart (PMC)";
+// ---- MCP Apps view protocol (inline implementation of the ext-apps wire
+// protocol - JSON-RPC 2.0 over postMessage; CSP forbids loading the SDK) ----
+let _rpcId = 0;
+const _pending = {};
+function _request(method, params) {
+  return new Promise((resolve) => {
+    const id = ++_rpcId;
+    _pending[id] = resolve;
+    window.parent.postMessage({ jsonrpc: "2.0", id: id, method: method, params: params }, "*");
+  });
+}
+function _notify(method, params) {
+  window.parent.postMessage({ jsonrpc: "2.0", method: method, params: params }, "*");
+}
+function _applyHostContext(ctx) {
+  if (ctx && (ctx.theme === "dark" || ctx.theme === "light")) {
+    document.documentElement.setAttribute("data-theme", ctx.theme);
+  }
+}
+function _reportSize() {
+  _notify("ui/notifications/size-changed", {
+    width: document.documentElement.scrollWidth,
+    height: document.documentElement.scrollHeight,
+  });
+}
+function _handleToolResult(result) { // params: standard CallToolResult
+  const payload = extractPayload({ result: result });
+  if (payload) { render(payload); requestAnimationFrame(_reportSize); }
+}
 window.addEventListener("message", (event) => {
-  const payload = extractPayload(event.data);
-  if (payload) render(payload);
+  const d = event.data;
+  if (!d || d.jsonrpc !== "2.0") {
+    const payload = extractPayload(d); // legacy raw-postMessage hosts
+    if (payload) { render(payload); requestAnimationFrame(_reportSize); }
+    return;
+  }
+  if (d.id != null && d.method == null) { // response to one of our requests
+    const resolve = _pending[d.id];
+    if (resolve) { delete _pending[d.id]; resolve(d.result); }
+    return;
+  }
+  if (d.method === "ui/notifications/tool-result") { _handleToolResult(d.params || {}); return; }
+  if (d.method === "ui/notifications/host-context-changed") { _applyHostContext(d.params || {}); return; }
+  if (d.method === "ui/resource-teardown" && d.id != null) {
+    window.parent.postMessage({ jsonrpc: "2.0", id: d.id, result: {} }, "*");
+  }
 });
+(async function _connect() {
+  const init = await _request("ui/initialize", {
+    protocolVersion: "2025-06-18",
+    appInfo: { name: APP_NAME, version: "1" },
+    appCapabilities: { availableDisplayModes: ["inline"] },
+  });
+  _applyHostContext(init && init.hostContext);
+  _notify("ui/notifications/initialized");
+})();
+if (window.ResizeObserver) {
+  new ResizeObserver(function () { _reportSize(); }).observe(document.body);
+}
 </script>
 </body>
 </html>

--- a/src/tp_mcp/apps/weekly_summary.html
+++ b/src/tp_mcp/apps/weekly_summary.html
@@ -14,6 +14,15 @@
       --done: #60a5fa; --planned: #1e3a5f; --tile: #1c2127;
     }
   }
+  /* Host-driven theme (MCP Apps hostContext) overrides the media query */
+  :root[data-theme="dark"] {
+      --bg: #111418; --fg: #e5e7eb; --muted: #9ca3af; --grid: #2a2f36;
+      --done: #60a5fa; --planned: #1e3a5f; --tile: #1c2127;
+  }
+  :root[data-theme="light"] {
+    --bg: #ffffff; --fg: #1a1d21; --muted: #6b7280; --grid: #e5e7eb;
+    --done: #2563eb; --planned: #93c5fd; --tile: #f3f4f6;
+  }
   html, body { margin: 0; background: var(--bg); color: var(--fg);
                font: 13px/1.4 -apple-system, system-ui, sans-serif; }
   .wrap { padding: 12px 14px; }
@@ -154,10 +163,66 @@ function render(p) {
   });
 }
 
+const APP_NAME = "Weekly summary card";
+// ---- MCP Apps view protocol (inline implementation of the ext-apps wire
+// protocol - JSON-RPC 2.0 over postMessage; CSP forbids loading the SDK) ----
+let _rpcId = 0;
+const _pending = {};
+function _request(method, params) {
+  return new Promise((resolve) => {
+    const id = ++_rpcId;
+    _pending[id] = resolve;
+    window.parent.postMessage({ jsonrpc: "2.0", id: id, method: method, params: params }, "*");
+  });
+}
+function _notify(method, params) {
+  window.parent.postMessage({ jsonrpc: "2.0", method: method, params: params }, "*");
+}
+function _applyHostContext(ctx) {
+  if (ctx && (ctx.theme === "dark" || ctx.theme === "light")) {
+    document.documentElement.setAttribute("data-theme", ctx.theme);
+  }
+}
+function _reportSize() {
+  _notify("ui/notifications/size-changed", {
+    width: document.documentElement.scrollWidth,
+    height: document.documentElement.scrollHeight,
+  });
+}
+function _handleToolResult(result) { // params: standard CallToolResult
+  const payload = extractPayload({ result: result });
+  if (payload) { render(payload); requestAnimationFrame(_reportSize); }
+}
 window.addEventListener("message", (event) => {
-  const payload = extractPayload(event.data);
-  if (payload) render(payload);
+  const d = event.data;
+  if (!d || d.jsonrpc !== "2.0") {
+    const payload = extractPayload(d); // legacy raw-postMessage hosts
+    if (payload) { render(payload); requestAnimationFrame(_reportSize); }
+    return;
+  }
+  if (d.id != null && d.method == null) { // response to one of our requests
+    const resolve = _pending[d.id];
+    if (resolve) { delete _pending[d.id]; resolve(d.result); }
+    return;
+  }
+  if (d.method === "ui/notifications/tool-result") { _handleToolResult(d.params || {}); return; }
+  if (d.method === "ui/notifications/host-context-changed") { _applyHostContext(d.params || {}); return; }
+  if (d.method === "ui/resource-teardown" && d.id != null) {
+    window.parent.postMessage({ jsonrpc: "2.0", id: d.id, result: {} }, "*");
+  }
 });
+(async function _connect() {
+  const init = await _request("ui/initialize", {
+    protocolVersion: "2025-06-18",
+    appInfo: { name: APP_NAME, version: "1" },
+    appCapabilities: { availableDisplayModes: ["inline"] },
+  });
+  _applyHostContext(init && init.hostContext);
+  _notify("ui/notifications/initialized");
+})();
+if (window.ResizeObserver) {
+  new ResizeObserver(function () { _reportSize(); }).observe(document.body);
+}
 </script>
 </body>
 </html>

--- a/src/tp_mcp/apps/workout_structure.html
+++ b/src/tp_mcp/apps/workout_structure.html
@@ -14,6 +14,15 @@
       --warm: #1e3a5f; --active: #60a5fa; --hard: #f87171; --rest: #374151; --cool: #14532d;
     }
   }
+  /* Host-driven theme (MCP Apps hostContext) overrides the media query */
+  :root[data-theme="dark"] {
+      --bg: #111418; --fg: #e5e7eb; --muted: #9ca3af; --grid: #2a2f36; --tile: #1c2127;
+      --warm: #1e3a5f; --active: #60a5fa; --hard: #f87171; --rest: #374151; --cool: #14532d;
+  }
+  :root[data-theme="light"] {
+    --bg: #ffffff; --fg: #1a1d21; --muted: #6b7280; --grid: #e5e7eb; --tile: #f3f4f6;
+    --warm: #93c5fd; --active: #2563eb; --hard: #dc2626; --rest: #d1d5db; --cool: #86efac;
+  }
   html, body { margin: 0; background: var(--bg); color: var(--fg);
                font: 13px/1.4 -apple-system, system-ui, sans-serif; }
   .wrap { padding: 12px 14px; }
@@ -176,10 +185,66 @@ function render(p) {
   $("desc").textContent = typeof p.description === "string" ? p.description : "";
 }
 
+const APP_NAME = "Workout structure viewer";
+// ---- MCP Apps view protocol (inline implementation of the ext-apps wire
+// protocol - JSON-RPC 2.0 over postMessage; CSP forbids loading the SDK) ----
+let _rpcId = 0;
+const _pending = {};
+function _request(method, params) {
+  return new Promise((resolve) => {
+    const id = ++_rpcId;
+    _pending[id] = resolve;
+    window.parent.postMessage({ jsonrpc: "2.0", id: id, method: method, params: params }, "*");
+  });
+}
+function _notify(method, params) {
+  window.parent.postMessage({ jsonrpc: "2.0", method: method, params: params }, "*");
+}
+function _applyHostContext(ctx) {
+  if (ctx && (ctx.theme === "dark" || ctx.theme === "light")) {
+    document.documentElement.setAttribute("data-theme", ctx.theme);
+  }
+}
+function _reportSize() {
+  _notify("ui/notifications/size-changed", {
+    width: document.documentElement.scrollWidth,
+    height: document.documentElement.scrollHeight,
+  });
+}
+function _handleToolResult(result) { // params: standard CallToolResult
+  const payload = extractPayload({ result: result });
+  if (payload) { render(payload); requestAnimationFrame(_reportSize); }
+}
 window.addEventListener("message", (event) => {
-  const payload = extractPayload(event.data);
-  if (payload) render(payload);
+  const d = event.data;
+  if (!d || d.jsonrpc !== "2.0") {
+    const payload = extractPayload(d); // legacy raw-postMessage hosts
+    if (payload) { render(payload); requestAnimationFrame(_reportSize); }
+    return;
+  }
+  if (d.id != null && d.method == null) { // response to one of our requests
+    const resolve = _pending[d.id];
+    if (resolve) { delete _pending[d.id]; resolve(d.result); }
+    return;
+  }
+  if (d.method === "ui/notifications/tool-result") { _handleToolResult(d.params || {}); return; }
+  if (d.method === "ui/notifications/host-context-changed") { _applyHostContext(d.params || {}); return; }
+  if (d.method === "ui/resource-teardown" && d.id != null) {
+    window.parent.postMessage({ jsonrpc: "2.0", id: d.id, result: {} }, "*");
+  }
 });
+(async function _connect() {
+  const init = await _request("ui/initialize", {
+    protocolVersion: "2025-06-18",
+    appInfo: { name: APP_NAME, version: "1" },
+    appCapabilities: { availableDisplayModes: ["inline"] },
+  });
+  _applyHostContext(init && init.hostContext);
+  _notify("ui/notifications/initialized");
+})();
+if (window.ResizeObserver) {
+  new ResizeObserver(function () { _reportSize(); }).observe(document.body);
+}
 </script>
 </body>
 </html>

--- a/uv.lock
+++ b/uv.lock
@@ -1266,7 +1266,7 @@ wheels = [
 
 [[package]]
 name = "tp-mcp"
-version = "3.1.1"
+version = "3.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Found via live Claude Desktop testing: **Desktop IS rendering the app iframes** (`resources/read` fired once per app tool call - server logs confirm) but they stayed blank.

## Root cause

Hosts speak the [ext-apps wire protocol](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx): JSON-RPC 2.0 over postMessage, with a `ui/initialize` → `ui/notifications/initialized` handshake - and *the host MUST NOT send anything to the view before receiving `initialized`*. Our pages passively listened for raw postMessage and never connected, so `ui/notifications/tool-result` never came.

## Fix

Inline implementation of the view protocol in each app (CSP blocks loading the official SDK from a CDN):
- `ui/initialize` handshake with `appCapabilities.availableDisplayModes`
- `ui/notifications/tool-result` (standard `CallToolResult` params) → render
- **Host theme** from `hostContext.theme` / `host-context-changed` applied via `[data-theme]` overrides (explicit host signal beats `prefers-color-scheme` inside a sandboxed iframe)
- **`size-changed` reporting** via ResizeObserver - also fixes the oversized blank iframe seen in testing
- `ui/resource-teardown` acknowledged
- Raw-postMessage path retained as fallback

## Verification

Spec-faithful host simulator in headless Chromium (answers initialize, waits for initialized, pushes tool-input then tool-result, per spec): all three apps complete the handshake, render, apply the dark host theme, and report size; raw fallback still works. 553 tests green.