### PR TITLE
fix: harden workout structures and preserve TSS metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ Restart Claude Desktop. You're ready to go!
 
 ## Structured Workouts
 
-Create workouts with full interval structure. The server auto-computes duration, IF, and TSS from the structure:
+Create workouts with full interval structure. The server auto-computes duration
+for all simplified structures, and IF/TSS for `percentOfFtp` structures:
 
 ```json
 {
@@ -293,14 +294,14 @@ Create workouts with full interval structure. The server auto-computes duration,
   "sport": "Bike",
   "title": "Sweet Spot Intervals",
   "structure": {
-    "primaryIntensityMetric": "percentOfFtp",
+    "primary_intensity_metric": "percentOfFtp",
     "steps": [
-      {"name": "Warm Up", "duration_seconds": 600, "intensity_min": 40, "intensity_max": 55, "intensityClass": "warmUp"},
+      {"name": "Warm Up", "duration_seconds": 600, "intensity_min": 40, "intensity_max": 55, "intensity_class": "warmUp"},
       {"type": "repetition", "reps": 4, "steps": [
-        {"name": "Sweet Spot", "duration_seconds": 480, "intensity_min": 88, "intensity_max": 93, "intensityClass": "active"},
-        {"name": "Recovery", "duration_seconds": 120, "intensity_min": 50, "intensity_max": 60, "intensityClass": "rest"}
+        {"name": "Sweet Spot", "duration_seconds": 480, "intensity_min": 88, "intensity_max": 93, "intensity_class": "active"},
+        {"name": "Recovery", "duration_seconds": 120, "intensity_min": 50, "intensity_max": 60, "intensity_class": "rest"}
       ]},
-      {"name": "Cool Down", "duration_seconds": 600, "intensity_min": 40, "intensity_max": 55, "intensityClass": "coolDown"}
+      {"name": "Cool Down", "duration_seconds": 600, "intensity_min": 40, "intensity_max": 55, "intensity_class": "coolDown"}
     ]
   }
 }
@@ -316,20 +317,32 @@ You can use the same simplified `structure` object with `tp_update_workout`:
   "duration_minutes": 57,
   "tss_planned": 62.3,
   "structure": {
-    "primaryIntensityMetric": "percentOfThresholdHr",
+    "primary_intensity_metric": "percentOfThresholdHr",
     "steps": [
-      {"name": "Warm-up", "duration_seconds": 900, "intensity_min": 65, "intensity_max": 80, "intensityClass": "warmUp"},
+      {"name": "Warm-up", "duration_seconds": 900, "intensity_min": 65, "intensity_max": 80, "intensity_class": "warmUp"},
       {"type": "repetition", "name": "4x5min controlled tempo", "reps": 4, "steps": [
-        {"name": "Interval", "duration_seconds": 300, "intensity_min": 89, "intensity_max": 94, "intensityClass": "active"},
-        {"name": "Jog recovery", "duration_seconds": 180, "intensity_min": 65, "intensity_max": 83, "intensityClass": "rest"}
+        {"name": "Interval", "duration_seconds": 300, "intensity_min": 89, "intensity_max": 94, "intensity_class": "active"},
+        {"name": "Jog recovery", "duration_seconds": 180, "intensity_min": 65, "intensity_max": 83, "intensity_class": "rest"}
       ]},
-      {"name": "Cool-down", "duration_seconds": 600, "intensity_min": 65, "intensity_max": 80, "intensityClass": "coolDown"}
+      {"name": "Cool-down", "duration_seconds": 600, "intensity_min": 65, "intensity_max": 80, "intensity_class": "coolDown"}
     ]
   }
 }
 ```
 
 If `duration_minutes` and `tss_planned` are omitted, they are derived from the structure. If you pass them explicitly, they override the derived values.
+
+For `percentOfThresholdHr` and `percentOfThresholdPace`, duration is derived but
+IF/TSS are not: those metrics require different load models. Pass `tss_planned`
+explicitly when needed.
+
+Simplified structures prefer `primary_intensity_metric` and `intensity_class`.
+The legacy camelCase spellings remain accepted, but unknown fields are rejected
+to prevent misspelled fields from silently changing a workout.
+
+`tp_get_workouts` always returns `tss_source`, the TrainingPeaks TSS model ID.
+Pass `include_structure: true` only when the full native workout-builder tree is
+needed; it is omitted by default to keep date-range responses compact.
 
 For advanced round-trip use cases, `tp_create_workout` and `tp_update_workout` also accept a native `structured_workout` payload in TrainingPeaks builder format. When a workout already has a native structure, `tp_get_workout` returns it as `structured_workout`.
 

