### PR TITLE
fix(analyze): refetch charts in windows for full-resolution time-series

### DIFF
--- a/src/tp_mcp/tools/analyze.py
+++ b/src/tp_mcp/tools/analyze.py
@@ -51,6 +51,19 @@ _SUMMARY_PATH = "/workout-analysis/v2/analyze/summary"
 _CHARTS_PATH = "/workout-analysis/v2/analyze/charts"
 _LAPS_PATH = "/workout-analysis/v2/analyze/laps"
 
+# The charts endpoint caps a full-span response at ~1000 points. For longer
+# workouts that response is a shape-preserving visual downsample that is
+# NOT energy-preserving: on a 90-min ride it under-reports work by ~30% and
+# badly skews NP/VI computed from the saved time-series (verified live
+# 2026-08-20: full-span gave 915 pts / 567 kJ vs the workout's true 807 kJ).
+# Windowed requests (start/stopOffsetSeconds spans <= ~1000s) return true
+# 1s-resolution data, so when the full-span response comes back coarse we
+# refetch it in windows and stitch.
+_CHARTS_WINDOW_SECONDS = 900
+_CHARTS_MAX_WINDOWS = 48  # 12 hours; beyond that keep the downsample
+_CHARTS_COARSE_DT = 1.5  # avg sample spacing (s) that flags downsampling
+_CHARTS_MIN_SPAN_FOR_REFETCH = 120
+
 
 def _save_analysis_json(workout_id: int, data: dict[str, Any]) -> str:
     """Save full analysis data (including time-series) to a JSON file.
@@ -130,6 +143,94 @@ async def _post_analysis(
             "error_code": "API_ERROR",
             "message": "Failed to parse analysis response.",
         }
+
+
+def _stitch_windows(windows: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Merge windowed chart rows, deduping boundary samples by time."""
+    merged: list[dict[str, Any]] = []
+    last_time: float | None = None
+    for rows in windows:
+        for row in rows:
+            t = row.get("time")
+            if last_time is not None and t is not None and t <= last_time:
+                continue
+            merged.append(row)
+            if t is not None:
+                last_time = t
+    return merged
+
+
+async def _refetch_full_resolution(
+    http_client: httpx.AsyncClient,
+    headers: dict[str, str],
+    workout_id: int,
+    rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Refetch chart data in windows when the full-span response is coarse.
+
+    Returns the stitched full-resolution rows, or the original rows when they
+    are already fine-grained, the span is trivial, the workout is too long,
+    or any window request fails (never worse than the downsample).
+    """
+    times = [r.get("time") for r in rows if r.get("time") is not None]
+    if len(times) < 2:
+        return rows
+    span = times[-1] - times[0]
+    if span < _CHARTS_MIN_SPAN_FOR_REFETCH:
+        return rows
+    if span / (len(times) - 1) <= _CHARTS_COARSE_DT:
+        return rows
+    if span / _CHARTS_WINDOW_SECONDS > _CHARTS_MAX_WINDOWS:
+        logger.warning(
+            "workout %s: span %ss too long for windowed refetch; keeping downsample",
+            workout_id,
+            span,
+        )
+        return rows
+
+    windows: list[list[dict[str, Any]]] = []
+    start, stop = int(times[0]), int(times[-1])
+    for window_start in range(start, stop + 1, _CHARTS_WINDOW_SECONDS):
+        window_stop = min(window_start + _CHARTS_WINDOW_SECONDS, stop)
+        try:
+            response = await http_client.post(
+                f"{ANALYSIS_API_BASE}{_CHARTS_PATH}",
+                headers=headers,
+                json={
+                    "workoutId": workout_id,
+                    "startOffsetSeconds": window_start,
+                    "stopOffsetSeconds": window_stop,
+                },
+            )
+        except httpx.RequestError:
+            logger.warning(
+                "workout %s: charts window %s-%ss errored; keeping downsample",
+                workout_id,
+                window_start,
+                window_stop,
+            )
+            return rows
+        if response.status_code != 200:
+            logger.warning(
+                "workout %s: charts window %s-%ss failed (HTTP %s); keeping downsample",
+                workout_id,
+                window_start,
+                window_stop,
+                response.status_code,
+            )
+            return rows
+        try:
+            window_rows = (response.json() or {}).get("data") or []
+        except Exception:
+            logger.warning(
+                "workout %s: charts window %s-%ss returned bad JSON; keeping downsample",
+                workout_id,
+                window_start,
+                window_stop,
+            )
+            return rows
+        windows.append(window_rows)
+    return _stitch_windows(windows)
 
 
 def _stop_timestamp(start_iso: str | None, elapsed_seconds: Any) -> str | None:
@@ -218,6 +319,12 @@ async def tp_analyze_workout(workout_id: str) -> dict[str, Any]:
                 else:
                     return charts_err
 
+            charts_rows = (charts or {}).get("data") or []
+            if charts_rows:
+                charts_rows = await _refetch_full_resolution(
+                    http_client, headers, wid, charts_rows
+                )
+
             laps, laps_err = await _post_analysis(http_client, _LAPS_PATH, headers, wid)
             if laps_err:
                 if laps_err.get("error_code") == "NOT_FOUND":
@@ -254,7 +361,7 @@ async def tp_analyze_workout(workout_id: str) -> dict[str, Any]:
         for ident, meta in charts_metadata.items()
         if isinstance(meta, dict)
     ]
-    time_series = (charts or {}).get("data") or []
+    time_series = charts_rows if charts else []
 
     lap_column_meta = (laps or {}).get("columnMetadata") or {}
     lap_columns = [

--- a/tests/test_tools/test_analyze.py
+++ b/tests/test_tools/test_analyze.py
@@ -382,3 +382,129 @@ class TestTpAnalyzeWorkout:
                 assert headers["Authorization"] == f"Bearer {TEST_ACCESS_TOKEN}"
                 assert "Cookie" not in headers
                 assert call_kwargs.kwargs["json"] == {"workoutId": 3553733903}
+
+    @pytest.mark.asyncio
+    async def test_coarse_charts_refetched_in_windows_at_full_resolution(self):
+        """A downsampled full-span charts response triggers windowed refetches.
+
+        The charts endpoint caps full-span responses at ~1000 points, which
+        is lossy for NP/work computed from the saved time-series. Windowed
+        requests return true 1s data and must be stitched (boundary samples
+        deduped, order preserved).
+        """
+        span = 1800
+        meta = _sample_charts_response()["metadata"]
+        # 301 points over 1800s -> 6s cadence, clearly downsampled
+        coarse = [{"time": t, "Power": 100} for t in range(0, span + 1, 6)]
+
+        async def post(url, headers=None, json=None):
+            resp = MagicMock()
+            resp.status_code = 200
+            if url.endswith("/v2/analyze/summary"):
+                resp.json.return_value = _sample_summary_response()
+            elif url.endswith("/v2/analyze/charts"):
+                if json.get("stopOffsetSeconds") is not None:
+                    start, stop = json["startOffsetSeconds"], json["stopOffsetSeconds"]
+                    resp.json.return_value = {
+                        "metadata": meta,
+                        "data": [
+                            {"time": t, "Power": 200} for t in range(start, stop + 1)
+                        ],
+                    }
+                else:
+                    resp.json.return_value = {"metadata": meta, "data": coarse}
+            elif url.endswith("/v2/analyze/laps"):
+                resp.json.return_value = _sample_laps_response()
+            else:
+                raise AssertionError(f"Unexpected URL requested: {url}")
+            return resp
+
+        mock_client = _mock_tp_client()
+        with patch("tp_mcp.tools.analyze.TPClient") as mock_tp:
+            mock_tp.return_value.__aenter__.return_value = mock_client
+            with patch("tp_mcp.tools.analyze.httpx.AsyncClient") as mock_httpx:
+                mock_http_client = AsyncMock()
+                mock_http_client.post = AsyncMock(side_effect=post)
+                mock_httpx.return_value.__aenter__.return_value = mock_http_client
+
+                result = await tp_analyze_workout("3553733903")
+
+        assert not result.get("isError")
+        # Stitched 1s data, not the 301-point downsample
+        assert result["time_series_points"] == span + 1
+        saved = json.loads(Path(result["data_file"]).read_text())
+        times = [row["time"] for row in saved["data"]]
+        assert times == sorted(set(times))  # deduped and ordered
+        assert all(row["Power"] == 200 for row in saved["data"])
+
+    @pytest.mark.asyncio
+    async def test_charts_window_failure_falls_back_to_downsample(self):
+        """If any windowed refetch fails, keep the initial downsampled data."""
+        span = 1800
+        meta = _sample_charts_response()["metadata"]
+        coarse = [{"time": t, "Power": 100} for t in range(0, span + 1, 6)]
+
+        async def post(url, headers=None, json=None):
+            resp = MagicMock()
+            if url.endswith("/v2/analyze/summary"):
+                resp.status_code = 200
+                resp.json.return_value = _sample_summary_response()
+            elif url.endswith("/v2/analyze/charts"):
+                if json.get("stopOffsetSeconds") is not None:
+                    resp.status_code = 500
+                    resp.json.return_value = None
+                else:
+                    resp.status_code = 200
+                    resp.json.return_value = {"metadata": meta, "data": coarse}
+            elif url.endswith("/v2/analyze/laps"):
+                resp.status_code = 200
+                resp.json.return_value = _sample_laps_response()
+            else:
+                raise AssertionError(f"Unexpected URL requested: {url}")
+            return resp
+
+        mock_client = _mock_tp_client()
+        with patch("tp_mcp.tools.analyze.TPClient") as mock_tp:
+            mock_tp.return_value.__aenter__.return_value = mock_client
+            with patch("tp_mcp.tools.analyze.httpx.AsyncClient") as mock_httpx:
+                mock_http_client = AsyncMock()
+                mock_http_client.post = AsyncMock(side_effect=post)
+                mock_httpx.return_value.__aenter__.return_value = mock_http_client
+
+                result = await tp_analyze_workout("3553733903")
+
+        assert not result.get("isError")
+        assert result["time_series_points"] == len(coarse)
+
+    @pytest.mark.asyncio
+    async def test_fine_grained_charts_not_refetched(self):
+        """Charts data already at <=1.5s cadence must not trigger refetches."""
+        meta = _sample_charts_response()["metadata"]
+        fine = [{"time": t, "Power": 100} for t in range(0, 301)]  # 1s data
+
+        async def post(url, headers=None, json=None):
+            resp = MagicMock()
+            resp.status_code = 200
+            if url.endswith("/v2/analyze/summary"):
+                resp.json.return_value = _sample_summary_response()
+            elif url.endswith("/v2/analyze/charts"):
+                assert json.get("stopOffsetSeconds") is None, "unexpected refetch"
+                resp.json.return_value = {"metadata": meta, "data": fine}
+            elif url.endswith("/v2/analyze/laps"):
+                resp.json.return_value = _sample_laps_response()
+            else:
+                raise AssertionError(f"Unexpected URL requested: {url}")
+            return resp
+
+        mock_client = _mock_tp_client()
+        with patch("tp_mcp.tools.analyze.TPClient") as mock_tp:
+            mock_tp.return_value.__aenter__.return_value = mock_client
+            with patch("tp_mcp.tools.analyze.httpx.AsyncClient") as mock_httpx:
+                mock_http_client = AsyncMock()
+                mock_http_client.post = AsyncMock(side_effect=post)
+                mock_httpx.return_value.__aenter__.return_value = mock_http_client
+
+                result = await tp_analyze_workout("3553733903")
+
+        assert not result.get("isError")
+        assert result["time_series_points"] == 301


### PR DESCRIPTION
## Problem

`tp_analyze_workout` composes the retired v1 endpoint's shape from the v2 split endpoints (great!), but the v2 `charts` endpoint caps a **full-span response at ~1000 points**. For any workout longer than ~17 minutes, the returned time-series is a shape-preserving visual downsample that is **not energy-preserving**:

- 91-min ride, full-span response: 915 points (~6 s spacing)
- Integrated work from those samples: **567 kJ vs the workout's true 807 kJ (−30%)**
- NP computed from the saved time-series: **121 W vs the true 178 W (−32%)**

Anything downstream that analyzes the saved `workout_<id>.json` (zone distributions, NP/VI, decoupling, interval detection) silently gets numbers that are badly wrong, while the inline totals (from `summary`) look fine.

## Fix

Windowed `charts` requests (`startOffsetSeconds`/`stopOffsetSeconds` spans ≤ ~1000 s) return true 1 s-resolution data — this is how the TP web app itself fetches detail when zooming. When the full-span response comes back coarse (avg sample spacing > 1.5 s over a span > 120 s), refetch in 900 s windows and stitch, deduping boundary samples.

Safety rails:
- Any window failure (non-200, network error, bad JSON) falls back to the original downsample — never worse than before.
- Rides longer than 12 h keep the downsample to bound the request count (48 extra calls max).
- Short/already-fine responses are untouched (no extra requests in the common short-workout case).

## Verification

- 3 new tests (windowed stitching, window-failure fallback, no-refetch-when-fine); the stitching test fails on current `main`.
- Full suite: 569 passed.
- Live against a real 91-min workout: 5484 points at 1 s, integrated work exactly matches the workout total (807 kJ), computed NP 178 W vs TP's reported 177 W.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVYEXrEXebUKzjuUkxsjEi