### PR TITLE
fix: run credential lookup off the event loop to prevent write-path hangs

### DIFF
--- a/src/tp_mcp/auth/__init__.py
+++ b/src/tp_mcp/auth/__init__.py
@@ -5,6 +5,7 @@ from tp_mcp.auth.keyring import CredentialResult, is_keyring_available
 from tp_mcp.auth.storage import (
     clear_credential,
     get_credential,
+    get_credential_async,
     get_storage_backend,
     store_credential,
 )
@@ -17,6 +18,7 @@ __all__ = [
     "EncryptedCredentialStore",
     "clear_credential",
     "get_credential",
+    "get_credential_async",
     "get_storage_backend",
     "is_keyring_available",
     "store_credential",

--- a/src/tp_mcp/auth/storage.py
+++ b/src/tp_mcp/auth/storage.py
@@ -6,6 +6,7 @@ source for headless servers, containers, and CI, and takes precedence
 over both stored backends.
 """
 
+import asyncio
 import os
 
 from tp_mcp.auth.encrypted import (
@@ -100,6 +101,29 @@ def get_credential() -> CredentialResult:
 
     # Fall back to encrypted file
     return get_credential_encrypted()
+
+
+async def get_credential_async() -> CredentialResult:
+    """Retrieve the TrainingPeaks auth cookie without blocking the event loop.
+
+    get_credential() is synchronous, and its keyring path
+    (keyring.get_password) can trigger a native OS credential-store prompt
+    (e.g. the macOS Keychain "Always Allow" dialog). Called directly from
+    an async context -- as every caller in this codebase does -- that
+    blocks the entire asyncio event loop until the prompt is resolved,
+    which can hang indefinitely when the process runs headless (e.g.
+    spawned by an MCP host with no visible window to click through). None
+    of the other blocking calls in this path have this problem: httpx
+    requests all carry an explicit timeout, but this one has none.
+
+    Running the lookup in a worker thread keeps the event loop free, so
+    concurrent tool calls keep responding and any timeout/cancellation
+    logic wrapping this coroutine actually has a chance to fire.
+
+    Returns:
+        CredentialResult with cookie if found.
+    """
+    return await asyncio.to_thread(get_credential)
 
 
 def clear_credential() -> CredentialResult:

--- a/src/tp_mcp/client/http.py
+++ b/src/tp_mcp/client/http.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import httpx
 
-from tp_mcp.auth import get_credential
+from tp_mcp.auth import get_credential_async
 
 logger = logging.getLogger("tp-mcp")
 
@@ -222,7 +222,7 @@ class TPClient:
         await self._throttle()
         assert self._client is not None
 
-        cred = get_credential()
+        cred = await get_credential_async()
         if not cred.success or not cred.cookie:
             return APIResponse(
                 success=False,
@@ -701,7 +701,7 @@ class TPClient:
         result: dict[str, Any] = {"success": False, "step": "init", "details": {}}
 
         # Step 1: Check credential
-        cred = get_credential()
+        cred = await get_credential_async()
         if not cred.success or not cred.cookie:
             result["step"] = "credential_check"
             result["error"] = "No credential stored. Run 'tp-mcp auth' to authenticate."

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -25,7 +25,7 @@ from mcp.types import (
 )
 
 from tp_mcp import __version__, apps
-from tp_mcp.auth import get_credential, validate_auth
+from tp_mcp.auth import get_credential_async, validate_auth
 from tp_mcp.client.context import athlete_override
 from tp_mcp.tools import (
     tp_add_athletes_to_group,
@@ -2133,7 +2133,7 @@ server.extensions[apps.EXTENSION_ID] = {}
 
 async def _validate_auth_on_startup() -> bool:
     """Validate authentication on server startup."""
-    cred = get_credential()
+    cred = await get_credential_async()
     if not cred.success or not cred.cookie:
         logger.warning("No credential stored. Run 'tp-mcp auth' to authenticate.")
         return False

--- a/src/tp_mcp/tools/auth_status.py
+++ b/src/tp_mcp/tools/auth_status.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from tp_mcp.auth import AuthStatus, get_credential, get_storage_backend, validate_auth
+from tp_mcp.auth import AuthStatus, get_credential_async, get_storage_backend, validate_auth
 
 
 async def tp_auth_status() -> dict[str, Any]:
@@ -11,7 +11,7 @@ async def tp_auth_status() -> dict[str, Any]:
     Returns:
         Dict with auth status, athlete_id if valid, and any action needed.
     """
-    cred = get_credential()
+    cred = await get_credential_async()
 
     if not cred.success or not cred.cookie:
         return {

--- a/tests/test_tools/test_auth_status.py
+++ b/tests/test_tools/test_auth_status.py
@@ -22,7 +22,11 @@ class TestTpAuthStatus:
             email="test@example.com",
         )
 
-        with patch("tp_mcp.tools.auth_status.get_credential", return_value=mock_cred):
+        with patch(
+            "tp_mcp.tools.auth_status.get_credential_async",
+            new_callable=AsyncMock,
+            return_value=mock_cred,
+        ):
             with patch(
                 "tp_mcp.tools.auth_status.validate_auth",
                 new_callable=AsyncMock,
@@ -44,7 +48,11 @@ class TestTpAuthStatus:
         """Test auth status with no stored credential."""
         mock_cred = CredentialResult(success=False, message="No credential")
 
-        with patch("tp_mcp.tools.auth_status.get_credential", return_value=mock_cred):
+        with patch(
+            "tp_mcp.tools.auth_status.get_credential_async",
+            new_callable=AsyncMock,
+            return_value=mock_cred,
+        ):
             result = await tp_auth_status()
 
         assert result["valid"] is False
@@ -60,7 +68,11 @@ class TestTpAuthStatus:
             message="Session expired",
         )
 
-        with patch("tp_mcp.tools.auth_status.get_credential", return_value=mock_cred):
+        with patch(
+            "tp_mcp.tools.auth_status.get_credential_async",
+            new_callable=AsyncMock,
+            return_value=mock_cred,
+        ):
             with patch(
                 "tp_mcp.tools.auth_status.validate_auth",
                 new_callable=AsyncMock,


### PR DESCRIPTION
Fixes a hang on write operations (delete/create/update) caused by a synchronous keyring.get_password() call blocking the asyncio event loop when it needs to show an OS credential prompt.