--- a/src/tp_mcp/client/models.py
+++ b/src/tp_mcp/client/models.py
@@ -95,8 +95,10 @@ class WorkoutSummary(BaseModel):
     duration_actual: int | float | None = Field(default=None, alias="totalTime")
     tss_planned: float | None = Field(default=None, alias="tssPlanned")
     tss_actual: float | None = Field(default=None, alias="tssActual")
+    tss_source: int | None = Field(default=None, alias="tssSource")
     distance_planned: float | None = Field(default=None, alias="distancePlanned")
     distance_actual: float | None = Field(default=None, alias="distance")
+    structure: dict[str, Any] | str | None = None
     completed: bool | None = Field(default=None)
     description: str | None = None
 

--- a/src/tp_mcp/server.py
+++ b/src/tp_mcp/server.py
@@ -130,29 +130,32 @@ logger = logging.getLogger("tp-mcp")
 
 STRUCTURE_DESCRIPTION = (
     "Interval structure as a JSON object or string."
-    ' Format: {"steps": [...], "primaryIntensityMetric":'
+    ' Format: {"steps": [...], "primary_intensity_metric":'
     ' "percentOfFtp"|"percentOfThresholdHr"|"percentOfThresholdPace"}.'
     " Each step is either a single interval or a repetition block."
     ' SINGLE STEP: {"name": "Endurance", "duration_seconds": 1200,'
     ' "intensity_min": 65, "intensity_max": 75,'
-    ' "intensityClass": "active"}.'
+    ' "intensity_class": "active"}.'
     ' REPETITION BLOCK: {"type": "repetition", "reps": 5, "steps": ['
     '{"name": "VO2max", "duration_seconds": 180,'
     ' "intensity_min": 106, "intensity_max": 120,'
-    ' "intensityClass": "active"},'
+    ' "intensity_class": "active"},'
     ' {"name": "Spin", "duration_seconds": 180,'
     ' "intensity_min": 40, "intensity_max": 50,'
-    ' "intensityClass": "rest"}]}.'
+    ' "intensity_class": "rest"}]}.'
     " FOR MULTIPLE SETS separated by longer recovery, alternate"
     " repetition blocks with single rest steps:"
     ' [{"type": "repetition", "reps": 4, "steps": [...]},'
     ' {"name": "Block Recovery", "duration_seconds": 600,'
     ' "intensity_min": 45, "intensity_max": 55,'
-    ' "intensityClass": "rest"},'
+    ' "intensity_class": "rest"},'
     ' {"type": "repetition", "reps": 4, "steps": [...]}].'
-    " intensityClass values: warmUp, active (work intervals),"
+    " intensity_class values: warmUp, active (work intervals),"
     " rest (all recovery), coolDown, other."
+    " Legacy camelCase aliases remain accepted. Unknown fields are rejected."
     " Intensity values are % of threshold (FTP/HR/pace)."
+    " IF/TSS are auto-computed only for percentOfFtp; provide tss_planned"
+    " explicitly for HR- or pace-based structures."
     " Optional per-step: cadence_min, cadence_max (rpm)."
 )
 RAW_STRUCTURE_DESCRIPTION = (
@@ -201,6 +204,8 @@ TOOLS = [
         name="tp_get_workouts",
         description=(
             "List workouts in date range. Query only days needed. Max 90 days. "
+            "Returns the TSS source model. Set include_structure only when the "
+            "full workout-builder tree is needed. "
             "Does NOT include strength-builder gym workouts — use "
             "tp_get_strength_workouts for those."
         ),
@@ -214,6 +219,14 @@ TOOLS = [
                     "enum": ["all", "planned", "completed"],
                     "description": "Filter: all, planned, or completed",
                     "default": "all",
+                },
+                "include_structure": {
+                    "type": "boolean",
+                    "description": (
+                        "Include full native workout-builder structures. This can "
+                        "substantially increase response size."
+                    ),
+                    "default": False,
                 },
             },
             "required": ["start_date", "end_date"],
@@ -235,7 +248,8 @@ TOOLS = [
         description=(
             "Create a planned workout with optional simplified interval structure "
             "or native TrainingPeaks structured_workout payload. Duration is "
-            "auto-computed only from simplified structure when not provided."
+            "auto-computed from simplified structure when not provided; IF/TSS are "
+            "auto-computed only for percentOfFtp structures."
         ),
         input_schema={
             "type": "object",
@@ -1641,6 +1655,7 @@ async def _h_get_workouts(args):
     return await tp_get_workouts(
         start_date=args["start_date"], end_date=args["end_date"],
         workout_filter=args.get("type", "all"),
+        include_structure=args.get("include_structure", False),
     )
 
 @_handler("tp_get_workout")

--- a/src/tp_mcp/tools/structure.py
+++ b/src/tp_mcp/tools/structure.py
@@ -7,9 +7,17 @@ and polyline generation.
 
 import json
 import logging
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from tp_mcp.tools._validation import format_validation_error
 
@@ -22,24 +30,34 @@ INTENSITY_CLASSES = {"warmUp", "active", "rest", "coolDown", "other"}
 INTENSITY_METRICS = {"percentOfFtp", "percentOfThresholdHr", "percentOfThresholdPace"}
 
 
-class SimpleStep(BaseModel):
+class StrictStructureModel(BaseModel):
+    """Base model that rejects misspelled workout-structure fields."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class SimpleStep(StrictStructureModel):
     """A single workout step in the simplified input format."""
 
     name: str = Field(min_length=1, max_length=100)
-    type: str = Field(default="step")
+    type: Literal["step"] = Field(default="step")
     duration_seconds: int = Field(gt=0, le=86400)
     intensity_min: float = Field(ge=0, le=300)
     intensity_max: float = Field(ge=0, le=300)
-    intensityClass: str = Field(default="active")  # noqa: N815
+    intensity_class: str = Field(
+        default="active",
+        validation_alias=AliasChoices("intensity_class", "intensityClass"),
+        serialization_alias="intensityClass",
+    )
     cadence_min: float | None = Field(default=None, ge=0, le=300)
     cadence_max: float | None = Field(default=None, ge=0, le=300)
 
-    @field_validator("intensityClass")
+    @field_validator("intensity_class")
     @classmethod
     def check_intensity_class(cls, v: str) -> str:
         if v not in INTENSITY_CLASSES:
             valid = ", ".join(sorted(INTENSITY_CLASSES))
-            raise ValueError(f"Invalid intensityClass '{v}'. Valid: {valid}")
+            raise ValueError(f"Invalid intensity_class '{v}'. Valid: {valid}")
         return v
 
     @model_validator(mode="after")
@@ -55,27 +73,33 @@ class SimpleStep(BaseModel):
         return self
 
 
-class SimpleRepetitionBlock(BaseModel):
+class SimpleRepetitionBlock(StrictStructureModel):
     """A repetition block containing multiple steps repeated N times."""
 
-    type: str = Field(default="repetition")
+    type: Literal["repetition"] = Field(default="repetition")
     name: str = Field(default="Repeat")
     reps: int = Field(gt=0, le=100)
     steps: list[SimpleStep] = Field(min_length=1)
 
 
-class SimpleWorkoutStructure(BaseModel):
+class SimpleWorkoutStructure(StrictStructureModel):
     """Top-level simplified structure input from the LLM."""
 
-    primaryIntensityMetric: str = Field(default="percentOfFtp")  # noqa: N815
+    primary_intensity_metric: str = Field(
+        default="percentOfFtp",
+        validation_alias=AliasChoices(
+            "primary_intensity_metric", "primaryIntensityMetric"
+        ),
+        serialization_alias="primaryIntensityMetric",
+    )
     steps: list[SimpleStep | SimpleRepetitionBlock] = Field(min_length=1)
 
-    @field_validator("primaryIntensityMetric")
+    @field_validator("primary_intensity_metric")
     @classmethod
     def check_metric(cls, v: str) -> str:
         if v not in INTENSITY_METRICS:
             valid = ", ".join(sorted(INTENSITY_METRICS))
-            raise ValueError(f"Invalid primaryIntensityMetric '{v}'. Valid: {valid}")
+            raise ValueError(f"Invalid primary_intensity_metric '{v}'. Valid: {valid}")
         return v
 
 
@@ -98,7 +122,7 @@ def _build_step_wire(step: SimpleStep) -> dict[str, Any]:
         "type": "step",
         "length": {"value": step.duration_seconds, "unit": "second"},
         "targets": targets,
-        "intensityClass": step.intensityClass,
+        "intensityClass": step.intensity_class,
         "openDuration": False,
     }
 
@@ -109,6 +133,11 @@ def _compute_block_duration(block: SimpleStep | SimpleRepetitionBlock) -> int:
         inner_duration = sum(s.duration_seconds for s in block.steps)
         return inner_duration * block.reps
     return block.duration_seconds
+
+
+def compute_duration_seconds(structure: SimpleWorkoutStructure) -> int:
+    """Compute total structure duration independently of its intensity metric."""
+    return sum(_compute_block_duration(block) for block in structure.steps)
 
 
 def _polyline_bar(
@@ -137,7 +166,7 @@ def build_wire_structure(structure: SimpleWorkoutStructure) -> dict[str, Any]:
     cumulative_seconds = 0
 
     # First pass: compute total duration for polyline normalisation
-    total_duration = sum(_compute_block_duration(b) for b in structure.steps)
+    total_duration = compute_duration_seconds(structure)
 
     for block in structure.steps:
         block_duration = _compute_block_duration(block)
@@ -194,17 +223,20 @@ def build_wire_structure(structure: SimpleWorkoutStructure) -> dict[str, Any]:
         "structure": wire_blocks,
         "polyline": polyline,
         "primaryLengthMetric": "duration",
-        "primaryIntensityMetric": structure.primaryIntensityMetric,
+        "primaryIntensityMetric": structure.primary_intensity_metric,
         "primaryIntensityTargetOrRange": "range",
     }
 
 
 def compute_if_tss(structure: SimpleWorkoutStructure) -> tuple[float, float, int]:
-    """Compute IF and TSS from a workout structure.
+    """Compute power-based IF and TSS from an FTP workout structure.
 
     Uses NP-style time-weighted 4th-power average of midpoint intensities.
     IF = (weighted_sum / total_seconds) ^ 0.25 / 100
     TSS = (total_seconds * IF^2 * 100) / 3600
+
+    HR- and pace-based structures require different load models and are rejected
+    rather than returning a plausible-looking but incorrect estimate.
 
     Args:
         structure: The simplified workout structure.
@@ -212,6 +244,11 @@ def compute_if_tss(structure: SimpleWorkoutStructure) -> tuple[float, float, int
     Returns:
         Tuple of (IF, TSS, total_duration_seconds).
     """
+    if structure.primary_intensity_metric != "percentOfFtp":
+        raise ValueError(
+            "Automatic IF/TSS estimation supports only percentOfFtp structures"
+        )
+
     weighted_sum = 0.0
     total_seconds = 0
 
@@ -257,20 +294,7 @@ def parse_structure_input(structure_input: dict[str, Any] | str) -> SimpleWorkou
     else:
         data = structure_input
 
-    # Parse steps - distinguish between simple steps and repetition blocks
-    raw_steps = data.get("steps", [])
-    parsed_steps: list[SimpleStep | SimpleRepetitionBlock] = []
-
-    for raw_step in raw_steps:
-        if raw_step.get("type") == "repetition":
-            parsed_steps.append(SimpleRepetitionBlock.model_validate(raw_step))
-        else:
-            parsed_steps.append(SimpleStep.model_validate(raw_step))
-
-    return SimpleWorkoutStructure(
-        primaryIntensityMetric=data.get("primaryIntensityMetric", "percentOfFtp"),
-        steps=parsed_steps,
-    )
+    return SimpleWorkoutStructure.model_validate(data)
 
 
 async def tp_validate_structure(structure: str) -> dict[str, Any]:
@@ -292,7 +316,13 @@ async def tp_validate_structure(structure: str) -> dict[str, Any]:
             "message": msg,
         }
 
-    intensity_factor, tss, total_seconds = compute_if_tss(parsed)
+    total_seconds = compute_duration_seconds(parsed)
+    supports_load_estimate = parsed.primary_intensity_metric == "percentOfFtp"
+    if supports_load_estimate:
+        intensity_factor, tss, _ = compute_if_tss(parsed)
+    else:
+        intensity_factor = None
+        tss = None
 
     # Count blocks
     block_count = len(parsed.steps)
@@ -303,7 +333,7 @@ async def tp_validate_structure(structure: str) -> dict[str, Any]:
         else:
             step_count += 1
 
-    return {
+    result: dict[str, Any] = {
         "valid": True,
         "block_count": block_count,
         "total_steps": step_count,
@@ -311,5 +341,11 @@ async def tp_validate_structure(structure: str) -> dict[str, Any]:
         "total_duration_minutes": round(total_seconds / 60, 1),
         "estimated_if": intensity_factor,
         "estimated_tss": tss,
-        "intensity_metric": parsed.primaryIntensityMetric,
+        "intensity_metric": parsed.primary_intensity_metric,
     }
+    if not supports_load_estimate:
+        result["estimation_warning"] = (
+            "Automatic IF/TSS estimation is unavailable for HR- and pace-based "
+            "structures; provide tss_planned explicitly when needed."
+        )
+    return result

--- a/src/tp_mcp/tools/workouts.py
+++ b/src/tp_mcp/tools/workouts.py
@@ -18,6 +18,7 @@ from tp_mcp.tools._validation import (
 )
 from tp_mcp.tools.structure import (
     build_wire_structure,
+    compute_duration_seconds,
     compute_if_tss,
     parse_structure_input,
 )
@@ -62,7 +63,12 @@ def _prepare_structure_payload(
     try:
         parsed_structure = parse_structure_input(structure)
         wire_structure = build_wire_structure(parsed_structure)
-        structure_if, structure_tss, total_seconds = compute_if_tss(parsed_structure)
+        total_seconds = compute_duration_seconds(parsed_structure)
+        if parsed_structure.primary_intensity_metric == "percentOfFtp":
+            structure_if, structure_tss, _ = compute_if_tss(parsed_structure)
+        else:
+            structure_if = None
+            structure_tss = None
         return StructurePayload(
             wire_structure=wire_structure,
             duration_minutes=total_seconds / 60.0,
@@ -170,6 +176,7 @@ async def tp_get_workouts(
     start_date: str,
     end_date: str,
     workout_filter: Literal["all", "planned", "completed"] = "all",
+    include_structure: bool = False,
 ) -> dict[str, Any]:
     """Get workouts for a date range.
 
@@ -177,6 +184,8 @@ async def tp_get_workouts(
         start_date: Start date in ISO format (YYYY-MM-DD).
         end_date: End date in ISO format (YYYY-MM-DD).
         workout_filter: Filter by status - "all", "planned", or "completed".
+        include_structure: Include native workout-builder structures. Defaults to
+            false because structures can make date-range responses very large.
 
     Returns:
         Dict with workouts list, count, and date_range.
@@ -229,9 +238,10 @@ async def tp_get_workouts(
             elif workout_filter == "completed":
                 workouts = [w for w in workouts if w.is_completed]
 
-            # Convert to dict format for response
-            workout_dicts = [
-                {
+            # Convert to compact dict format for response.
+            workout_dicts: list[dict[str, Any]] = []
+            for w in workouts:
+                workout_data: dict[str, Any] = {
                     "id": str(w.id),
                     "date": w.date.isoformat(),
                     "title": w.title,
@@ -241,13 +251,17 @@ async def tp_get_workouts(
                     "duration_actual": w.duration_actual,
                     "distance_planned_km": w.distance_planned / 1000 if w.distance_planned else None,
                     "distance_actual_km": w.distance_actual / 1000 if w.distance_actual else None,
-                    "tss": w.tss_actual or w.tss_planned,
+                    "tss": w.tss_actual if w.tss_actual is not None else w.tss_planned,
                     "tss_planned": w.tss_planned,
                     "tss_actual": w.tss_actual,
+                    "tss_source": w.tss_source,
                     "description": w.description,
                 }
-                for w in workouts
-            ]
+                if include_structure:
+                    workout_data["structured_workout"] = _decode_structured_workout(
+                        w.structure
+                    )
+                workout_dicts.append(workout_data)
 
             return {
                 "workouts": workout_dicts,
@@ -705,6 +719,10 @@ async def tp_update_workout(
                 existing["ifPlanned"] = effective_if
             else:
                 existing.pop("ifPlanned", None)
+            if structure_payload.tss is None:
+                existing.pop("tssSource", None)
+                if params.tss_planned is None:
+                    existing.pop("tssPlanned", None)
         elif raw_structure_payload is not None:
             existing["structure"] = raw_structure_payload
 

--- a/tests/test_client/test_models.py
+++ b/tests/test_client/test_models.py
@@ -59,6 +59,8 @@ class TestWorkoutSummary:
             "totalTime": 3500,
             "tssPlanned": 80,
             "tssActual": 75,
+            "tssSource": 1,
+            "structure": {"structure": []},
             "completed": True,
         }
         workout = WorkoutSummary.model_validate(data)
@@ -70,6 +72,8 @@ class TestWorkoutSummary:
         assert workout.is_completed is True
         assert workout.workout_status == "completed"
         assert workout.sport == "Bike"  # resolved from workoutTypeValueId
+        assert workout.tss_source == 1
+        assert workout.structure == {"structure": []}
 
     def test_parse_planned_workout(self):
         """Test parsing planned workout summary."""

--- a/tests/test_server_functional.py
+++ b/tests/test_server_functional.py
@@ -144,6 +144,16 @@ class TestListTools:
         assert props["is_hidden"]["default"] is False
 
     @pytest.mark.asyncio
+    async def test_get_workouts_schema_includes_optional_structure(self):
+        tools = await list_tools()
+        get_workouts = next(t for t in tools if t.name == "tp_get_workouts")
+        props = get_workouts.input_schema["properties"]
+
+        assert props["include_structure"]["type"] == "boolean"
+        assert props["include_structure"]["default"] is False
+        assert "include_structure" not in get_workouts.input_schema["required"]
+
+    @pytest.mark.asyncio
     async def test_update_workout_schema_includes_structured_workout(self):
         tools = await list_tools()
         uw = next(t for t in tools if t.name == "tp_update_workout")

--- a/tests/test_tools/test_new_workouts.py
+++ b/tests/test_tools/test_new_workouts.py
@@ -84,6 +84,47 @@ class TestCreateWorkoutWithStructure:
         assert "polyline" in parsed
 
     @pytest.mark.asyncio
+    async def test_create_hr_structure_does_not_write_power_load_estimate(self):
+        structure = {
+            "primary_intensity_metric": "percentOfThresholdHr",
+            "steps": [
+                {
+                    "name": "Tempo",
+                    "duration_seconds": 1800,
+                    "intensity_min": 85,
+                    "intensity_max": 90,
+                },
+            ],
+        }
+        create_response = APIResponse(
+            success=True,
+            data={
+                "workoutId": 7001,
+                "title": "HR Structure",
+                "workoutDay": "2026-03-01T00:00:00",
+            },
+        )
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.post = AsyncMock(return_value=create_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_create_workout(
+                date_str="2026-03-01",
+                sport="Run",
+                title="HR Structure",
+                structure=structure,
+            )
+
+        assert result["success"] is True
+        payload = mock_instance.post.call_args[1]["json"]
+        assert payload["totalTimePlanned"] == 0.5
+        assert "ifPlanned" not in payload
+        assert "tssPlanned" not in payload
+
+    @pytest.mark.asyncio
     async def test_create_with_explicit_duration_overrides_structure(self):
         """Explicit duration should override structure-computed duration."""
         structure = {
@@ -587,6 +628,47 @@ class TestUpdateWorkout:
         assert put_payload["ifPlanned"] == pytest.approx(0.771, abs=0.001)
         assert put_payload["ifPlanned"] < 1
         assert put_payload["tssPlanned"] > 1
+
+    @pytest.mark.asyncio
+    async def test_update_hr_structure_clears_stale_power_load_estimate(self):
+        existing = {
+            "workoutId": 1001,
+            "ifPlanned": 0.91,
+            "tssPlanned": 75,
+            "tssSource": 1,
+        }
+        get_response = APIResponse(success=True, data=existing)
+        put_response = APIResponse(success=True, data=None)
+        structure = {
+            "primary_intensity_metric": "percentOfThresholdHr",
+            "steps": [
+                {
+                    "name": "Tempo",
+                    "duration_seconds": 1800,
+                    "intensity_min": 85,
+                    "intensity_max": 90,
+                },
+            ],
+        }
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=get_response)
+            mock_instance.put = AsyncMock(return_value=put_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_update_workout(
+                workout_id="1001",
+                structure=structure,
+            )
+
+        assert result["success"] is True
+        payload = mock_instance.put.call_args[1]["json"]
+        assert payload["totalTimePlanned"] == 0.5
+        assert "ifPlanned" not in payload
+        assert "tssPlanned" not in payload
+        assert "tssSource" not in payload
 
     @pytest.mark.asyncio
     async def test_update_with_structure_explicit_duration_and_tss_override(self):

--- a/tests/test_tools/test_structure.py
+++ b/tests/test_tools/test_structure.py
@@ -18,7 +18,17 @@ from tp_mcp.tools.structure import (
 class TestBuildSimpleStep:
     """Test building single steps and verifying wire format."""
 
+    def test_snake_case_intensity_class(self):
+        step = SimpleStep(
+            name="Warm Up", duration_seconds=600,
+            intensity_min=40, intensity_max=55, intensity_class="warmUp",
+        )
+        wire = build_wire_structure(SimpleWorkoutStructure(steps=[step]))
+
+        assert wire["structure"][0]["steps"][0]["intensityClass"] == "warmUp"
+
     def test_warmup_step(self):
+        """The legacy camelCase alias remains accepted."""
         step = SimpleStep(
             name="Warm Up", duration_seconds=600,
             intensity_min=40, intensity_max=55, intensityClass="warmUp",
@@ -169,6 +179,21 @@ class TestComputeIFTSS:
         assert intensity_factor > 0.6
         assert tss > 0
 
+    def test_non_power_metric_is_not_estimated_with_power_model(self):
+        step = SimpleStep(
+            name="Tempo",
+            duration_seconds=1800,
+            intensity_min=85,
+            intensity_max=90,
+        )
+        structure = SimpleWorkoutStructure(
+            primary_intensity_metric="percentOfThresholdPace",
+            steps=[step],
+        )
+
+        with pytest.raises(ValueError, match="only percentOfFtp"):
+            compute_if_tss(structure)
+
     def test_empty_steps_returns_zero(self):
         """Edge case: if somehow total_seconds is 0."""
         # Cannot create empty structure due to min_length=1, so test directly
@@ -204,20 +229,98 @@ class TestValidation:
         with pytest.raises(Exception):
             SimpleWorkoutStructure(primaryIntensityMetric="invalidMetric", steps=[step])
 
+    @pytest.mark.parametrize(
+        ("payload", "unknown_field"),
+        [
+            (
+                {
+                    "steps": [
+                        {
+                            "name": "Main",
+                            "duration_seconds": 300,
+                            "intensity_min": 50,
+                            "intensity_max": 60,
+                        },
+                    ],
+                    "primary_intensity_metic": "percentOfFtp",
+                },
+                "primary_intensity_metic",
+            ),
+            (
+                {
+                    "steps": [
+                        {
+                            "name": "Main",
+                            "duration_seconds": 300,
+                            "intensity_min": 50,
+                            "intensity_max": 60,
+                            "intensity_clas": "warmUp",
+                        },
+                    ],
+                },
+                "intensity_clas",
+            ),
+            (
+                {
+                    "steps": [
+                        {
+                            "type": "repetition",
+                            "reps": 2,
+                            "stepz": [],
+                            "steps": [
+                                {
+                                    "name": "Main",
+                                    "duration_seconds": 300,
+                                    "intensity_min": 50,
+                                    "intensity_max": 60,
+                                },
+                            ],
+                        },
+                    ],
+                },
+                "stepz",
+            ),
+        ],
+    )
+    def test_unknown_fields_are_rejected(self, payload, unknown_field):
+        with pytest.raises(Exception, match=unknown_field):
+            parse_structure_input(payload)
+
 
 class TestParseStructureInput:
     """Test parsing structure from dict and JSON string."""
 
     def test_parse_from_dict(self):
         data = {
-            "primaryIntensityMetric": "percentOfFtp",
+            "primary_intensity_metric": "percentOfFtp",
             "steps": [
-                {"name": "WU", "duration_seconds": 600, "intensity_min": 40, "intensity_max": 55, "intensityClass": "warmUp"},
+                {"name": "WU", "duration_seconds": 600, "intensity_min": 40, "intensity_max": 55, "intensity_class": "warmUp"},
             ],
         }
         parsed = parse_structure_input(data)
         assert len(parsed.steps) == 1
-        assert parsed.primaryIntensityMetric == "percentOfFtp"
+        assert parsed.primary_intensity_metric == "percentOfFtp"
+        assert parsed.steps[0].intensity_class == "warmUp"
+
+
+    def test_parse_legacy_camel_case_aliases(self):
+        data = {
+            "primaryIntensityMetric": "percentOfThresholdHr",
+            "steps": [
+                {
+                    "name": "WU",
+                    "duration_seconds": 600,
+                    "intensity_min": 60,
+                    "intensity_max": 70,
+                    "intensityClass": "warmUp",
+                },
+            ],
+        }
+
+        parsed = parse_structure_input(data)
+
+        assert parsed.primary_intensity_metric == "percentOfThresholdHr"
+        assert parsed.steps[0].intensity_class == "warmUp"
 
     def test_parse_from_json_string(self):
         data = {
@@ -286,3 +389,41 @@ class TestTpValidateStructure:
 
         assert result["isError"] is True
         assert result["error_code"] == "VALIDATION_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_misspelled_intensity_class_returns_error(self):
+        result = await tp_validate_structure(json.dumps({
+            "steps": [
+                {
+                    "name": "WU",
+                    "duration_seconds": 600,
+                    "intensity_min": 40,
+                    "intensity_max": 55,
+                    "intensity_clas": "warmUp",
+                },
+            ],
+        }))
+
+        assert result["isError"] is True
+        assert result["error_code"] == "VALIDATION_ERROR"
+        assert "intensity_clas" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_non_power_metric_has_no_load_estimate(self):
+        result = await tp_validate_structure(json.dumps({
+            "primary_intensity_metric": "percentOfThresholdHr",
+            "steps": [
+                {
+                    "name": "Tempo",
+                    "duration_seconds": 1800,
+                    "intensity_min": 85,
+                    "intensity_max": 90,
+                },
+            ],
+        }))
+
+        assert result["valid"] is True
+        assert result["total_duration_seconds"] == 1800
+        assert result["estimated_if"] is None
+        assert result["estimated_tss"] is None
+        assert "provide tss_planned explicitly" in result["estimation_warning"]

--- a/tests/test_tools/test_workouts.py
+++ b/tests/test_tools/test_workouts.py
@@ -63,6 +63,53 @@ class TestTpGetWorkouts:
         assert planned["tss"] == 40
 
     @pytest.mark.asyncio
+    async def test_get_workouts_includes_tss_source_and_optional_structure(
+        self, mock_api_responses,
+    ):
+        structured_workout = {
+            "structure": [],
+            "polyline": [],
+            "primaryLengthMetric": "duration",
+            "primaryIntensityMetric": "percentOfFtp",
+            "primaryIntensityTargetOrRange": "range",
+        }
+        workout_data = dict(mock_api_responses["workouts"][0])
+        workout_data["tssSource"] = 1
+        workout_data["structure"] = json.dumps(structured_workout)
+        workouts_response = APIResponse(success=True, data=[workout_data])
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=workouts_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            compact = await tp_get_workouts("2025-01-08", "2025-01-08")
+            expanded = await tp_get_workouts(
+                "2025-01-08", "2025-01-08", include_structure=True,
+            )
+
+        assert compact["workouts"][0]["tss_source"] == 1
+        assert "structured_workout" not in compact["workouts"][0]
+        assert expanded["workouts"][0]["structured_workout"] == structured_workout
+
+    @pytest.mark.asyncio
+    async def test_get_workouts_preserves_zero_actual_tss(self, mock_api_responses):
+        workout_data = dict(mock_api_responses["workouts"][0])
+        workout_data["tssActual"] = 0
+        workouts_response = APIResponse(success=True, data=[workout_data])
+
+        with patch("tp_mcp.tools.workouts.TPClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.ensure_athlete_id = AsyncMock(return_value=123)
+            mock_instance.get = AsyncMock(return_value=workouts_response)
+            mock_client.return_value.__aenter__.return_value = mock_instance
+
+            result = await tp_get_workouts("2025-01-08", "2025-01-08")
+
+        assert result["workouts"][0]["tss"] == 0
+
+    @pytest.mark.asyncio
     async def test_get_workouts_filter_completed(self, mock_api_responses):
         """Test filtering for completed workouts only."""
         workouts_response = APIResponse(success=True, data=mock_api_responses["workouts"])


### PR DESCRIPTION
## Summary
- accept snake_case intensity_class and primary_intensity_metric while preserving the existing camelCase aliases
- reject unknown fields at the structure, repetition-block, and step levels so typos cannot silently fall back to active
- constrain step type discriminators and keep the generated TrainingPeaks wire format unchanged
- auto-compute IF/TSS only for percentOfFtp structures; HR/pace structures still derive duration but require explicit tss_planned
- expose tss_source from workout-list responses and add opt-in include_structure for the native builder tree
- preserve a real tssActual value of zero instead of falling back to planned TSS

## Compatibility
Existing camelCase structure payloads remain valid. Full list structures are opt-in because returning builder trees for every workout can substantially increase response size.

## Validation
- 579 tests passed on a clean branch based on upstream main at a412a84
- ruff check src/
- mypy src/

Closes #172.
Addresses the dropped structure/tssSource portion of #170; its athlete-schema and direct-call documentation requests remain separate.