### PR TITLE
feat(strength): add tp_update_strength_workout - edit in place without losing Garmin data (v3.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ honoured exactly. They update a **threshold** (FTP / LTHR / threshold pace).
 | `tp_get_strength_summary` | Get a strength workout's compliance summary (blocks/prescriptions/sets completed) |
 | `tp_get_strength_workouts` | List strength/gym workouts in a date range (they don't appear in `tp_get_workouts`) |
 | `tp_get_strength_workout` | Get a strength workout's full detail: blocks, exercises, sets, prescribed vs executed weights |
+| `tp_update_strength_workout` | Update a strength workout in place (replace/append blocks, retitle, mark complete) - preserves Garmin TSS and FIT files, so use this rather than delete-and-recreate on device-synced workouts |
 | `tp_delete_strength_workout` | Delete a strength workout by ID |
 
 ### Athlete Groups (coach accounts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tp-mcp"
-version = "3.1.3"
+version = "3.2.0"
 description = "TrainingPeaks MCP Server - AI assistant integration for TrainingPeaks"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -109,6 +109,7 @@ from tp_mcp.tools import (
     tp_update_note,
     tp_update_nutrition,
     tp_update_speed_zones,
+    tp_update_strength_workout,
     tp_update_workout,
     tp_upload_workout_file,
     tp_validate_structure,
@@ -1325,6 +1326,51 @@ TOOLS = [
         },
     ),
     Tool(
+        name="tp_update_strength_workout",
+        description=(
+            "Update an existing strength workout in place: replace or append blocks, "
+            "retitle, or mark it complete. Preserves everything else, including "
+            "Garmin-derived TSS and the attached FIT file — so this is the correct "
+            "way to fill in a device-synced workout that arrived with no structure. "
+            "Never delete-and-recreate for that: exercise detail is rebuildable, "
+            "HR-derived training load is not."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "workout_id": {"type": "string", "description": "Strength workout ID."},
+                "blocks": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "Blocks in the same shape as tp_create_strength_workout. "
+                        "Omit to leave the existing structure untouched."
+                    ),
+                },
+                "title": {"type": "string", "description": "Optional new title."},
+                "instructions": {"type": "string", "description": "Optional new instructions."},
+                "mode": {
+                    "type": "string",
+                    "enum": ["replace", "append"],
+                    "description": "replace (default) swaps the blocks; append adds after them.",
+                },
+                "mark_complete": {
+                    "type": "boolean",
+                    "description": (
+                        "Mark every set complete and copy prescribed values into executed "
+                        "ones, so the workout reports real volume. Use when logging a "
+                        "session already performed."
+                    ),
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "Report what would change without writing.",
+                },
+            },
+            "required": ["workout_id"],
+        },
+    ),
+    Tool(
         name="tp_delete_strength_workout",
         description="Delete a strength workout by ID.",
         input_schema={
@@ -1729,6 +1775,15 @@ async def _h_get_strength_workouts(args):
 @_handler("tp_get_strength_workout")
 async def _h_get_strength_workout(args):
     return await tp_get_strength_workout(workout_id=args["workout_id"])
+
+@_handler("tp_update_strength_workout")
+async def _h_update_strength(args):
+    return await tp_update_strength_workout(
+        workout_id=args["workout_id"], blocks=args.get("blocks"),
+        title=args.get("title"), instructions=args.get("instructions"),
+        mode=args.get("mode", "replace"),
+        mark_complete=bool(args.get("mark_complete", False)),
+        dry_run=bool(args.get("dry_run", False)))
 
 @_handler("tp_delete_strength_workout")
 async def _h_delete_strength(args):

--- a/src/tp_mcp/tools/__init__.py
+++ b/src/tp_mcp/tools/__init__.py
@@ -73,6 +73,7 @@ from tp_mcp.tools.strength import (
     tp_get_strength_workout,
     tp_get_strength_workouts,
     tp_search_exercises,
+    tp_update_strength_workout,
 )
 from tp_mcp.tools.structure import tp_validate_structure
 from tp_mcp.tools.weekly_summary import tp_get_weekly_summary
@@ -184,4 +185,5 @@ __all__ = [
     "tp_get_strength_workout",
     "tp_get_strength_workouts",
     "tp_delete_strength_workout",
+    "tp_update_strength_workout",
 ]

--- a/src/tp_mcp/tools/strength.py
+++ b/src/tp_mcp/tools/strength.py
@@ -10,6 +10,10 @@ exists server-side), so `tp_search_exercises` runs fully offline.
 
 Verified against the live API:
   • create  → POST   /rx/activity/v1/workouts/save        (returns numeric id)
+  • update  → POST   /rx/activity/v1/workouts/save        (SAME endpoint — it is an
+              UPSERT keyed on the numeric `id`; posting a document that carries an
+              existing id edits in place and returns that same id, with no duplicate
+              appearing on the calendar)
   • list    → GET    /rx/activity/v1/workouts/calendar/{calendarId}/{start}/{end}
               (bare JSON array of workout summaries — the ONLY discovery route;
               strength workouts never appear in the /fitness/v6 endpoints)
@@ -20,6 +24,26 @@ Verified against the live API:
     distinct from the exercise's library parameters and each set's values;
   • parameter metadata may be minimal (`{parameter, inputFormat}`);
   • Superset/Circuit blocks require an equal number of sets across exercises.
+
+Update semantics (probed 2026-08-02, live API):
+  • PARTIAL PAYLOADS ARE REJECTED. Posting `{id, blocks}` alone returns 400 with
+    `calendarId`, `workoutType` and `prescribedDate` all "required". An update
+    must therefore GET the full document, mutate it, and post the whole thing
+    back — which is also what makes updates non-destructive.
+  • A full-document round-trip preserves EVERYTHING the server owns. Verified on
+    a Garmin-synced workout: `completedTss`, `completedTssSource`,
+    `completedIntensityFactor`, `completionSource`, `startDateTime`,
+    `completedDateTime`, `executedDurationInSeconds` and the attached FIT `files`
+    all survived untouched; `lastUpdatedAt` was the only field the server changed.
+    This is why editing a device-synced workout must never be done as
+    delete-then-recreate: the exercise detail is reconstructible, the HR-derived
+    training load is not.
+  • Completion is flagged with `isComplete` (on blocks, prescriptions AND sets) —
+    NOT `completed`, which the server accepts with a 200 and silently ignores,
+    leaving `complianceState: "NoCompletion"`. Set `isComplete` at all three
+    levels plus each parameter's `executedValue`, and the server recomputes
+    compliance correctly (`Compliant` / 100%).
+  • Sets carry an undocumented `setOrigin` field; it round-trips harmlessly.
 
 This tool is intentionally unit-agnostic: it passes through whatever weight
 parameter the caller supplies (`WeightKg`, `WeightLb`, `WeightPercentage`, …).
@@ -383,6 +407,218 @@ async def tp_create_strength_workout(
             "total_blocks": snap.get("totalBlocks"),
             "total_sets": snap.get("totalSets"),
         }
+
+
+def _recount(blocks: list[dict[str, Any]]) -> dict[str, Any]:
+    """Recompute the snapshot counters from the blocks themselves.
+
+    Counts actual `isComplete` flags rather than assuming, so the snapshot stays
+    honest when a partially-completed workout is edited or appended to.
+    """
+    total_sets = completed_sets = 0
+    total_pres = completed_pres = 0
+    completed_blocks = 0
+    for b in blocks:
+        block_pres = b.get("prescriptions") or []
+        total_pres += len(block_pres)
+        block_sets = 0
+        block_done = 0
+        for p in block_pres:
+            sets = p.get("sets") or []
+            done = sum(1 for s in sets if s.get("isComplete"))
+            total_sets += len(sets)
+            completed_sets += done
+            block_sets += len(sets)
+            block_done += done
+            if sets and done == len(sets):
+                completed_pres += 1
+        if block_sets and block_done == block_sets:
+            completed_blocks += 1
+    return {
+        "totalBlocks": len(blocks),
+        "completedBlocks": completed_blocks,
+        "totalSets": total_sets,
+        "completedSets": completed_sets,
+        "totalPrescriptions": total_pres,
+        "completedPrescriptions": completed_pres,
+    }
+
+
+def _mark_complete(blocks: list[dict[str, Any]]) -> None:
+    """Mark every block/prescription/set complete, mirroring prescribed→executed.
+
+    In-place. Used when logging a session that has already been performed, so
+    TrainingPeaks shows executed sets/reps/volume rather than an unstarted plan.
+    An existing `executedValue` is never overwritten — only blanks are filled.
+    """
+    for b in blocks:
+        b["isComplete"] = True
+        for p in b.get("prescriptions") or []:
+            for s in p.get("sets") or []:
+                s["isComplete"] = True
+                for pv in s.get("parameterValues") or []:
+                    if pv.get("executedValue") is None:
+                        pv["executedValue"] = pv.get("prescribedValue")
+
+
+async def tp_update_strength_workout(
+    workout_id: str,
+    blocks: list[dict[str, Any]] | None = None,
+    title: str | None = None,
+    instructions: str | None = None,
+    mode: str = "replace",
+    mark_complete: bool = False,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Update an existing strength workout in place (blocks, title, instructions).
+
+    Fetches the full workout, applies the requested changes, and posts the whole
+    document back to the upsert endpoint. Everything not explicitly changed is
+    preserved — including Garmin-derived training load and the attached FIT file
+    — which makes this the correct way to fill in a device-synced workout that
+    arrived with an empty structure. Never delete-and-recreate for that: the
+    exercise detail can be rebuilt, the HR-derived TSS cannot.
+
+    Args:
+        workout_id: The strength workout ID (from tp_get_strength_workouts).
+        blocks: Optional replacement/additional blocks, same shape as
+            tp_create_strength_workout. Omit to leave the structure alone (e.g.
+            when only retitling, or only marking an existing plan complete).
+        title: Optional new title.
+        instructions: Optional new session instructions.
+        mode: "replace" (default) swaps the block list for `blocks`; "append"
+            adds them after the existing blocks.
+        mark_complete: Mark every set complete and copy prescribed values into
+            executed ones, so the workout reports real volume and compliance.
+            Use when logging a session already performed. Existing executed
+            values are left untouched.
+        dry_run: Validate and build the update, report what would change, but
+            send nothing.
+
+    Returns:
+        Dict with the workout_id, before/after block and set counts, the fields
+        changed, and (for dry runs) `dry_run: True` with nothing written.
+    """
+    wid = str(workout_id).strip()
+    if not wid:
+        return _err("VALIDATION_ERROR", "workout_id is required.")
+    if mode not in ("replace", "append"):
+        return _err("VALIDATION_ERROR", f"mode must be 'replace' or 'append', got {mode!r}.")
+    if blocks is not None:
+        if not isinstance(blocks, list):
+            return _err("VALIDATION_ERROR", "blocks must be a list.")
+        invalid = _validate_blocks(blocks)
+        if invalid:
+            return _err("VALIDATION_ERROR", invalid)
+    if blocks is None and title is None and instructions is None and not mark_complete:
+        return _err(
+            "VALIDATION_ERROR",
+            "Nothing to update: provide blocks, title, instructions or mark_complete.",
+        )
+
+    async with TPClient() as client:
+        _, access, err = await _access(client)
+        if err:
+            return err
+        try:
+            async with httpx.AsyncClient(timeout=STRENGTH_TIMEOUT) as h:
+                r = await h.get(
+                    f"{STRENGTH_API_BASE}/rx/activity/v1/workouts/{wid}",
+                    headers=_headers(access),
+                )
+                if r.status_code != 200:
+                    return _map_status(r.status_code, r.text)
+                doc = r.json().get("data") or {}
+                if not doc:
+                    return _err("NOT_FOUND", "Strength workout not found.")
+
+                before = dict(doc.get("snapshot") or {})
+                changed: list[str] = []
+
+                if blocks is not None:
+                    catalogue = _catalogue()
+                    new_blocks = [
+                        {
+                            "id": _u(),
+                            "blockType": b.get("type", "SingleExercise"),
+                            "title": b.get("title"),
+                            "coachNotes": b.get("notes"),
+                            "prescriptions": [
+                                _build_prescription(ex, catalogue) for ex in b["exercises"]
+                            ],
+                        }
+                        for b in blocks
+                    ]
+                    if mode == "append":
+                        doc["blocks"] = (doc.get("blocks") or []) + new_blocks
+                    else:
+                        doc["blocks"] = new_blocks
+                    changed.append(f"blocks ({mode})")
+
+                if title is not None:
+                    doc["title"] = str(title).strip()
+                    changed.append("title")
+                if instructions is not None:
+                    doc["instructions"] = instructions
+                    changed.append("instructions")
+                if mark_complete:
+                    _mark_complete(doc.get("blocks") or [])
+                    changed.append("mark_complete")
+
+                doc["snapshot"] = _recount(doc.get("blocks") or [])
+
+                if dry_run:
+                    return {
+                        "workout_id": wid,
+                        "dry_run": True,
+                        "changed": changed,
+                        "sets_before": before.get("totalSets"),
+                        "sets_after": doc["snapshot"]["totalSets"],
+                        "blocks_before": before.get("totalBlocks"),
+                        "blocks_after": doc["snapshot"]["totalBlocks"],
+                    }
+
+                r = await h.post(
+                    f"{STRENGTH_API_BASE}/rx/activity/v1/workouts/save",
+                    headers=_headers(access),
+                    json=doc,
+                )
+        except httpx.TimeoutException:
+            return _err("NETWORK_ERROR", "Strength update timed out.")
+        except httpx.RequestError:
+            logger.exception("Network error updating strength workout")
+            return _err("NETWORK_ERROR", "A network error occurred.")
+
+        if r.status_code != 200:
+            try:
+                errs = r.json().get("errors")
+                if errs:
+                    return _err("API_ERROR", f"Strength API rejected the update: {errs}")
+            except Exception:
+                pass
+            return _map_status(r.status_code, r.text)
+
+        data = r.json().get("data") or {}
+        snap = data.get("snapshot") or doc["snapshot"]
+        returned = str(data.get("id")) if data.get("id") is not None else wid
+        result = {
+            "workout_id": returned,
+            "title": doc.get("title"),
+            "changed": changed,
+            "blocks_before": before.get("totalBlocks"),
+            "blocks_after": snap.get("totalBlocks"),
+            "sets_before": before.get("totalSets"),
+            "sets_after": snap.get("totalSets"),
+            "completed_sets": snap.get("completedSets"),
+        }
+        # The upsert must edit in place; a different id means a duplicate was
+        # created and the caller needs to know immediately.
+        if returned != wid:
+            result["warning"] = (
+                f"Server returned id {returned}, expected {wid} — a duplicate may "
+                f"have been created. Check the calendar for that date."
+            )
+        return result
 
 
 async def tp_get_strength_summary(workout_id: str) -> dict[str, Any]:

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -117,6 +117,7 @@ class TestListTools:
             "tp_get_strength_summary",
             "tp_get_strength_workouts",
             "tp_get_strength_workout",
+            "tp_update_strength_workout",
             "tp_delete_strength_workout",
             "tp_list_training_plans",
             "tp_get_training_plan",

--- a/tests/test_tools/test_strength.py
+++ b/tests/test_tools/test_strength.py
@@ -18,6 +18,7 @@ from tp_mcp.tools.strength import (
     tp_get_strength_workout,
     tp_get_strength_workouts,
     tp_search_exercises,
+    tp_update_strength_workout,
 )
 
 TEST_ATHLETE_ID = 123456
@@ -418,3 +419,205 @@ class TestListAndDetail:
                 mh.return_value.__aenter__.return_value = http
                 r = await tp_get_strength_workout(workout_id="999")
         assert r["error_code"] == "NOT_FOUND"
+
+
+# ── Update (in-place upsert) ─────────────────────────────────────────────────
+
+
+def _garmin_doc():
+    """A device-synced workout as the live API returns it: telemetry, no blocks.
+
+    Mirrors the real shape observed on a Garmin-synced session — the case the
+    update tool exists for.
+    """
+    return {
+        "id": "24373159",
+        "calendarId": TEST_ATHLETE_ID,
+        "workoutType": "StructuredStrength",
+        "title": "Strength",
+        "prescribedDate": "2026-08-02",
+        "instructions": None,
+        "blocks": [],
+        "snapshot": {"totalBlocks": 0, "completedBlocks": 0, "totalSets": 0,
+                     "completedSets": 0, "totalPrescriptions": 0,
+                     "completedPrescriptions": 0},
+        "completedTss": 27.0,
+        "completedTssSource": "HeartRateTss",
+        "completedIntensityFactor": 0.53,
+        "completionSource": "DeviceFile",
+        "executedDurationInSeconds": 3144,
+        "startDateTime": "2026-08-02T18:48:10",
+        "completedDateTime": "2026-08-02T19:40:34",
+        "files": [{"fileName": "garmin.FIT.gz", "isGarmin": True}],
+    }
+
+
+def _mock_get_then_post(doc, post_status=200, post_json=None):
+    """Mock the GET detail → POST save sequence, capturing the posted body."""
+    get_resp = MagicMock()
+    get_resp.status_code = 200
+    get_resp.json.return_value = {"data": doc}
+    get_resp.text = "{}"
+
+    post_resp = MagicMock()
+    post_resp.status_code = post_status
+    post_resp.json.return_value = post_json if post_json is not None else {
+        "data": {"id": doc["id"], "snapshot": {"totalBlocks": 1, "totalSets": 2,
+                                               "completedSets": 0}}}
+    post_resp.text = "{}"
+
+    http = AsyncMock()
+    http.get.return_value = get_resp
+    http.post.return_value = post_resp
+    return http
+
+
+def _posted(http):
+    return http.post.call_args.kwargs["json"]
+
+
+_BLOCKS = [{"type": "SingleExercise", "title": "Chest",
+            "exercises": [{"id": "1", "sets": [{"Reps": "10", "WeightKg": "40"},
+                                               {"Reps": "10", "WeightKg": "40"}]}]}]
+
+
+class TestUpdateStrength:
+    async def _run(self, http, **kwargs):
+        with patch("tp_mcp.tools.strength.TPClient") as mtp:
+            mtp.return_value.__aenter__.return_value = _mock_tp_client()
+            with patch("tp_mcp.tools.strength.httpx.AsyncClient") as mh:
+                mh.return_value.__aenter__.return_value = http
+                return await tp_update_strength_workout(**kwargs)
+
+    @pytest.mark.asyncio
+    async def test_replace_blocks_keeps_id(self):
+        http = _mock_get_then_post(_garmin_doc())
+        r = await self._run(http, workout_id="24373159", blocks=_BLOCKS)
+        assert r["workout_id"] == "24373159"
+        assert "warning" not in r
+        body = _posted(http)
+        assert body["id"] == "24373159"
+        assert len(body["blocks"]) == 1
+        assert body["snapshot"]["totalSets"] == 2
+
+    @pytest.mark.asyncio
+    async def test_preserves_garmin_telemetry(self):
+        """The whole point: an update must not strip device-derived data."""
+        http = _mock_get_then_post(_garmin_doc())
+        await self._run(http, workout_id="24373159", blocks=_BLOCKS)
+        body = _posted(http)
+        assert body["completedTss"] == 27.0
+        assert body["completedTssSource"] == "HeartRateTss"
+        assert body["completedIntensityFactor"] == 0.53
+        assert body["completionSource"] == "DeviceFile"
+        assert body["executedDurationInSeconds"] == 3144
+        assert body["files"] == [{"fileName": "garmin.FIT.gz", "isGarmin": True}]
+        # Required-by-server fields the 400 probe identified must be present.
+        assert body["calendarId"] == TEST_ATHLETE_ID
+        assert body["workoutType"] == "StructuredStrength"
+        assert body["prescribedDate"] == "2026-08-02"
+
+    @pytest.mark.asyncio
+    async def test_append_adds_to_existing(self):
+        doc = _garmin_doc()
+        doc["blocks"] = [{"id": "existing", "blockType": "WarmUp", "prescriptions": []}]
+        http = _mock_get_then_post(doc)
+        await self._run(http, workout_id="24373159", blocks=_BLOCKS, mode="append")
+        body = _posted(http)
+        assert len(body["blocks"]) == 2
+        assert body["blocks"][0]["id"] == "existing"
+
+    @pytest.mark.asyncio
+    async def test_mark_complete_mirrors_executed_values(self):
+        http = _mock_get_then_post(_garmin_doc())
+        await self._run(http, workout_id="24373159", blocks=_BLOCKS, mark_complete=True)
+        body = _posted(http)
+        assert body["snapshot"]["completedSets"] == 2
+        assert body["snapshot"]["completedBlocks"] == 1
+        for blk in body["blocks"]:
+            assert blk["isComplete"] is True
+            for p in blk["prescriptions"]:
+                for s in p["sets"]:
+                    assert s["isComplete"] is True
+                    for pv in s["parameterValues"]:
+                        assert pv["executedValue"] == pv["prescribedValue"]
+
+    @pytest.mark.asyncio
+    async def test_mark_complete_does_not_overwrite_existing_executed(self):
+        doc = _garmin_doc()
+        doc["blocks"] = [{
+            "id": "b", "blockType": "SingleExercise",
+            "prescriptions": [{"id": "p", "sets": [{
+                "id": "s",
+                "parameterValues": [{"parameter": "Reps", "prescribedValue": "10",
+                                     "executedValue": "7"}],
+            }]}],
+        }]
+        http = _mock_get_then_post(doc)
+        await self._run(http, workout_id="24373159", mark_complete=True)
+        pv = _posted(http)["blocks"][0]["prescriptions"][0]["sets"][0]["parameterValues"][0]
+        assert pv["executedValue"] == "7"
+
+    @pytest.mark.asyncio
+    async def test_dry_run_writes_nothing(self):
+        http = _mock_get_then_post(_garmin_doc())
+        r = await self._run(http, workout_id="24373159", blocks=_BLOCKS, dry_run=True)
+        assert r["dry_run"] is True
+        assert r["sets_before"] == 0
+        assert r["sets_after"] == 2
+        http.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_id_warns(self):
+        http = _mock_get_then_post(
+            _garmin_doc(), post_json={"data": {"id": "99999", "snapshot": {}}})
+        r = await self._run(http, workout_id="24373159", blocks=_BLOCKS)
+        assert "warning" in r
+        assert "99999" in r["warning"]
+
+    @pytest.mark.asyncio
+    async def test_title_and_instructions_only(self):
+        http = _mock_get_then_post(_garmin_doc())
+        r = await self._run(http, workout_id="24373159", title="Push Day",
+                            instructions="easy")
+        body = _posted(http)
+        assert body["title"] == "Push Day"
+        assert body["instructions"] == "easy"
+        assert body["blocks"] == []          # structure untouched
+        assert set(r["changed"]) == {"title", "instructions"}
+
+    @pytest.mark.asyncio
+    async def test_nothing_to_update_rejected(self):
+        r = await tp_update_strength_workout(workout_id="1")
+        assert r["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_bad_mode_rejected(self):
+        r = await tp_update_strength_workout(workout_id="1", blocks=_BLOCKS, mode="merge")
+        assert r["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_invalid_blocks_rejected_before_network(self):
+        bad = [{"type": "SingleExercise", "exercises": [{"id": "0", "sets": [{"Reps": "8"}]}]}]
+        r = await tp_update_strength_workout(workout_id="1", blocks=bad)
+        assert r["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_missing_workout_is_not_found(self):
+        resp = MagicMock()
+        resp.status_code = 404
+        resp.json.return_value = {}
+        resp.text = "{}"
+        http = AsyncMock()
+        http.get.return_value = resp
+        r = await self._run(http, workout_id="404404", blocks=_BLOCKS)
+        assert r["error_code"] == "NOT_FOUND"
+        http.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_server_rejection_surfaces_field_errors(self):
+        http = _mock_get_then_post(_garmin_doc(), post_status=400,
+                                   post_json={"errors": {"blocks[0]": ["bad"]}})
+        r = await self._run(http, workout_id="24373159", blocks=_BLOCKS)
+        assert r["error_code"] == "API_ERROR"
+        assert "bad" in r["message"]


### PR DESCRIPTION
## Problem

Strength workouts could be created and deleted but never **edited**.

That matters most for device-synced sessions. Garmin sends TrainingPeaks the duration and HR for a gym session but no exercise detail, so the workout lands with `blocks: []` and reports 0 sets, 0 reps, 0 volume. The only previous fix was delete-and-recreate — which throws away the HR-derived training load. That's exactly the wrong trade: the sets and reps are reconstructible from any logging app, the `completedTss` is not.

## Finding

The existing create endpoint, `POST /rx/activity/v1/workouts/save`, is already an **upsert** keyed on the numeric `id`. Posting a document that carries an existing id edits in place, returns that same id, and adds nothing to the calendar. No new endpoint required — we were just always minting a fresh UUID.

Probed against the live API (all throwaway workouts on a far-future date, deleted afterwards):

| Probe | Result |
|---|---|
| Post full doc with existing numeric id | 200, same id returned, blocks 1→2, calendar count unchanged |
| Post `{id, blocks}` only | **400** — `calendarId`, `workoutType`, `prescribedDate` all required |
| Field preservation on round-trip | every untouched field survived |
| `completed: true` on sets | 200 but **silently ignored**, `complianceState: NoCompletion` |
| `isComplete: true` + `executedValue` | `Compliant`, 100%, `completedSets` correct |
| No-op round-trip on a real Garmin workout | `completedTss` 27.0, FIT file, intensity factor, completion source **all preserved**; `lastUpdatedAt` the only change |

The `completed` vs `isComplete` distinction is the nastiest of these — the server returns 200 either way, so the wrong field fails silently.

## Change

`tp_update_strength_workout(workout_id, blocks?, title?, instructions?, mode, mark_complete, dry_run)`

- Fetches the full document, mutates, posts it back — so preservation is structural, not something the caller has to remember
- `mode`: `replace` (default) or `append`
- `mark_complete`: sets `isComplete` and mirrors prescribed → executed so real volume is reported. Never overwrites an executed value that already exists
- `dry_run`: reports the before/after set and block counts, writes nothing
- Warns if the server returns a different id, since that would mean a duplicate rather than an edit

Module docstring now records the upsert behaviour, the partial-payload rejection, the `isComplete` trap and the undocumented `setOrigin` field, so the next person doesn't have to re-probe.

## Tests

13 new tests (566 total, all passing), including a regression test asserting that Garmin telemetry and the three server-required fields survive in the posted body. `ruff check src/` and `mypy src/` clean.

## Note

Pre-existing `ruff format` drift on main (41 files) is untouched — CI only runs `ruff check src/`, and reformatting here would bury the diff.